### PR TITLE
Extension-friendly HttpSource

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
@@ -171,6 +171,11 @@ public class HTTPSource extends AbstractSource implements
       + " specified");
   }
 
+  /**
+   * Jetty Context customization hook.
+   *
+   * @param context the Jetty context.
+   */
   protected void customizeServletContext(org.mortbay.jetty.servlet.Context context){
 
   }
@@ -220,6 +225,11 @@ public class HTTPSource extends AbstractSource implements
     super.start();
   }
 
+  /**
+   * Http Servlet factory method.
+   *
+   * @return an instance of {@see javax.servlet.http.HttpServlet}
+   */
   protected HttpServlet getServlet() {
     return new FlumeHTTPServlet();
   }


### PR DESCRIPTION
This patch allows third-party to developers extend HttpSource behavior easily, without having to reimplement the whole thing.

More specifically:
- Adds an hook to customize `org.mortbay.jetty.servlet.Context`.
- Delegates the HttpServlet instance creation to a protected factory method.
- Changes FlumeHttpServlet visibility to `protected`, to let third party developers extend from it.
- Adds an hook in `FlumeHTTPServlet` to customize `HttpServletResponse` before it is flushed.

We developed this patch because we had to add a custom servlet filter to the Jetty context.

Having this patch applied, a third-party developer could easily extend HttpSource like this:

```
public class CustomHTTPSource extends HTTPSource {

    @Override
    protected void customizeServletContext(Context context) {
        super.customizeServletContext(context);

        context.addFilter(MyCustomHttpServletFilter.class,"/*",0);
    }

    @Override
    protected HttpServlet getServlet() {
        return new KeedioFlumeHTTPServlet();
    }

    protected class KeedioFlumeHTTPServlet extends FlumeHTTPServlet{
        @Override
        protected void customizeServletResponse(HttpServletRequest request, HttpServletResponse response) {
            super.customizeServletResponse(request, response);

            response.addHeader("Accept-Encoding","...");
        }
    }
} 
```
