### PR TITLE
change FLUME_HOME to fix the LIBRARY NOT FOUND bug

### DIFF
--- a/bin/flume-ng
+++ b/bin/flume-ng
@@ -341,7 +341,7 @@ if [ -n "${opt_classpath}" ]; then
 fi
 
 if [ -z "${FLUME_HOME}" ]; then
-  FLUME_HOME=$(cd $(dirname $0)/..; pwd)
+  FLUME_HOME=$(cd $(dirname $0)/..)
 fi
 
 # prepend $FLUME_HOME/lib jars to the specified classpath (if any)


### PR DESCRIPTION
Assigning `FLUME_HOME` to `$(cd $(dirname $0)/..; pwd)` will cause an `org.apache.flume.node.Application not found` error. This can be fixed by elimilated the `;pwd` path.
