### PR TITLE
Update spelling error in 'A simple example'

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -174,7 +174,7 @@ Here, we give an example configuration file, describing a single-node Flume depl
   # Use a channel which buffers events in memory
   agent1.channels.channel1.type = memory
   agent1.channels.channel1.capacity = 1000
-  agent1.channels.channel1.transactionCapactiy = 100
+  agent1.channels.channel1.transactionCapacity = 100
 
   # Bind the source and sink to the channel
   agent1.sources.source1.channels = channel1


### PR DESCRIPTION
This spelling error causes Flume to fail when the example code is used to bootstrap a new development environment.

In my case, I copy -> pasted and then moved to exploring HDFS sinks.
