### PR TITLE
Flume 2866

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
@@ -429,11 +429,13 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
    * If the {@link #consumeOrder} variable is {@link ConsumeOrder#RANDOM}
    * then cache the directory listing to amortize retreival cost, and return
    * any arbitary file from the directory.
+   * If the file last modified time is less than offset, the file will not be processed.
    */
   private Optional<FileInfo> getNextFile() {
     List<File> candidateFiles = Collections.emptyList();
-    long olderThanTime = System.currentTimeMillis() - (fileTimeMinOffsetSeconds * 1000);
-    long newerThanTime = System.currentTimeMillis() + (fileTimeMinOffsetSeconds * 1000);
+    final long currentTime = System.currentTimeMillis();
+    final long olderThanTime = currentTime - (fileTimeMinOffsetSeconds * 1000);
+    final long newerThanTime = currentTime + (fileTimeMinOffsetSeconds * 1000);
 
     if (consumeOrder != ConsumeOrder.RANDOM ||
       candidateFileIter == null ||

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
@@ -70,6 +70,7 @@ Configurable, EventDrivenSource {
   private int maxBackoff;
   private ConsumeOrder consumeOrder;
   private int pollDelay;
+  private int fileTimeMinOffsetSeconds;
 
   @Override
   public synchronized void start() {
@@ -95,6 +96,7 @@ Configurable, EventDrivenSource {
           .inputCharset(inputCharset)
           .decodeErrorPolicy(decodeErrorPolicy)
           .consumeOrder(consumeOrder)
+          .fileTimeMinOffsetSeconds(fileTimeMinOffsetSeconds)
           .build();
     } catch (IOException ioe) {
       throw new FlumeException("Error instantiating spooling event parser",
@@ -167,6 +169,9 @@ Configurable, EventDrivenSource {
         DEFAULT_CONSUME_ORDER.toString()).toUpperCase(Locale.ENGLISH));
 
     pollDelay = context.getInteger(POLL_DELAY, DEFAULT_POLL_DELAY);
+
+    fileTimeMinOffsetSeconds = context.getInteger(FILE_TIME_MIN_OFFSET_SECONDS,
+        DEFAULT_FILE_TIME_MIN_OFFSET_SECONDS);
 
     // "Hack" to support backwards compatibility with previous generation of
     // spooling directory source, which did not support deserializers

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySourceConfigurationConstants.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySourceConfigurationConstants.java
@@ -97,4 +97,8 @@ public class SpoolDirectorySourceConfigurationConstants {
   /** Delay(in milliseconds) used when polling for new files. The default is 500ms */
   public static final String POLL_DELAY = "pollDelay";
   public static final int DEFAULT_POLL_DELAY = 500;
+
+  /** Minimum time offset from current time before picking up a file */
+  public static final String FILE_TIME_MIN_OFFSET_SECONDS = "fileTimeMinOffsetSeconds";
+  public static final int DEFAULT_FILE_TIME_MIN_OFFSET_SECONDS = 0;
 }


### PR DESCRIPTION
This resolves FLUME-2866.

This adds a property "fileTimeMinOffsetSeconds" in the Spooling Directory Source. This prevents processing of files that are not older or newer than the amount of seconds defined by this property. The default value is "0" seconds, which preserves current behavior.
