### PR TITLE
check message size before send to kafka

### DIFF
--- a/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSinkConstants.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSinkConstants.java
@@ -34,7 +34,7 @@ public class KafkaSinkConstants {
   public static final String REQUIRED_ACKS_KEY = "request.required.acks";
   public static final String BROKER_LIST_FLUME_KEY = "brokerList";
   public static final String REQUIRED_ACKS_FLUME_KEY = "requiredAcks";
-
+  public static final String MESSAGE_MAX_SIZE = "messageMaxSize";
 
 
   public static final int DEFAULT_BATCH_SIZE = 100;
@@ -44,4 +44,5 @@ public class KafkaSinkConstants {
   public static final String DEFAULT_KEY_SERIALIZER =
           "kafka.serializer.StringEncoder";
   public static final String DEFAULT_REQUIRED_ACKS = "1";
+  public static final int DEFAULT_MESSAGE_MAX_SIZE = 8388608;
 }


### PR DESCRIPTION
Kafka Sink fetch message from channel and use Kafka Producer to send message to Kafka Broker . When Kafka Broker's config `message.max.bytes` and message is too long Flume Kafka Sink will failed to send message. 

I add a check before message send to Kafka Broker . The too long message will be discard and record log with message size.
You also can config the messageMaxSize in properties file.

I Create a JIRA Ticket:https://issues.apache.org/jira/browse/FLUME-2837

thanks
