### PR TITLE
Fixes to address 2K message size limit when using SyslogUDPSource.

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogSourceConfigurationConstants.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogSourceConfigurationConstants.java
@@ -51,6 +51,8 @@ public final class SyslogSourceConfigurationConstants {
 
   public static final String CONFIG_BATCHSIZE = "batchSize";
 
+  public static final String DATAGRAM_SIZE = "datagramSize";
+
   public static final String CONFIG_CHARSET = "charset.default";
 
   public static final String DEFAULT_CHARSET = "UTF-8";

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUDPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUDPSource.java
@@ -46,6 +46,7 @@ public class SyslogUDPSource extends AbstractSource
 
   private int port;
   private int maxsize = 1 << 16; // 64k is max allowable in RFC 5426
+  private int datagramSize;
   private String host = null;
   private Channel nettyChannel;
   private Map<String, String> formaterProp;
@@ -102,8 +103,7 @@ public class SyslogUDPSource extends AbstractSource
     handler.setFormater(formaterProp);
     handler.setKeepFields(keepFields);
     serverBootstrap.setOption("receiveBufferSizePredictorFactory",
-      new AdaptiveReceiveBufferSizePredictorFactory(DEFAULT_MIN_SIZE,
-        DEFAULT_INITIAL_SIZE, maxsize));
+      new FixedReceiveBufferSizePredictorFactory(datagramSize));
     serverBootstrap.setPipelineFactory(new ChannelPipelineFactory() {
       @Override
       public ChannelPipeline getPipeline() {
@@ -150,6 +150,7 @@ public class SyslogUDPSource extends AbstractSource
         context.getString(
             SyslogSourceConfigurationConstants.CONFIG_KEEP_FIELDS,
             SyslogSourceConfigurationConstants.DEFAULT_KEEP_FIELDS));
+    datagramSize = context.getInteger(SyslogSourceConfigurationConstants.DATAGRAM_SIZE, DEFAULT_INITIAL_SIZE);
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Please see https://issues.apache.org/jira/browse/FLUME-2885.  Currently, the SyslogUDPSource truncates messages > 2K.  With this fix, the default behavior remains the same (2K is used for the buffer size), but if a user specifies a value for datagramSize in the flume configuration, then that size is used instead.  If we want to use AdaptiveReceiveBufferSizePredictor to avoid allocating buffers that are larger than necessary, 'someone' is going to have to develop a more comprehensive fix.  This at least allows for udp syslog users with messages larger than 2K to process their messages without truncation.

I have deployed this fix in two environments where syslog messages can be larger than 2K, and it works as expected.
