### PR TITLE
Support multiline and recursive directory in TaildirSource. And make the buffersize be configured.

### DIFF
--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
@@ -80,6 +80,8 @@ public class TaildirSource extends AbstractSource implements
   private List<Long> idleInodes = new CopyOnWriteArrayList<Long>();
   private Long backoffSleepIncrement;
   private Long maxBackOffSleepInterval;
+  private String lineStartRegex;
+  private int bufferSize;
 
   @Override
   public synchronized void start() {
@@ -91,6 +93,8 @@ public class TaildirSource extends AbstractSource implements
           .positionFilePath(positionFilePath)
           .skipToEnd(skipToEnd)
           .addByteOffset(byteOffsetHeader)
+          .lineStartRegex(lineStartRegex)
+          .bufferSize(bufferSize)
           .build();
     } catch (IOException e) {
       throw new FlumeException("Error instantiating ReliableTaildirEventReader", e);
@@ -162,6 +166,8 @@ public class TaildirSource extends AbstractSource implements
             , PollableSourceConstants.DEFAULT_BACKOFF_SLEEP_INCREMENT);
     maxBackOffSleepInterval = context.getLong(PollableSourceConstants.MAX_BACKOFF_SLEEP
             , PollableSourceConstants.DEFAULT_MAX_BACKOFF_SLEEP);
+    lineStartRegex = context.getString(REGEX_START, DEFAULT_REGEX_START);
+    bufferSize = context.getInteger(BUFFER_SIZE, DEFAULT_BUFFER_SIZE);
 
     if (sourceCounter == null) {
       sourceCounter = new SourceCounter(getName());

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
@@ -49,4 +49,13 @@ public class TaildirSourceConfigurationConstants {
   public static final String BYTE_OFFSET_HEADER = "byteOffsetHeader";
   public static final String BYTE_OFFSET_HEADER_KEY = "byteoffset";
   public static final boolean DEFAULT_BYTE_OFFSET_HEADER = false;
+
+  /** Lines starts with regex matched string is considered as a flume event. */
+  public static final String REGEX_START = "lineStartRegex";
+  public static final String DEFAULT_REGEX_START = "";
+
+  /** Max Number of bytes for a flume event body's content. */
+  public static final String BUFFER_SIZE = "bufferSize";
+  public static final int DEFAULT_BUFFER_SIZE = 8192;
+
 }

--- a/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
@@ -68,12 +68,26 @@ public class TestTaildirSource {
     posFilePath = tmpDir.getAbsolutePath() + "/taildir_position_test.json";
   }
 
+  private boolean delDir(File dir) {
+    if (dir.isDirectory()) {
+      String[] children = dir.list();
+      //Delete Folder Recursively.
+      for (int i=0; i<children.length; i++) {
+        boolean success = delDir(new File(dir, children[i]));
+        if (!success) {
+          return false;
+        }
+      }
+    }
+    return dir.delete();
+  }
+
   @After
   public void tearDown() {
     for (File f : tmpDir.listFiles()) {
       f.delete();
     }
-    tmpDir.delete();
+    delDir(tmpDir);
   }
 
   @Test
@@ -119,6 +133,99 @@ public class TestTaildirSource {
     assertTrue(out.contains("b.log"));
     assertTrue(out.contains("c.log.yyyy-MM-01"));
     assertTrue(out.contains("c.log.yyyy-MM-02"));
+  }
+
+  @Test
+  public void testRecursionAndRegexFileName() throws IOException {
+    File f1 = new File(tmpDir.getAbsolutePath()+"/20160606/01/a.log");
+    Files.createParentDirs(f1);
+    File f2 = new File(tmpDir, "a.log.1");
+    File f3 = new File(tmpDir, "b.log");
+    File f4 = new File(tmpDir.getAbsolutePath()+"/20160607/c.log.yyyy-MM-01");
+    Files.createParentDirs(f4);
+    File f5 = new File(tmpDir, "c.log.yyyy-MM-02");
+    Files.write("a.log\n", f1, Charsets.UTF_8);
+    Files.write("a.log.1\n", f2, Charsets.UTF_8);
+    Files.write("b.log\n", f3, Charsets.UTF_8);
+    Files.write("c.log.yyyy-MM-01\n", f4, Charsets.UTF_8);
+    Files.write("c.log.yyyy-MM-02\n", f5, Charsets.UTF_8);
+
+    Context context = new Context();
+    context.put(POSITION_FILE, posFilePath);
+    context.put(FILE_GROUPS, "ab c");
+    // Tail a.log and b.log
+    context.put(FILE_GROUPS_PREFIX + "ab", tmpDir.getAbsolutePath() + "/*/01/[ab].log");
+    // Tail files that starts with c.log
+    context.put(FILE_GROUPS_PREFIX + "c", tmpDir.getAbsolutePath() + "/*/c.log.*");
+
+    Configurables.configure(source, context);
+    source.start();
+    source.process();
+    Transaction txn = channel.getTransaction();
+    txn.begin();
+    List<String> out = Lists.newArrayList();
+    for (int i = 0; i < 5; i++) {
+      Event e = channel.take();
+      if (e != null) {
+        out.add(TestTaildirEventReader.bodyAsString(e));
+      }
+    }
+    txn.commit();
+    txn.close();
+
+    assertEquals(2, out.size());
+    // Make sure we got every file
+    assertTrue(out.contains("a.log"));
+    assertFalse(out.contains("a.log.1"));
+    assertFalse(out.contains("b.log"));
+    assertTrue(out.contains("c.log.yyyy-MM-01"));
+    assertFalse(out.contains("c.log.yyyy-MM-02"));
+  }
+
+  @Test
+  public void testMultiline() throws IOException {
+    File f1 = new File(tmpDir, "a.log");
+    File f2 = new File(tmpDir, "b.log");
+    File f3 = new File(tmpDir, "c.log");
+    Files.write("a.log\n\n2016-05-17 00:12:06,713 [Thread-7] TRACE \n f1 \n 2016-05-18 00:12:06,713 [Thread-7] TRACE \n" +
+            " f1 \n" +
+            " f1f1", f1, Charsets.UTF_8);
+
+    Files.write(" 2016-05-19 00:12:06,713 [Thread-7] TRACE \n f2 \n f2f2\n2016-05-20 00:12:06,713 [Thread-7] TRACE\n ", f2, Charsets.UTF_8);
+    Files.write("c.log\n", f3, Charsets.UTF_8);
+
+    Context context = new Context();
+    context.put(POSITION_FILE, posFilePath);
+    context.put(FILE_GROUPS, "f1");
+    // Tail a.log and b.log
+    context.put(FILE_GROUPS_PREFIX + "f1", tmpDir.getAbsolutePath() + "/[abc].log");
+    context.put(REGEX_START, "\\s?\\d\\d\\d\\d-\\d\\d-\\d\\d\\s\\d\\d:\\d\\d:\\d\\d,\\d\\d\\d");
+
+    Configurables.configure(source, context);
+    source.start();
+    source.process();
+    Transaction txn = channel.getTransaction();
+    txn.begin();
+    List<String> out = Lists.newArrayList();
+    for (int i = 0; i < 3; i++) {
+      Event e = channel.take();
+      if (e != null) {
+        out.add(TestTaildirEventReader.bodyAsString(e));
+      }
+    }
+    txn.commit();
+    txn.close();
+
+    assertEquals(3, out.size());
+    // Make sure we got every file
+
+    assertTrue(out.get(0).equals("a.log\n"));
+    assertTrue(out.get(1).equals("\n2016-05-17 00:12:06,713 [Thread-7] TRACE \n" +
+            " f1 \n"));
+
+    assertTrue(out.get(2).equals(" 2016-05-19 00:12:06,713 [Thread-7] TRACE \n" +
+            " f2 \n" +
+            " f2f2"));
   }
 
   @Test
@@ -266,9 +373,6 @@ public class TestTaildirSource {
     }
     txn.commit();
     txn.close();
-
-    System.out.println(consumedOrder);
-
     // 6) Ensure consumption order is in order of last update time
     ArrayList<String> expected = Lists.newArrayList(line1, line2, line3,    // file1
                                                     line1b, line2b, line3b, // file2


### PR DESCRIPTION
1.Add two parameters in TaildirSourceConfigurationConstants.java:
   a. REGEX_START is used for generating Flume events containing multiple lines in the body, per event. The parameter determines the start of an event. Default value is "". If the value is set to "",  a line with the end of '\n' will be dealed into one flume event.
   b. BUFFER_SIZE is used to define the max number of bytes for one flume event body's content. Default size is 8192.

2.Put the filePath, hostname, IP into the headers of a flume event if the headers do not contain the keys.

3.Modify the function getMatchFiles() in ReliableTaildirEventReader.java . It will support recursive directory.
   The sample usage:
   agent.sources.taildirsource.filegroups.f1 = /Users/wenqiao/work/flume/apache-flume-1.7.0-SNAPSHOT-bin/conf/*/01/[ab].log
