### PR TITLE
Remove test dependencies from binary release artifact

### DIFF
--- a/flume-ng-dist/src/main/assembly/bin.xml
+++ b/flume-ng-dist/src/main/assembly/bin.xml
@@ -38,6 +38,12 @@
       <useProjectArtifact>false</useProjectArtifact>
       <excludes>
         <exclude>org.apache.flume.flume-ng-clients:flume-ng-log4jappender:jar:jar-with-dependencies</exclude>
+        <!-- The below test classes get pulled in by flume-shared-kafka-test,
+             but we don't want them in the final release classpath. Maybe there
+             is a better way to exclude all of the dependencies of that module;
+             for now, specifically exclude these test deps. -->
+        <exclude>junit:junit</exclude>
+        <exclude>org.hamcrest:hamcrest-core</exclude>
       </excludes>
     </dependencySet>
     <dependencySet>
@@ -50,8 +56,7 @@
     </dependencySet>
   </dependencySets>
 
-
-   <fileSets>
+  <fileSets>
     <fileSet>
       <directory>../</directory>
 


### PR DESCRIPTION
This patch removes some test-specific dependencies from the binary
release artifact. These were introduced by the new
flume-shared-kafka-test module that is intended for sharing test code.
Please see the new comment in bin.xml for more information.
