### PR TITLE
startup flume error if the plugins added in plugins.d directory

### DIFF
--- a/bin/flume-ng.ps1
+++ b/bin/flume-ng.ps1
@@ -320,7 +320,7 @@ if ("$pluginsPath" -eq "") {
 foreach($plugin in  $pluginsPath.Split(";") )  {
   if ( Test-path "$plugin" ) {
     $pluginTmp =
-        ( (Get-ChildItem "$plugin\*\lib")  + (Get-ChildItem "$plugin\*\libext") ) -join "\*"";"""
+        ( @(Get-ChildItem "$plugin\*\lib")  + @(Get-ChildItem "$plugin\*\libext") ) -join "\*"";"""
     if( "$pluginTmp" -ne "" ) {
       $javaClassPath="$javaClassPath;""" + $pluginTmp + "\*"";"
     }


### PR DESCRIPTION
On windows platform, running flume-ng.cmd  will be faild  if you put some plugins into plugins.d dierctory.
