### PR TITLE
Set MAVEN_OPTS for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,9 @@
 # under the License.
 
 language: java
-cache:
-  directories:
-    - $HOME/.m2
 before_install:
-  - echo "MAVEN_OPTS='-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m'" > ~/.mavenrc
+  - export MAVEN_SKIP_RC="true"
 install:
   -
 script:
-  - mvn clean install -DskipTests
+  - MAVEN_OPTS="-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m" mvn clean install -DskipTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
   directories:
     - $HOME/.m2
 before_install:
-  - echo "MAVEN_OPTS='-Xmx2g -XX:MaxPermSize=512m'" > ~/.mavenrc
+  - echo "MAVEN_OPTS='-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m'" > ~/.mavenrc
 install:
   -
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,12 @@
 # under the License.
 
 language: java
-script: mvn clean install -DskipTests
+cache:
+  directories:
+    - $HOME/.m2
+before_install:
+  - echo "MAVEN_OPTS='-Xmx2g -XX:MaxPermSize=512m'" > ~/.mavenrc
+install:
+  -
+script:
+  - mvn clean install -DskipTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@
 
 language: java
 before_install:
-  - export MAVEN_SKIP_RC="true"
+  - export MAVEN_SKIP_RC="true" # Travis has settings in /etc/mavenrc. We want to override them. See https://github.com/travis-ci/travis-ci/issues/4613
 install:
-  -
+  - # Skip mvn install. See https://docs.travis-ci.com/user/languages/java/
 script:
   - MAVEN_OPTS="-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m" mvn clean install -DskipTests


### PR DESCRIPTION
Travis builds occasionally fail with Java heap space error.

This commit sets higher limits to fix the issue mentioned above.
