### PR TITLE
Add flume-shared module to assembly xmls

### DIFF
--- a/flume-ng-dist/src/main/assembly/bin.xml
+++ b/flume-ng-dist/src/main/assembly/bin.xml
@@ -69,6 +69,7 @@
         <exclude>flume-ng-embedded-agent/**</exclude>
         <exclude>flume-tools/**</exclude>
         <exclude>flume-ng-auth/**</exclude>
+        <exclude>flume-shared/**</exclude>
         <exclude>**/target/**</exclude>
         <exclude>**/.classpath</exclude>
         <exclude>**/.project</exclude>

--- a/flume-ng-dist/src/main/assembly/src.xml
+++ b/flume-ng-dist/src/main/assembly/src.xml
@@ -50,6 +50,7 @@
         <include>org.apache.flume:flume-ng-embedded-agent</include>
         <include>org.apache.flume:flume-tools</include>
         <include>org.apache.flume:flume-ng-auth</include>
+        <include>org.apache.flume:flume-shared</include>
       </includes>
 
       <sources>


### PR DESCRIPTION
Fixes the issue that the assembly plugin created the source package without the `flume-shared` project in it so maven compile failed on that.
