### PR TITLE
FLUME-2876 ElasticSearchSink: indexnameBuilderContext.putAll bug fixes

### DIFF
--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
@@ -313,7 +313,7 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
     }
 
     Context indexnameBuilderContext = new Context();
-    serializerContext.putAll(
+    indexnameBuilderContext.putAll(
             context.getSubProperties(INDEX_NAME_BUILDER_PREFIX));
 
     try {

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
@@ -170,7 +170,6 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
     return indexNameBuilder;
   }
 
-  @Override
   public Status process() throws EventDeliveryException {
     logger.debug("processing...");
     Status status = Status.READY;
@@ -233,7 +232,6 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
     return status;
   }
 
-  @Override
   public void configure(Context context) {
     if (!isLocal) {
       if (StringUtils.isNotBlank(context.getString(HOSTNAMES))) {
@@ -314,7 +312,7 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
 
     Context indexnameBuilderContext = new Context();
     indexnameBuilderContext.putAll(
-            context.getSubProperties(INDEX_NAME_BUILDER_PREFIX));
+            context.getSubProperties(INDEX_NAME_BUILDER_PREFIX)); 
 
     try {
       @SuppressWarnings("unchecked")


### PR DESCRIPTION
ElasticSearchSink: indexnameBuilderContext.putAll bug fixes
org.apache.flume.sink.elasticsearch.ElasticSearchSink 
indexnameBuilderContext.putAll wrong serializerContext.putAll
[https://issues.apache.org/jira/browse/FLUME-2876](url)
