### PR TITLE
Size based rolling support for file sink

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/formatter/output/PathManager.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/formatter/output/PathManager.java
@@ -24,33 +24,31 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class PathManager {
 
-  private long seriesTimestamp;
   private File baseDirectory;
   private AtomicInteger fileIndex;
-
+  private String fileName;
+  
   private File currentFile;
 
-  public PathManager() {
-    seriesTimestamp = System.currentTimeMillis();
-    fileIndex = new AtomicInteger();
+  public PathManager(String fileName, int maxRolledCount) {
+    this.fileName = fileName;
+    fileIndex = new AtomicInteger(maxRolledCount);
   }
 
-  public File nextFile() {
-    currentFile = new File(baseDirectory, seriesTimestamp + "-"
-        + fileIndex.incrementAndGet());
-
-    return currentFile;
+  public File nextRotatedFile() {
+    return  new File(baseDirectory, fileName + "-" + fileIndex.incrementAndGet()); 
   }
 
   public File getCurrentFile() {
     if (currentFile == null) {
-      return nextFile();
+      currentFile = new File(baseDirectory, fileName);
     }
 
     return currentFile;
   }
 
   public void rotate() {
+    currentFile.renameTo(nextRotatedFile());
     currentFile = null;
   }
 
@@ -62,8 +60,8 @@ public class PathManager {
     this.baseDirectory = baseDirectory;
   }
 
-  public long getSeriesTimestamp() {
-    return seriesTimestamp;
+  public String getFileName() {
+    return fileName;
   }
 
   public AtomicInteger getFileIndex() {

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -2128,6 +2128,12 @@ Property Name        Default  Description
 sink.rollInterval    30       Roll the file every 30 seconds. Specifying 0 will disable rolling and cause all events to be written to a single file.
 sink.serializer      TEXT     Other possible options include ``avro_event`` or the FQCN of an implementation of EventSerializer.Builder interface.
 batchSize            100
+**sink.fileName**    --       Name to use for the file, current file will always have this named. When rolled file name will be appended an
+                              integer indicating how many files have been rolled.
+sink.maxFileSize     -1       Max size for a file can reach before it can be rolled. Size can be specified in GB, MB, KB or
+                              even in B(appending B at the is optional) e.g. 2GB, 2000MB, 2KB etc. For a non positive value size based rolling would
+                              not kick in.
+sink.maxHistory      -1       Maximum number of old files to keep. For a non positive value old files would not be deleted.
 ===================  =======  ======================================================================================================================
 
 Example for agent named a1:


### PR DESCRIPTION
This fixes #FLUME-2856.
Also added support use a fixed naming pattern for files.
Support for allowing to delete old sink files is also added.

Updated documentation for above mentioned changes.

 To support `maxHistory` feature (i.e. to delete older files) I had to be able to predict file names. I introduced new required property for `RollingFileSink` called `fileName`. This is the only backwards incompatible change from end users point of view. I have also made a couple of backwards incompatible changes to `PathManager` class. However `PathManager` class is not being used by any class other than `RollingFileSink` class.

I am open to rewrite some of the changes if people think refactoring will cause any issues.
