### PR TITLE
Update KafkaSource.java

### DIFF
--- a/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
+++ b/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
@@ -102,7 +102,10 @@ public class KafkaSource extends AbstractSource
           headers.put(KafkaSourceConstants.TIMESTAMP,
                   String.valueOf(System.currentTimeMillis()));
           headers.put(KafkaSourceConstants.TOPIC, topic);
-          headers.put(KafkaSourceConstants.KEY, new String(kafkaKey));
+          if (kafkaKey == null)
+            headers.put(KafkaSourceConstants.KEY, KafkaSourceConstants.KEY);
+          else
+            headers.put(KafkaSourceConstants.KEY, new String(kafkaKey));
           if (log.isDebugEnabled()) {
             log.debug("Message: {}", new String(kafkaMessage));
           }


### PR DESCRIPTION
Key is not always defined by a producer. In case of null key, this code blows up.
