### PR TITLE
allow poorly formatted events/data to be dropped

### DIFF
--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSinkConstants.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSinkConstants.java
@@ -60,6 +60,17 @@ public class ElasticSearchSinkConstants {
   public static final String TTL = "ttl";
 
   /**
+   * Actions to take when a bulk index operation to ElasticSearch fails:
+   *  drop - ignore the event and move on to the next one
+   *  log - log the event to the logger
+   *  retry - keep it in queue and continually retry
+   */
+  public static final String BULK_ERROR_ACTION = "bulkErrorAction";
+  public static final String BULK_ERROR_ACTION_DROP = "drop";
+  public static final String BULK_ERROR_ACTION_LOG = "log";
+  public static final String BULK_ERROR_ACTION_RETRY = "retry";
+
+  /**
    * The fully qualified class name of the serializer the sink should use.
    */
   public static final String SERIALIZER = "serializer";
@@ -108,4 +119,5 @@ public class ElasticSearchSinkConstants {
           "sink.elasticsearch.ElasticSearchLogStashEventSerializer";
   public static final String DEFAULT_INDEX_NAME_BUILDER_CLASS =
           "org.apache.flume.sink.elasticsearch.TimeBasedIndexNameBuilder";
+  public static final String DEFAULT_BULK_ERROR_ACTION = BULK_ERROR_ACTION_RETRY;
 }

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/test/java/org/apache/flume/sink/elasticsearch/client/TestElasticSearchTransportClient.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/test/java/org/apache/flume/sink/elasticsearch/client/TestElasticSearchTransportClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.flume.sink.elasticsearch.client;
 
+import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.sink.elasticsearch.ElasticSearchEventSerializer;
@@ -121,6 +122,22 @@ public class TestElasticSearchTransportClient {
     when(action.actionGet()).thenReturn(response);
     when(response.hasFailures()).thenReturn(true);
 
+    fixture.addEvent(event, nameBuilder, "bar_type", 10);
+    fixture.execute();
+  }
+
+  @Test
+  public void shouldNotThrowExceptionOnExecuteFailed() throws Exception {
+    ListenableActionFuture<BulkResponse> action =
+        (ListenableActionFuture<BulkResponse>) mock(ListenableActionFuture.class);
+    BulkResponse response = mock(BulkResponse.class);
+    when(bulkRequestBuilder.execute()).thenReturn(action);
+    when(action.actionGet()).thenReturn(response);
+    when(response.hasFailures()).thenReturn(true);
+
+    Context ctx = new Context();
+    ctx.put("bulkErrorAction","drop");
+    fixture.configure(ctx);
     fixture.addEvent(event, nameBuilder, "bar_type", 10);
     fixture.execute();
   }


### PR DESCRIPTION
I ran into an issue where some of the raw data going into ElasticSearch was malformed (fields didn't match the data mapping), which ES rejected as part of the bulk insert. The Flume ES sink currently handles this by just sending the record over and over (hoping that maybe ES will just accept it later). Unfortunately, this creates a LOT of log traffic in ES default log settings AND it backed up our flume channel, because the data doesn't getting any better by blindly retrying it.

This patch allows users to choose between 3 options on what to do when bulk insert errors occur:
1) retry until it somehow magically works (current default within apache flume)
2) log the error message, then drop it
3) drop it silently.

In our case, we just want to drop it, because losing a few records is worth it to keep our data flows moving. However, it would be better to have a more advanced option that can account for times when the ES server is down. Unfortunately, the ES client API doesn't allow for this flexibility to know the type of error, so this was the best option available at the time.
