### PR TITLE
Add methods to retrieve information about the file

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/serialization/ResettableFileInputStream.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/serialization/ResettableFileInputStream.java
@@ -293,5 +293,13 @@ public class ResettableFileInputStream extends ResettableInputStream
     tracker.close();
     in.close();
   }
+  
+  public String getFileName(){
+    return file.getName();
+  }
+  
+  public String getFilePath(){
+    return file.getAbsolutePath();
+  }
 
 }


### PR DESCRIPTION
The getFileName() and getFilePath() methods are useful for a custom  deserializer that works with a ResettableFileInputStream. At the moment, there is no way in a Deserializer to find out which file it is processing. The other option is to make the FileInfo available in the Deserializer but imo this looks like the better of the two options.
