### PR TITLE
FLUME-2911. Added include pattern option in SpoolDir source

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
@@ -93,6 +93,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
   private final String completedSuffix;
   private final String deserializerType;
   private final Context deserializerContext;
+  private final Pattern includePattern;
   private final Pattern ignorePattern;
   private final File metaFile;
   private final boolean annotateFileName;
@@ -118,7 +119,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
    * Create a ReliableSpoolingFileEventReader to watch the given directory.
    */
   private ReliableSpoolingFileEventReader(File spoolDirectory,
-      String completedSuffix, String ignorePattern, String trackerDirPath,
+      String completedSuffix, String includePattern, String ignorePattern, String trackerDirPath,
       boolean annotateFileName, String fileNameHeader,
       boolean annotateBaseName, String baseNameHeader,
       String deserializerType, Context deserializerContext,
@@ -130,6 +131,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
     // Sanity checks
     Preconditions.checkNotNull(spoolDirectory);
     Preconditions.checkNotNull(completedSuffix);
+    Preconditions.checkNotNull(includePattern);
     Preconditions.checkNotNull(ignorePattern);
     Preconditions.checkNotNull(trackerDirPath);
     Preconditions.checkNotNull(deserializerType);
@@ -183,6 +185,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
     this.fileNameHeader = fileNameHeader;
     this.annotateBaseName = annotateBaseName;
     this.baseNameHeader = baseNameHeader;
+    this.includePattern = Pattern.compile(includePattern);
     this.ignorePattern = Pattern.compile(ignorePattern);
     this.deletePolicy = deletePolicy;
     this.inputCharset = Charset.forName(inputCharset);
@@ -249,6 +252,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
           String fileName = candidate.getFileName().toString();
           if (!fileName.endsWith(completedSuffix) &&
               !fileName.startsWith(".") &&
+              includePattern.matcher(fileName).matches() &&
               !ignorePattern.matcher(fileName).matches()) {
             candidateFiles.add(candidate.toFile());
           }
@@ -633,6 +637,8 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
     private File spoolDirectory;
     private String completedSuffix =
         SpoolDirectorySourceConfigurationConstants.SPOOLED_FILE_SUFFIX;
+    private String includePattern = 
+        SpoolDirectorySourceConfigurationConstants.DEFAULT_INCLUDE_PAT;
     private String ignorePattern =
         SpoolDirectorySourceConfigurationConstants.DEFAULT_IGNORE_PAT;
     private String trackerDirPath =
@@ -667,6 +673,11 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
 
     public Builder completedSuffix(String completedSuffix) {
       this.completedSuffix = completedSuffix;
+      return this;
+    }
+
+    public Builder includePattern(String includePattern) {
+      this.includePattern = includePattern;
       return this;
     }
 
@@ -737,7 +748,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
 
     public ReliableSpoolingFileEventReader build() throws IOException {
       return new ReliableSpoolingFileEventReader(spoolDirectory, completedSuffix,
-          ignorePattern, trackerDirPath, annotateFileName, fileNameHeader,
+          includePattern, ignorePattern, trackerDirPath, annotateFileName, fileNameHeader,
           annotateBaseName, baseNameHeader, deserializerType,
           deserializerContext, deletePolicy, inputCharset, decodeErrorPolicy,
           consumeOrder, recursiveDirectorySearch);

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
@@ -56,6 +56,7 @@ public class SpoolDirectorySource extends AbstractSource
   private boolean basenameHeader;
   private String basenameHeaderKey;
   private int batchSize;
+  private String includePattern;
   private String ignorePattern;
   private String trackerDirPath;
   private String deserializerType;
@@ -87,6 +88,7 @@ public class SpoolDirectorySource extends AbstractSource
       reader = new ReliableSpoolingFileEventReader.Builder()
           .spoolDirectory(directory)
           .completedSuffix(completedSuffix)
+          .includePattern(includePattern)
           .ignorePattern(ignorePattern)
           .trackerDirPath(trackerDirPath)
           .annotateFileName(fileHeader)
@@ -160,6 +162,7 @@ public class SpoolDirectorySource extends AbstractSource
         context.getString(DECODE_ERROR_POLICY, DEFAULT_DECODE_ERROR_POLICY)
         .toUpperCase(Locale.ENGLISH));
 
+    includePattern = context.getString(INCLUDE_PAT, DEFAULT_INCLUDE_PAT);
     ignorePattern = context.getString(IGNORE_PAT, DEFAULT_IGNORE_PAT);
     trackerDirPath = context.getString(TRACKER_DIR, DEFAULT_TRACKER_DIR);
 

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySourceConfigurationConstants.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySourceConfigurationConstants.java
@@ -59,6 +59,10 @@ public class SpoolDirectorySourceConfigurationConstants {
   @Deprecated
   public static final int DEFAULT_BUFFER_MAX_LINE_LENGTH = 5000;
 
+  /** Pattern of files to include */
+  public static final String INCLUDE_PAT = "includePattern";
+  public static final String DEFAULT_INCLUDE_PAT = "^.*$"; // any file
+
   /** Pattern of files to ignore */
   public static final String IGNORE_PAT = "ignorePattern";
   public static final String DEFAULT_IGNORE_PAT = "^$"; // no effect

--- a/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
@@ -21,9 +21,7 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-
 import junit.framework.Assert;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.flume.Event;
@@ -178,13 +176,14 @@ public class TestReliableSpoolingFileEventReader {
   
   @Test
   public void testIncludeExcludePatternNoConflict() throws IOException {
-	// Expected behavior mixing include/exclude conditions:
-	// - file0, file1, file3: not deleted as matching ignore pattern and not
-	// matching include pattern
-	// - file2: deleted as not matching ignore pattern and matching include
-	// pattern
-	// - emptylineFile: not deleted as not matching ignore pattern but not
-	// matching include pattern as well
+    
+    // Expected behavior mixing include/exclude conditions:
+    // - file0, file1, file3: not deleted as matching ignore pattern and not
+    // matching include pattern
+    // - file2: deleted as not matching ignore pattern and matching include
+    // pattern
+    // - emptylineFile: not deleted as not matching ignore pattern but not
+    // matching include pattern as well
     ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder()
         .spoolDirectory(WORK_DIR)
         .ignorePattern("^file[013]$")
@@ -220,11 +219,12 @@ public class TestReliableSpoolingFileEventReader {
 
   @Test
   public void testIncludeExcludePatternConflict() throws IOException {
-	// This test will stress what happens when both ignore and include options 
-	// are specified and the two patterns match at the same time.
-	// Expected behavior:
-	// - file2: not deleted as both include and ignore patterns match (safety 
-	// measure: ignore always wins on conflict)
+	  
+    // This test will stress what happens when both ignore and include options 
+	  // are specified and the two patterns match at the same time.
+	  // Expected behavior:
+	  // - file2: not deleted as both include and ignore patterns match (safety 
+	  // measure: ignore always wins on conflict)
     ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder()
         .spoolDirectory(WORK_DIR)
         .ignorePattern("^file2$")
@@ -240,9 +240,9 @@ public class TestReliableSpoolingFileEventReader {
       events = reader.readEvents(10);
       reader.commit();
     } while (!events.isEmpty());
-
-	// If both ignore and include conditions match for a file, then the file
-	// should be ignored
+    
+	  // If both ignore and include conditions match for a file, then the file
+	  // should be ignored
     List<File> after = listFiles(WORK_DIR);
     Assert.assertEquals("Expected 5, not: " + after, 5, after.size());
         Set<String> expectedLeftFiles = new HashSet<String>(

--- a/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
@@ -220,11 +220,11 @@ public class TestReliableSpoolingFileEventReader {
   @Test
   public void testIncludeExcludePatternConflict() throws IOException {
 	  
-    // This test will stress what happens when both ignore and include options 
-	  // are specified and the two patterns match at the same time.
-	  // Expected behavior:
-	  // - file2: not deleted as both include and ignore patterns match (safety 
-	  // measure: ignore always wins on conflict)
+    // This test will stress what happens when both ignore and include options
+    // are specified and the two patterns match at the same time.
+    // Expected behavior:
+    // - file2: not deleted as both include and ignore patterns match (safety 
+    // measure: ignore always wins on conflict)
     ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder()
         .spoolDirectory(WORK_DIR)
         .ignorePattern("^file2$")
@@ -240,9 +240,9 @@ public class TestReliableSpoolingFileEventReader {
       events = reader.readEvents(10);
       reader.commit();
     } while (!events.isEmpty());
-    
-	  // If both ignore and include conditions match for a file, then the file
-	  // should be ignored
+
+    // If both ignore and include conditions match for a file, then the file
+    // should be ignored
     List<File> after = listFiles(WORK_DIR);
     Assert.assertEquals("Expected 5, not: " + after, 5, after.size());
         Set<String> expectedLeftFiles = new HashSet<String>(

--- a/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
@@ -17,28 +17,11 @@
  */
 package org.apache.flume.client.avro;
 
-import com.google.common.base.Charsets;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import com.google.common.io.Files;
-import junit.framework.Assert;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.SystemUtils;
-import org.apache.flume.Event;
-import org.apache.flume.client.avro.ReliableSpoolingFileEventReader.DeletePolicy;
-import org.apache.flume.source.SpoolDirectorySourceConfigurationConstants;
-import org.apache.flume.source.SpoolDirectorySourceConfigurationConstants.ConsumeOrder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -54,13 +37,34 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.SystemUtils;
+import org.apache.flume.Event;
+import org.apache.flume.client.avro.ReliableSpoolingFileEventReader.DeletePolicy;
+import org.apache.flume.source.SpoolDirectorySourceConfigurationConstants;
+import org.apache.flume.source.SpoolDirectorySourceConfigurationConstants.ConsumeOrder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.io.Files;
+
+import junit.framework.Assert;
+
 public class TestReliableSpoolingFileEventReader {
 
-  private static final Logger logger =
-      LoggerFactory.getLogger(TestReliableSpoolingFileEventReader.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestReliableSpoolingFileEventReader.class);
 
-  private static final File WORK_DIR = new File("target/test/work/" +
-      TestReliableSpoolingFileEventReader.class.getSimpleName());
+  private static final File WORK_DIR = new File(
+      "target/test/work/" + TestReliableSpoolingFileEventReader.class.getSimpleName());
+
+  private static final File TRACKER_DIR = new File(WORK_DIR,
+      SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR);
 
   @Before
   public void setup() throws IOException, InterruptedException {
@@ -113,70 +117,78 @@ public class TestReliableSpoolingFileEventReader {
     }
   }
 
-  @Test
-  public void testIncludePattern() throws IOException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder()
-        .spoolDirectory(WORK_DIR)
-        .includePattern("^file2$")
-        .deletePolicy(DeletePolicy.IMMEDIATE.toString())
-        .build();
- 
-    List<File> before = listFiles(WORK_DIR);
-    Assert.assertEquals("Expected 5, not: " + before, 5, before.size());
-
+  private void processEventsWithReader(ReliableEventReader reader, int nEvents) throws IOException {
     List<Event> events;
     do {
-      events = reader.readEvents(10);
+      events = reader.readEvents(nEvents);
       reader.commit();
     } while (!events.isEmpty());
+  }
 
-    List<File> after = listFiles(WORK_DIR);
-    Assert.assertEquals("Expected 4, not: " + after, 4, after.size());
+  /**
+   * Verify if the give dir contains only the given files
+   * 
+   * @param dir
+   *          the directory to check
+   * @param files
+   *          the files that should be contained in dir
+   * @return true only if the dir contains exactly the same files given, false
+   *         otherwise
+   */
+  private boolean checkLeftFilesInDir(File dir, String[] files) {
+
+    List<File> after = listFiles(dir);
+    Set<String> expectedFileSet = new HashSet<String>(Arrays.asList(files));
     
-    // Check if the expected file was sent
-    Set<String> expectedLeftFiles = new HashSet<String>(Arrays.asList("file0", "file1", "file3", "emptylineFile"));
-    for (File f: after) {
-      expectedLeftFiles.remove(f.getName());
+    // Verify if the number of file in the dir is the expected
+    if (after.size() != expectedFileSet.size()) {
+      return false;
+    }
+    
+    // Then check files by name
+    for (File f : after) {
+      expectedFileSet.remove(f.getName());
     }
 
-    Assert.assertTrue("Unexpected files were sent", expectedLeftFiles.isEmpty());
-    
-    List<File> trackerFiles = listFiles(new File(WORK_DIR,
-        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR));
-    Assert.assertEquals("Expected 0, not: " + trackerFiles, 0,
-        trackerFiles.size());
+    return expectedFileSet.isEmpty();
+  }
+
+  @Test
+  public void testIncludePattern() throws IOException {
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .includePattern("^file2$").deletePolicy(DeletePolicy.IMMEDIATE.toString()).build();
+
+    String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
+    Assert.assertTrue("Expected " + beforeFiles.length + " files in working dir",
+        checkLeftFilesInDir(WORK_DIR, beforeFiles));
+
+    processEventsWithReader(reader, 10);
+
+    String[] afterFiles = { "file0", "file1", "file3", "emptylineFile" };
+    Assert.assertTrue("Expected " + afterFiles.length + " files left in working dir",
+        checkLeftFilesInDir(WORK_DIR, afterFiles));
+    Assert.assertTrue("Expected no files left in tracker dir", checkLeftFilesInDir(TRACKER_DIR, new String[0]));
   }
 
   @Test
   public void testIgnorePattern() throws IOException {
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder()
-            .spoolDirectory(WORK_DIR)
-            .ignorePattern("^file2$")
-            .deletePolicy(DeletePolicy.IMMEDIATE.toString())
-            .build();
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .ignorePattern("^file2$").deletePolicy(DeletePolicy.IMMEDIATE.toString()).build();
 
-    List<File> before = listFiles(WORK_DIR);
-    Assert.assertEquals("Expected 5, not: " + before, 5, before.size());
+    String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
+    Assert.assertTrue("Expected " + beforeFiles.length + " files in working dir",
+        checkLeftFilesInDir(WORK_DIR, beforeFiles));
 
-    List<Event> events;
-    do {
-      events = reader.readEvents(10);
-      reader.commit();
-    } while (!events.isEmpty());
+    processEventsWithReader(reader, 10);
 
-    List<File> after = listFiles(WORK_DIR);
-    Assert.assertEquals("Expected 1, not: " + after, 1, after.size());
-    Assert.assertEquals("file2", after.get(0).getName());
-    List<File> trackerFiles = listFiles(new File(WORK_DIR,
-        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR));
-    Assert.assertEquals("Expected 0, not: " + trackerFiles, 0,
-        trackerFiles.size());
+    String[] files = { "file2" };
+    Assert.assertTrue("Expected " + files.length + " files left in working dir", checkLeftFilesInDir(WORK_DIR, files));
+    Assert.assertTrue("Expected no files left in tracker dir", checkLeftFilesInDir(TRACKER_DIR, new String[0]));
   }
-  
+
   @Test
   public void testIncludeExcludePatternNoConflict() throws IOException {
-    
+
     // Expected behavior mixing include/exclude conditions:
     // - file0, file1, file3: not deleted as matching ignore pattern and not
     // matching include pattern
@@ -184,86 +196,45 @@ public class TestReliableSpoolingFileEventReader {
     // pattern
     // - emptylineFile: not deleted as not matching ignore pattern but not
     // matching include pattern as well
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder()
-        .spoolDirectory(WORK_DIR)
-        .ignorePattern("^file[013]$")
-        .includePattern("^file2$")
-        .deletePolicy(DeletePolicy.IMMEDIATE.toString())
-        .build();
- 
-    List<File> before = listFiles(WORK_DIR);
-    Assert.assertEquals("Expected 5, not: " + before, 5, before.size());
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .ignorePattern("^file[013]$").includePattern("^file2$").deletePolicy(DeletePolicy.IMMEDIATE.toString()).build();
 
-    List<Event> events;
-    do {
-      events = reader.readEvents(10);
-      reader.commit();
-    } while (!events.isEmpty());
+    String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
+    Assert.assertTrue("Expected " + beforeFiles.length + " files in working dir",
+        checkLeftFilesInDir(WORK_DIR, beforeFiles));
 
+    processEventsWithReader(reader, 10);
 
-    List<File> after = listFiles(WORK_DIR);
-    Assert.assertEquals("Expected 4, not: " + after, 4, after.size());
-        Set<String> expectedLeftFiles = new HashSet<String>(
-        		Arrays.asList("file0", "file1", "file3", "emptylineFile"));
-    for (File f: after) {
-      expectedLeftFiles.remove(f.getName());
-    }
-
-    Assert.assertTrue("Unexpected files were sent", expectedLeftFiles.isEmpty());
-    
-    List<File> trackerFiles = listFiles(new File(WORK_DIR,
-        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR));
-    Assert.assertEquals("Expected 0, not: " + trackerFiles, 0,
-        trackerFiles.size());
+    String[] files = { "file0", "file1", "file3", "emptylineFile" };
+    Assert.assertTrue("Expected " + files.length + " files left in working dir", checkLeftFilesInDir(WORK_DIR, files));
+    Assert.assertTrue("Expected no files left in tracker dir", checkLeftFilesInDir(TRACKER_DIR, new String[0]));
   }
 
   @Test
   public void testIncludeExcludePatternConflict() throws IOException {
-	  
+
     // This test will stress what happens when both ignore and include options
     // are specified and the two patterns match at the same time.
     // Expected behavior:
-    // - file2: not deleted as both include and ignore patterns match (safety 
+    // - file2: not deleted as both include and ignore patterns match (safety
     // measure: ignore always wins on conflict)
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder()
-        .spoolDirectory(WORK_DIR)
-        .ignorePattern("^file2$")
-        .includePattern("^file2$")
-        .deletePolicy(DeletePolicy.IMMEDIATE.toString())
-        .build();
- 
-    List<File> before = listFiles(WORK_DIR);
-    Assert.assertEquals("Expected 5, not: " + before, 5, before.size());
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .ignorePattern("^file2$").includePattern("^file2$").deletePolicy(DeletePolicy.IMMEDIATE.toString()).build();
 
-    List<Event> events;
-    do {
-      events = reader.readEvents(10);
-      reader.commit();
-    } while (!events.isEmpty());
+    String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
+    Assert.assertTrue("Expected " + beforeFiles.length + " files in working dir",
+        checkLeftFilesInDir(WORK_DIR, beforeFiles));
 
-    // If both ignore and include conditions match for a file, then the file
-    // should be ignored
-    List<File> after = listFiles(WORK_DIR);
-    Assert.assertEquals("Expected 5, not: " + after, 5, after.size());
-        Set<String> expectedLeftFiles = new HashSet<String>(
-        		Arrays.asList("file0", "file1", "file2", "file3", "emptylineFile"));
-    for (File f: after) {
-      expectedLeftFiles.remove(f.getName());
-    }
+    processEventsWithReader(reader, 10);
 
-    Assert.assertTrue("Unexpected files were sent", expectedLeftFiles.isEmpty());
-    
-    List<File> trackerFiles = listFiles(new File(WORK_DIR,
-        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR));
-    Assert.assertEquals("Expected 0, not: " + trackerFiles, 0,
-        trackerFiles.size());
+    String[] files = { "file0", "file1", "file2", "file3", "emptylineFile" };
+    Assert.assertTrue("Expected " + files.length + " files left in working dir", checkLeftFilesInDir(WORK_DIR, files));
+    Assert.assertTrue("Expected no files left in tracker dir", checkLeftFilesInDir(TRACKER_DIR, new String[0]));
   }
-  
+
   @Test
   public void testRepeatedCallsWithCommitAlways() throws IOException {
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .build();
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR).build();
 
     final int expectedLines = 0 + 1 + 2 + 3 + 1;
     int seenLines = 0;
@@ -278,14 +249,11 @@ public class TestReliableSpoolingFileEventReader {
 
   @Test
   public void testRepeatedCallsWithCommitOnSuccess() throws IOException {
-    String trackerDirPath =
-        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR;
+    String trackerDirPath = SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR;
     File trackerDir = new File(WORK_DIR, trackerDirPath);
 
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .trackerDirPath(trackerDirPath)
-                                                     .build();
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .trackerDirPath(trackerDirPath).build();
 
     final int expectedLines = 0 + 1 + 2 + 3 + 1;
     int seenLines = 0;
@@ -299,8 +267,7 @@ public class TestReliableSpoolingFileEventReader {
         // ensure that there are files in the trackerDir
         File[] files = trackerDir.listFiles();
         Assert.assertNotNull(files);
-        Assert.assertTrue("Expected tracker files in tracker dir " + trackerDir
-            .getAbsolutePath(), files.length > 0);
+        Assert.assertTrue("Expected tracker files in tracker dir " + trackerDir.getAbsolutePath(), files.length > 0);
       }
     }
 
@@ -309,10 +276,8 @@ public class TestReliableSpoolingFileEventReader {
 
   @Test
   public void testFileDeletion() throws IOException {
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .deletePolicy(DeletePolicy.IMMEDIATE.name())
-                                                     .build();
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .deletePolicy(DeletePolicy.IMMEDIATE.name()).build();
 
     List<File> before = listFiles(WORK_DIR);
     Assert.assertEquals("Expected 5, not: " + before, 5, before.size());
@@ -325,25 +290,20 @@ public class TestReliableSpoolingFileEventReader {
 
     List<File> after = listFiles(WORK_DIR);
     Assert.assertEquals("Expected 0, not: " + after, 0, after.size());
-    List<File> trackerFiles = listFiles(new File(WORK_DIR,
-        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR));
-    Assert.assertEquals("Expected 0, not: " + trackerFiles, 0,
-        trackerFiles.size());
+    List<File> trackerFiles = listFiles(
+        new File(WORK_DIR, SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR));
+    Assert.assertEquals("Expected 0, not: " + trackerFiles, 0, trackerFiles.size());
   }
 
   @Test(expected = NullPointerException.class)
   public void testNullConsumeOrder() throws IOException {
-    new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                 .consumeOrder(null)
-                                                 .build();
+    new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR).consumeOrder(null).build();
   }
-  
+
   @Test
   public void testConsumeFileRandomly() throws IOException {
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .consumeOrder(ConsumeOrder.RANDOM)
-                                                     .build();
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .consumeOrder(ConsumeOrder.RANDOM).build();
     File fileName = new File(WORK_DIR, "new-file");
     FileUtils.write(fileName, "New file created in the end. Shoud be read randomly.\n");
     Set<String> actual = Sets.newHashSet();
@@ -352,7 +312,7 @@ public class TestReliableSpoolingFileEventReader {
     createExpectedFromFilesInSetup(expected);
     expected.add("");
     expected.add("New file created in the end. Shoud be read randomly.");
-    Assert.assertEquals(expected, actual);    
+    Assert.assertEquals(expected, actual);
   }
 
   @Test
@@ -361,10 +321,8 @@ public class TestReliableSpoolingFileEventReader {
     if (SystemUtils.IS_OS_WINDOWS) {
       return;
     }
-    final ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .consumeOrder(ConsumeOrder.RANDOM)
-                                                     .build();
+    final ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .consumeOrder(ConsumeOrder.RANDOM).build();
     File fileName = new File(WORK_DIR, "new-file");
     FileUtils.write(fileName, "New file created in the end. Shoud be read randomly.\n");
     Set<String> expected = Sets.newHashSet();
@@ -385,7 +343,7 @@ public class TestReliableSpoolingFileEventReader {
     FileUtils.write(finalFile, "Last file");
     semaphore2.release();
     wait.get();
-    int listFilesCount = ((ReliableSpoolingFileEventReader)reader).getListFilesCount();
+    int listFilesCount = ((ReliableSpoolingFileEventReader) reader).getListFilesCount();
     finalFile.delete();
     createExpectedFromFilesInSetup(expected);
     expected.add("");
@@ -397,12 +355,10 @@ public class TestReliableSpoolingFileEventReader {
 
   @Test
   public void testConsumeFileOldest() throws IOException, InterruptedException {
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .consumeOrder(ConsumeOrder.OLDEST)
-                                                     .build();
-    File file1 = new File(WORK_DIR, "new-file1");   
-    File file2 = new File(WORK_DIR, "new-file2");    
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .consumeOrder(ConsumeOrder.OLDEST).build();
+    File file1 = new File(WORK_DIR, "new-file1");
+    File file2 = new File(WORK_DIR, "new-file2");
     File file3 = new File(WORK_DIR, "new-file3");
     Thread.sleep(1000L);
     FileUtils.write(file2, "New file2 created.\n");
@@ -411,23 +367,21 @@ public class TestReliableSpoolingFileEventReader {
     Thread.sleep(1000L);
     FileUtils.write(file3, "New file3 created.\n");
     // order of age oldest to youngest (file2, file1, file3)
-    List<String> actual = Lists.newLinkedList();    
-    readEventsForFilesInDir(WORK_DIR, reader, actual);        
+    List<String> actual = Lists.newLinkedList();
+    readEventsForFilesInDir(WORK_DIR, reader, actual);
     List<String> expected = Lists.newLinkedList();
     createExpectedFromFilesInSetup(expected);
     expected.add(""); // Empty file was added in the last in setup.
     expected.add("New file2 created.");
     expected.add("New file1 created.");
-    expected.add("New file3 created.");    
+    expected.add("New file3 created.");
     Assert.assertEquals(expected, actual);
   }
-  
+
   @Test
   public void testConsumeFileYoungest() throws IOException, InterruptedException {
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .consumeOrder(ConsumeOrder.YOUNGEST)
-                                                     .build();
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .consumeOrder(ConsumeOrder.YOUNGEST).build();
     File file1 = new File(WORK_DIR, "new-file1");
     File file2 = new File(WORK_DIR, "new-file2");
     File file3 = new File(WORK_DIR, "new-file3");
@@ -438,27 +392,24 @@ public class TestReliableSpoolingFileEventReader {
     Thread.sleep(1000L);
     FileUtils.write(file1, "New file1 created.\n");
     // order of age youngest to oldest (file2, file3, file1)
-    List<String> actual = Lists.newLinkedList();    
-    readEventsForFilesInDir(WORK_DIR, reader, actual);        
+    List<String> actual = Lists.newLinkedList();
+    readEventsForFilesInDir(WORK_DIR, reader, actual);
     List<String> expected = Lists.newLinkedList();
     createExpectedFromFilesInSetup(expected);
     Collections.sort(expected);
     // Empty Line file was added in the last in Setup.
     expected.add(0, "");
-    expected.add(0, "New file2 created.");    
+    expected.add(0, "New file2 created.");
     expected.add(0, "New file3 created.");
     expected.add(0, "New file1 created.");
-        
+
     Assert.assertEquals(expected, actual);
   }
 
   @Test
-  public void testConsumeFileOldestWithLexicographicalComparision()
-      throws IOException, InterruptedException {
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .consumeOrder(ConsumeOrder.OLDEST)
-                                                     .build();
+  public void testConsumeFileOldestWithLexicographicalComparision() throws IOException, InterruptedException {
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .consumeOrder(ConsumeOrder.OLDEST).build();
     File file1 = new File(WORK_DIR, "new-file1");
     File file2 = new File(WORK_DIR, "new-file2");
     File file3 = new File(WORK_DIR, "new-file3");
@@ -482,12 +433,9 @@ public class TestReliableSpoolingFileEventReader {
   }
 
   @Test
-  public void testConsumeFileYoungestWithLexicographicalComparision()
-      throws IOException, InterruptedException {
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .consumeOrder(ConsumeOrder.YOUNGEST)
-                                                     .build();
+  public void testConsumeFileYoungestWithLexicographicalComparision() throws IOException, InterruptedException {
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .consumeOrder(ConsumeOrder.YOUNGEST).build();
     File file1 = new File(WORK_DIR, "new-file1");
     File file2 = new File(WORK_DIR, "new-file2");
     File file3 = new File(WORK_DIR, "new-file3");
@@ -510,11 +458,13 @@ public class TestReliableSpoolingFileEventReader {
     Assert.assertEquals(expected, actual);
   }
 
-  @Test public void testLargeNumberOfFilesOLDEST() throws IOException {    
+  @Test
+  public void testLargeNumberOfFilesOLDEST() throws IOException {
     templateTestForLargeNumberOfFiles(ConsumeOrder.OLDEST, null, 1000);
   }
 
-  @Test public void testLargeNumberOfFilesYOUNGEST() throws IOException {    
+  @Test
+  public void testLargeNumberOfFilesYOUNGEST() throws IOException {
     templateTestForLargeNumberOfFiles(ConsumeOrder.YOUNGEST, new Comparator<Long>() {
 
       @Override
@@ -524,14 +474,14 @@ public class TestReliableSpoolingFileEventReader {
     }, 1000);
   }
 
-  @Test public void testLargeNumberOfFilesRANDOM() throws IOException {    
+  @Test
+  public void testLargeNumberOfFilesRANDOM() throws IOException {
     templateTestForLargeNumberOfFiles(ConsumeOrder.RANDOM, null, 1000);
   }
 
   @Test
   public void testZeroByteTrackerFile() throws IOException {
-    String trackerDirPath =
-        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR;
+    String trackerDirPath = SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR;
     File trackerDir = new File(WORK_DIR, trackerDirPath);
     if (!trackerDir.exists()) {
       trackerDir.mkdir();
@@ -542,10 +492,8 @@ public class TestReliableSpoolingFileEventReader {
     }
     trackerFile.createNewFile();
 
-    ReliableEventReader reader =
-        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-                                                     .trackerDirPath(trackerDirPath)
-                                                     .build();
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+        .trackerDirPath(trackerDirPath).build();
     final int expectedLines = 1;
     int seenLines = 0;
     List<Event> events = reader.readEvents(10);
@@ -558,16 +506,14 @@ public class TestReliableSpoolingFileEventReader {
     Assert.assertEquals(expectedLines, seenLines);
   }
 
-  private void templateTestForLargeNumberOfFiles(ConsumeOrder order, Comparator<Long> comparator,
-                                                 int N) throws IOException {
+  private void templateTestForLargeNumberOfFiles(ConsumeOrder order, Comparator<Long> comparator, int N)
+      throws IOException {
     File dir = null;
     try {
       dir = new File("target/test/work/" + this.getClass().getSimpleName() + "_large");
       Files.createParentDirs(new File(dir, "dummy"));
-      ReliableEventReader reader =
-          new ReliableSpoolingFileEventReader.Builder().spoolDirectory(dir)
-                                                       .consumeOrder(order)
-                                                       .build();
+      ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(dir).consumeOrder(order)
+          .build();
       Map<Long, List<String>> expected;
       if (comparator == null) {
         expected = new TreeMap<Long, List<String>>();
@@ -612,15 +558,14 @@ public class TestReliableSpoolingFileEventReader {
     }
   }
 
-  private void readEventsForFilesInDir(File dir, ReliableEventReader reader,
-                                       Collection<String> actual) throws IOException {
+  private void readEventsForFilesInDir(File dir, ReliableEventReader reader, Collection<String> actual)
+      throws IOException {
     readEventsForFilesInDir(dir, reader, actual, null, null);
   }
-    
+
   /* Read events, one for each file in the given directory. */
-  private void readEventsForFilesInDir(File dir, ReliableEventReader reader,
-                                       Collection<String> actual, Semaphore semaphore1,
-                                       Semaphore semaphore2) throws IOException {
+  private void readEventsForFilesInDir(File dir, ReliableEventReader reader, Collection<String> actual,
+      Semaphore semaphore1, Semaphore semaphore2) throws IOException {
     List<Event> events;
     boolean executed = false;
     for (int i = 0; i < listFiles(dir).size(); i++) {
@@ -643,16 +588,17 @@ public class TestReliableSpoolingFileEventReader {
         throw new IOException(ex);
       }
     }
-  }    
+  }
+
   /* Create expected results out of the files created in the setup method. */
   private void createExpectedFromFilesInSetup(Collection<String> expected) {
-    for (int i = 0; i < 4; i++) {      
-      for (int j = 0; j < i; j++) {        
+    for (int i = 0; i < 4; i++) {
+      for (int j = 0; j < i; j++) {
         expected.add("file" + i + "line" + j);
-      }      
+      }
     }
   }
-  
+
   private static List<File> listFiles(File dir) {
     List<File> files = Lists.newArrayList(dir.listFiles(new FileFilter() {
       @Override

--- a/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
@@ -137,27 +137,30 @@ public class TestReliableSpoolingFileEventReader {
    */
   private boolean checkLeftFilesInDir(File dir, String[] files) {
 
-    List<File> after = listFiles(dir);
-    Set<String> expectedFileSet = new HashSet<String>(Arrays.asList(files));
+    List<File> actualFiles = listFiles(dir);
+    Set<String> expectedFiles = new HashSet<String>(Arrays.asList(files));
     
-    // Verify if the number of file in the dir is the expected
-    if (after.size() != expectedFileSet.size()) {
+    // Verify if the number of files in the dir is the expected
+    if (actualFiles.size() != expectedFiles.size()) {
       return false;
     }
     
     // Then check files by name
-    for (File f : after) {
-      expectedFileSet.remove(f.getName());
+    for (File f : actualFiles) {
+      expectedFiles.remove(f.getName());
     }
 
-    return expectedFileSet.isEmpty();
+    return expectedFiles.isEmpty();
   }
 
   @Test
   public void testIncludePattern() throws IOException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .includePattern("^file2$").deletePolicy(DeletePolicy.IMMEDIATE.toString()).build();
-
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder()
+        .spoolDirectory(WORK_DIR)
+        .includePattern("^file2$")
+        .deletePolicy(DeletePolicy.IMMEDIATE.toString())
+        .build();
+    
     String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
     Assert.assertTrue("Expected " + beforeFiles.length + " files in working dir",
         checkLeftFilesInDir(WORK_DIR, beforeFiles));
@@ -172,8 +175,12 @@ public class TestReliableSpoolingFileEventReader {
 
   @Test
   public void testIgnorePattern() throws IOException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .ignorePattern("^file2$").deletePolicy(DeletePolicy.IMMEDIATE.toString()).build();
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder()
+            .spoolDirectory(WORK_DIR)
+            .ignorePattern("^file2$")
+            .deletePolicy(DeletePolicy.IMMEDIATE.toString())
+            .build();
 
     String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
     Assert.assertTrue("Expected " + beforeFiles.length + " files in working dir",
@@ -196,8 +203,13 @@ public class TestReliableSpoolingFileEventReader {
     // pattern
     // - emptylineFile: not deleted as not matching ignore pattern but not
     // matching include pattern as well
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .ignorePattern("^file[013]$").includePattern("^file2$").deletePolicy(DeletePolicy.IMMEDIATE.toString()).build();
+    
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder()
+        .spoolDirectory(WORK_DIR)
+        .ignorePattern("^file[013]$")
+        .includePattern("^file2$")
+        .deletePolicy(DeletePolicy.IMMEDIATE.toString())
+        .build(); 
 
     String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
     Assert.assertTrue("Expected " + beforeFiles.length + " files in working dir",
@@ -218,9 +230,14 @@ public class TestReliableSpoolingFileEventReader {
     // Expected behavior:
     // - file2: not deleted as both include and ignore patterns match (safety
     // measure: ignore always wins on conflict)
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .ignorePattern("^file2$").includePattern("^file2$").deletePolicy(DeletePolicy.IMMEDIATE.toString()).build();
-
+    
+    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder()
+        .spoolDirectory(WORK_DIR)
+        .ignorePattern("^file2$")
+        .includePattern("^file2$")
+        .deletePolicy(DeletePolicy.IMMEDIATE.toString())
+        .build();
+    
     String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
     Assert.assertTrue("Expected " + beforeFiles.length + " files in working dir",
         checkLeftFilesInDir(WORK_DIR, beforeFiles));
@@ -234,7 +251,9 @@ public class TestReliableSpoolingFileEventReader {
 
   @Test
   public void testRepeatedCallsWithCommitAlways() throws IOException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR).build();
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .build();
 
     final int expectedLines = 0 + 1 + 2 + 3 + 1;
     int seenLines = 0;
@@ -249,11 +268,14 @@ public class TestReliableSpoolingFileEventReader {
 
   @Test
   public void testRepeatedCallsWithCommitOnSuccess() throws IOException {
-    String trackerDirPath = SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR;
+    String trackerDirPath =
+        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR;
     File trackerDir = new File(WORK_DIR, trackerDirPath);
 
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .trackerDirPath(trackerDirPath).build();
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .trackerDirPath(trackerDirPath)
+                                                     .build();
 
     final int expectedLines = 0 + 1 + 2 + 3 + 1;
     int seenLines = 0;
@@ -267,7 +289,8 @@ public class TestReliableSpoolingFileEventReader {
         // ensure that there are files in the trackerDir
         File[] files = trackerDir.listFiles();
         Assert.assertNotNull(files);
-        Assert.assertTrue("Expected tracker files in tracker dir " + trackerDir.getAbsolutePath(), files.length > 0);
+        Assert.assertTrue("Expected tracker files in tracker dir " + trackerDir
+            .getAbsolutePath(), files.length > 0);
       }
     }
 
@@ -276,8 +299,10 @@ public class TestReliableSpoolingFileEventReader {
 
   @Test
   public void testFileDeletion() throws IOException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .deletePolicy(DeletePolicy.IMMEDIATE.name()).build();
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .deletePolicy(DeletePolicy.IMMEDIATE.name())
+                                                     .build();
 
     List<File> before = listFiles(WORK_DIR);
     Assert.assertEquals("Expected 5, not: " + before, 5, before.size());
@@ -290,20 +315,25 @@ public class TestReliableSpoolingFileEventReader {
 
     List<File> after = listFiles(WORK_DIR);
     Assert.assertEquals("Expected 0, not: " + after, 0, after.size());
-    List<File> trackerFiles = listFiles(
-        new File(WORK_DIR, SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR));
-    Assert.assertEquals("Expected 0, not: " + trackerFiles, 0, trackerFiles.size());
+    List<File> trackerFiles = listFiles(new File(WORK_DIR,
+        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR));
+    Assert.assertEquals("Expected 0, not: " + trackerFiles, 0,
+        trackerFiles.size());
   }
 
   @Test(expected = NullPointerException.class)
   public void testNullConsumeOrder() throws IOException {
-    new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR).consumeOrder(null).build();
+    new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                 .consumeOrder(null)
+                                                 .build();
   }
-
+  
   @Test
   public void testConsumeFileRandomly() throws IOException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .consumeOrder(ConsumeOrder.RANDOM).build();
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .consumeOrder(ConsumeOrder.RANDOM)
+                                                     .build();
     File fileName = new File(WORK_DIR, "new-file");
     FileUtils.write(fileName, "New file created in the end. Shoud be read randomly.\n");
     Set<String> actual = Sets.newHashSet();
@@ -312,7 +342,7 @@ public class TestReliableSpoolingFileEventReader {
     createExpectedFromFilesInSetup(expected);
     expected.add("");
     expected.add("New file created in the end. Shoud be read randomly.");
-    Assert.assertEquals(expected, actual);
+    Assert.assertEquals(expected, actual);    
   }
 
   @Test
@@ -321,8 +351,10 @@ public class TestReliableSpoolingFileEventReader {
     if (SystemUtils.IS_OS_WINDOWS) {
       return;
     }
-    final ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .consumeOrder(ConsumeOrder.RANDOM).build();
+    final ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .consumeOrder(ConsumeOrder.RANDOM)
+                                                     .build();
     File fileName = new File(WORK_DIR, "new-file");
     FileUtils.write(fileName, "New file created in the end. Shoud be read randomly.\n");
     Set<String> expected = Sets.newHashSet();
@@ -343,7 +375,7 @@ public class TestReliableSpoolingFileEventReader {
     FileUtils.write(finalFile, "Last file");
     semaphore2.release();
     wait.get();
-    int listFilesCount = ((ReliableSpoolingFileEventReader) reader).getListFilesCount();
+    int listFilesCount = ((ReliableSpoolingFileEventReader)reader).getListFilesCount();
     finalFile.delete();
     createExpectedFromFilesInSetup(expected);
     expected.add("");
@@ -355,10 +387,12 @@ public class TestReliableSpoolingFileEventReader {
 
   @Test
   public void testConsumeFileOldest() throws IOException, InterruptedException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .consumeOrder(ConsumeOrder.OLDEST).build();
-    File file1 = new File(WORK_DIR, "new-file1");
-    File file2 = new File(WORK_DIR, "new-file2");
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .consumeOrder(ConsumeOrder.OLDEST)
+                                                     .build();
+    File file1 = new File(WORK_DIR, "new-file1");   
+    File file2 = new File(WORK_DIR, "new-file2");    
     File file3 = new File(WORK_DIR, "new-file3");
     Thread.sleep(1000L);
     FileUtils.write(file2, "New file2 created.\n");
@@ -367,21 +401,23 @@ public class TestReliableSpoolingFileEventReader {
     Thread.sleep(1000L);
     FileUtils.write(file3, "New file3 created.\n");
     // order of age oldest to youngest (file2, file1, file3)
-    List<String> actual = Lists.newLinkedList();
-    readEventsForFilesInDir(WORK_DIR, reader, actual);
+    List<String> actual = Lists.newLinkedList();    
+    readEventsForFilesInDir(WORK_DIR, reader, actual);        
     List<String> expected = Lists.newLinkedList();
     createExpectedFromFilesInSetup(expected);
     expected.add(""); // Empty file was added in the last in setup.
     expected.add("New file2 created.");
     expected.add("New file1 created.");
-    expected.add("New file3 created.");
+    expected.add("New file3 created.");    
     Assert.assertEquals(expected, actual);
   }
-
+  
   @Test
   public void testConsumeFileYoungest() throws IOException, InterruptedException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .consumeOrder(ConsumeOrder.YOUNGEST).build();
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .consumeOrder(ConsumeOrder.YOUNGEST)
+                                                     .build();
     File file1 = new File(WORK_DIR, "new-file1");
     File file2 = new File(WORK_DIR, "new-file2");
     File file3 = new File(WORK_DIR, "new-file3");
@@ -392,24 +428,27 @@ public class TestReliableSpoolingFileEventReader {
     Thread.sleep(1000L);
     FileUtils.write(file1, "New file1 created.\n");
     // order of age youngest to oldest (file2, file3, file1)
-    List<String> actual = Lists.newLinkedList();
-    readEventsForFilesInDir(WORK_DIR, reader, actual);
+    List<String> actual = Lists.newLinkedList();    
+    readEventsForFilesInDir(WORK_DIR, reader, actual);        
     List<String> expected = Lists.newLinkedList();
     createExpectedFromFilesInSetup(expected);
     Collections.sort(expected);
     // Empty Line file was added in the last in Setup.
     expected.add(0, "");
-    expected.add(0, "New file2 created.");
+    expected.add(0, "New file2 created.");    
     expected.add(0, "New file3 created.");
     expected.add(0, "New file1 created.");
-
+        
     Assert.assertEquals(expected, actual);
   }
 
   @Test
-  public void testConsumeFileOldestWithLexicographicalComparision() throws IOException, InterruptedException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .consumeOrder(ConsumeOrder.OLDEST).build();
+  public void testConsumeFileOldestWithLexicographicalComparision()
+      throws IOException, InterruptedException {
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .consumeOrder(ConsumeOrder.OLDEST)
+                                                     .build();
     File file1 = new File(WORK_DIR, "new-file1");
     File file2 = new File(WORK_DIR, "new-file2");
     File file3 = new File(WORK_DIR, "new-file3");
@@ -433,9 +472,12 @@ public class TestReliableSpoolingFileEventReader {
   }
 
   @Test
-  public void testConsumeFileYoungestWithLexicographicalComparision() throws IOException, InterruptedException {
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .consumeOrder(ConsumeOrder.YOUNGEST).build();
+  public void testConsumeFileYoungestWithLexicographicalComparision()
+      throws IOException, InterruptedException {
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .consumeOrder(ConsumeOrder.YOUNGEST)
+                                                     .build();
     File file1 = new File(WORK_DIR, "new-file1");
     File file2 = new File(WORK_DIR, "new-file2");
     File file3 = new File(WORK_DIR, "new-file3");
@@ -458,13 +500,11 @@ public class TestReliableSpoolingFileEventReader {
     Assert.assertEquals(expected, actual);
   }
 
-  @Test
-  public void testLargeNumberOfFilesOLDEST() throws IOException {
+  @Test public void testLargeNumberOfFilesOLDEST() throws IOException {    
     templateTestForLargeNumberOfFiles(ConsumeOrder.OLDEST, null, 1000);
   }
 
-  @Test
-  public void testLargeNumberOfFilesYOUNGEST() throws IOException {
+  @Test public void testLargeNumberOfFilesYOUNGEST() throws IOException {    
     templateTestForLargeNumberOfFiles(ConsumeOrder.YOUNGEST, new Comparator<Long>() {
 
       @Override
@@ -474,14 +514,14 @@ public class TestReliableSpoolingFileEventReader {
     }, 1000);
   }
 
-  @Test
-  public void testLargeNumberOfFilesRANDOM() throws IOException {
+  @Test public void testLargeNumberOfFilesRANDOM() throws IOException {    
     templateTestForLargeNumberOfFiles(ConsumeOrder.RANDOM, null, 1000);
   }
 
   @Test
   public void testZeroByteTrackerFile() throws IOException {
-    String trackerDirPath = SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR;
+    String trackerDirPath =
+        SpoolDirectorySourceConfigurationConstants.DEFAULT_TRACKER_DIR;
     File trackerDir = new File(WORK_DIR, trackerDirPath);
     if (!trackerDir.exists()) {
       trackerDir.mkdir();
@@ -492,8 +532,10 @@ public class TestReliableSpoolingFileEventReader {
     }
     trackerFile.createNewFile();
 
-    ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
-        .trackerDirPath(trackerDirPath).build();
+    ReliableEventReader reader =
+        new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .trackerDirPath(trackerDirPath)
+                                                     .build();
     final int expectedLines = 1;
     int seenLines = 0;
     List<Event> events = reader.readEvents(10);
@@ -506,14 +548,16 @@ public class TestReliableSpoolingFileEventReader {
     Assert.assertEquals(expectedLines, seenLines);
   }
 
-  private void templateTestForLargeNumberOfFiles(ConsumeOrder order, Comparator<Long> comparator, int N)
-      throws IOException {
+  private void templateTestForLargeNumberOfFiles(ConsumeOrder order, Comparator<Long> comparator,
+                                                 int N) throws IOException {
     File dir = null;
     try {
       dir = new File("target/test/work/" + this.getClass().getSimpleName() + "_large");
       Files.createParentDirs(new File(dir, "dummy"));
-      ReliableEventReader reader = new ReliableSpoolingFileEventReader.Builder().spoolDirectory(dir).consumeOrder(order)
-          .build();
+      ReliableEventReader reader =
+          new ReliableSpoolingFileEventReader.Builder().spoolDirectory(dir)
+                                                       .consumeOrder(order)
+                                                       .build();
       Map<Long, List<String>> expected;
       if (comparator == null) {
         expected = new TreeMap<Long, List<String>>();
@@ -558,14 +602,15 @@ public class TestReliableSpoolingFileEventReader {
     }
   }
 
-  private void readEventsForFilesInDir(File dir, ReliableEventReader reader, Collection<String> actual)
-      throws IOException {
+  private void readEventsForFilesInDir(File dir, ReliableEventReader reader,
+                                       Collection<String> actual) throws IOException {
     readEventsForFilesInDir(dir, reader, actual, null, null);
   }
-
+    
   /* Read events, one for each file in the given directory. */
-  private void readEventsForFilesInDir(File dir, ReliableEventReader reader, Collection<String> actual,
-      Semaphore semaphore1, Semaphore semaphore2) throws IOException {
+  private void readEventsForFilesInDir(File dir, ReliableEventReader reader,
+                                       Collection<String> actual, Semaphore semaphore1,
+                                       Semaphore semaphore2) throws IOException {
     List<Event> events;
     boolean executed = false;
     for (int i = 0; i < listFiles(dir).size(); i++) {
@@ -588,17 +633,16 @@ public class TestReliableSpoolingFileEventReader {
         throw new IOException(ex);
       }
     }
-  }
-
+  }    
   /* Create expected results out of the files created in the setup method. */
   private void createExpectedFromFilesInSetup(Collection<String> expected) {
-    for (int i = 0; i < 4; i++) {
-      for (int j = 0; j < i; j++) {
+    for (int i = 0; i < 4; i++) {      
+      for (int j = 0; j < i; j++) {        
         expected.add("file" + i + "line" + j);
-      }
+      }      
     }
   }
-
+  
   private static List<File> listFiles(File dir) {
     List<File> files = Lists.newArrayList(dir.listFiles(new FileFilter() {
       @Override

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -989,7 +989,13 @@ fileHeaderKey             file            Header key to use when appending absol
 basenameHeader            false           Whether to add a header storing the basename of the file.
 basenameHeaderKey         basename        Header Key to use when appending  basename of file to event header.
 includePattern            ^.*$            Regular expression specifying which files to include.
+                                          It can used together with ``ignorePattern``.
+                                          If a file matches both ``ignorePattern`` and ``includePattern`` regex,
+                                          the file is ignored.
 ignorePattern             ^$              Regular expression specifying which files to ignore (skip).
+                                          It can used together with ``includePattern``.
+                                          If a file matches both ``ignorePattern`` and ``includePattern`` regex,
+                                          the file is ignored.
 trackerDir                .flumespool     Directory to store metadata related to processing of files.
                                           If this path is not an absolute path, then it is interpreted as relative to the spoolDir.
 consumeOrder              oldest          In which order files in the spooling directory will be consumed ``oldest``,
@@ -1232,7 +1238,7 @@ useFlumeEventFormat              false        By default events are taken as byt
                                               on the KafkaSink or with the parseAsFlumeEvent property on the Kafka Channel this will preserve
                                               any Flume headers sent on the producing side.
 Other Kafka Consumer Properties  --           These properties are used to configure the Kafka Consumer. Any producer property supported
-                                              by Kafka can be used. The only requirement is to prepend the property name with the prefix 
+                                              by Kafka can be used. The only requirement is to prepend the property name with the prefix
                                               ``kafka.consumer``.
                                               For example: ``kafka.consumer.auto.offset.reset``
                                               Check `Kafka documentation <http://kafka.apache.org/documentation.html#newconsumerconfigs>`_ for details

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -988,7 +988,8 @@ fileHeader                false           Whether to add a header storing the ab
 fileHeaderKey             file            Header key to use when appending absolute path filename to event header.
 basenameHeader            false           Whether to add a header storing the basename of the file.
 basenameHeaderKey         basename        Header Key to use when appending  basename of file to event header.
-ignorePattern             ^$              Regular expression specifying which files to ignore (skip)
+includePattern            ^.*$            Regular expression specifying which files to include.
+ignorePattern             ^$              Regular expression specifying which files to ignore (skip).
 trackerDir                .flumespool     Directory to store metadata related to processing of files.
                                           If this path is not an absolute path, then it is interpreted as relative to the spoolDir.
 consumeOrder              oldest          In which order files in the spooling directory will be consumed ``oldest``,


### PR DESCRIPTION
Current implementation of `SpoolDirectorySource` does not allow users to specify a regex pattern to select which files should be monitored. Instead, the current implementation allows users to specify which should not monitored, via the `ignorePattern` parameter.

We implemented the feature, allowing users to specify the include pattern as `a1.sources.src-1.includePattern=^foo.*$` (includes all the files that starts in "foo").

By default, the `includePattern` regex is set to `^.*$` (all files).

Include and exclude patterns can be used at same time and the results are combined.

We also opened this JIRA issue: https://issues.apache.org/jira/browse/FLUME-2911
