### PR TITLE
Kafka Source in combination with Kafka Sink leads to infinite loop

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -1286,6 +1286,10 @@ Other Kafka Consumer Properties     --           These properties are used to co
           The Kafka Source also provides defaults for the key.deserializer(org.apache.kafka.common.serialization.StringSerializer)
           and value.deserializer(org.apache.kafka.common.serialization.ByteArraySerializer). Modification of these parameters is not recommended.
 
+.. note:: The Kafka Source sets several event headers if they don't exist already: "timestamp", "topic", "partition" and "key" (if it's a keyed kafka message).
+          Especially the header field "topic" can lead to unexpected behaviour when used in combination with the Kafka Sink.
+          This header field overwrites the destination topic of the sinks configuration and leads to an indefinite loop producing the messages to into the topic where they has been read from.
+
 Deprecated Properties
 
 ===============================  ===================  =============================================================================================


### PR DESCRIPTION
Because Kafka Source sets some header fields - especially "topic" - this leads to unexpected behavior in combination with the Kafka Sink => The messages will be consumed and produced again into that topic until the agent will be shut down.

The Kafka Sink determines the topic to which the event should be produced to based on a header field "topic" and overwrites the configuration of the sink.
To (nearly) fix that there are multiple options:
- update the documentation - done with this PR
- explicitly allow topic overriding at the kafka sink via a flag
- write the source topic into another header field - maybe "kafka.topic"
