### PR TITLE
FLUME-2781 proposed implementation

### DIFF
--- a/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
+++ b/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
@@ -260,21 +260,26 @@ public class KafkaChannel extends BasicChannelSemantics {
       }
 
       try {
-        if (!tempOutStream.isPresent()) {
-          tempOutStream = Optional.of(new ByteArrayOutputStream());
+        if (parseAsFlumeEvent){
+	      if (!tempOutStream.isPresent()) {
+	        tempOutStream = Optional.of(new ByteArrayOutputStream());
+	      }
+	      if (!writer.isPresent()) {
+	        writer = Optional.of(new
+	          SpecificDatumWriter<AvroFlumeEvent>(AvroFlumeEvent.class));
+	      }
+	      tempOutStream.get().reset();
+	      AvroFlumeEvent e = new AvroFlumeEvent(
+	        toCharSeqMap(event.getHeaders()), 
+	        ByteBuffer.wrap(event.getBody()));
+	      encoder = EncoderFactory.get()
+	        .directBinaryEncoder(tempOutStream.get(), encoder);
+	      writer.get().write(e, encoder);
+	      // Not really possible to avoid this copy :(
+	      serializedEvents.get().add(tempOutStream.get().toByteArray());
+        } else {
+        	serializedEvents.get().add(event.getBody());
         }
-        if (!writer.isPresent()) {
-          writer = Optional.of(new
-            SpecificDatumWriter<AvroFlumeEvent>(AvroFlumeEvent.class));
-        }
-        tempOutStream.get().reset();
-        AvroFlumeEvent e = new AvroFlumeEvent(
-          toCharSeqMap(event.getHeaders()), ByteBuffer.wrap(event.getBody()));
-        encoder = EncoderFactory.get()
-          .directBinaryEncoder(tempOutStream.get(), encoder);
-        writer.get().write(e, encoder);
-        // Not really possible to avoid this copy :(
-        serializedEvents.get().add(tempOutStream.get().toByteArray());
       } catch (Exception e) {
         throw new ChannelException("Error while serializing event", e);
       }


### PR DESCRIPTION
Implemented a tiny change so "put" in the channel is consistent with "take". If parseAsFlumeEvent is false it uses the event body text instead of an Avro Flume event object.
