### PR TITLE
fix: netcat source tcp connection is not closed

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/NetcatSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/NetcatSource.java
@@ -341,8 +341,11 @@ public class NetcatSource extends AbstractSource implements Configurable,
 
         counterGroup.incrementAndGet("sessions.completed");
       } catch (IOException e) {
-        socketChannel.shutdownOutput();
-        socketChannel.close();
+        try {
+            socketChannel.shutdownOutput();
+            socketChannel.close();
+        } catch (IOException e1) {
+        }
         counterGroup.incrementAndGet("sessions.broken");
       }
 

--- a/flume-ng-core/src/main/java/org/apache/flume/source/NetcatSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/NetcatSource.java
@@ -336,10 +336,13 @@ public class NetcatSource extends AbstractSource implements Configurable,
           }
         }
 
+        socketChannel.shutdownOutput();
         socketChannel.close();
 
         counterGroup.incrementAndGet("sessions.completed");
       } catch (IOException e) {
+        socketChannel.shutdownOutput();
+        socketChannel.close();
         counterGroup.incrementAndGet("sessions.broken");
       }
 


### PR DESCRIPTION
when client using tcp short connection, netcat source tcp connections were not closed. flume had lots of tcp close_wait until  process exited!
