### PR TITLE
bug fix: close the file before reopen it if the file is renamed

### DIFF
--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
@@ -245,6 +245,9 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
         long inode = getInode(f);
         TailFile tf = tailFiles.get(inode);
         if (tf == null || !tf.getPath().equals(f.getAbsolutePath())) {
+          if (tf != null && tf.getRaf() != null) {
+            tf.close();
+          }
           long startPos = skipToEnd ? f.length() : 0;
           tf = openFile(f, headers, inode, startPos);
         } else {

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -19,6 +19,7 @@
 
 package org.apache.flume.source.taildir;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.apache.flume.Event;
 import org.apache.flume.event.EventBuilder;
@@ -73,6 +74,18 @@ public class TailFile {
 
   public RandomAccessFile getRaf() {
     return raf;
+  }
+
+  @VisibleForTesting
+  public void setRaf(RandomAccessFile raf) {
+    if (this.raf != null) {
+      try {
+        this.raf.close();
+      } catch (IOException e) {
+        logger.error("Failed closing file: " + path + ", inode: " + inode, e);
+      }
+    }
+    this.raf = raf;
   }
 
   public String getPath() {


### PR DESCRIPTION
In taildir source, if a file is renamed, it will be reopened, it should be closed first to avoid resource leaks
