### PR TITLE
FLUME-2812: Exception in thread "SinkRunner-PollingRunner-DefaultSinkProcessor" java.lang.Error: Maximum permit count exceeded

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
@@ -18,6 +18,7 @@
  */
 package org.apache.flume.channel;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.flume.ChannelException;
 import org.apache.flume.ChannelFullException;
@@ -171,7 +172,6 @@ public class MemoryChannel extends BasicChannelSemantics {
         }
         putList.clear();
       }
-      bytesRemaining.release(putByteCounter);
       putByteCounter = 0;
       takeByteCounter = 0;
 
@@ -373,5 +373,10 @@ public class MemoryChannel extends BasicChannelSemantics {
     }
     //Each event occupies at least 1 slot, so return 1.
     return 1;
+  }
+
+  @VisibleForTesting
+  int getBytesRemainingValue() {
+    return bytesRemaining.availablePermits();
   }
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
@@ -54,7 +54,10 @@ public class MemoryChannel extends BasicChannelSemantics {
   private static Logger LOGGER = LoggerFactory.getLogger(MemoryChannel.class);
   private static final Integer defaultCapacity = 100;
   private static final Integer defaultTransCapacity = 100;
-  private static final double byteCapacitySlotSize = 100;
+
+  @VisibleForTesting
+  static final double byteCapacitySlotSize = 100;
+
   private static final Long defaultByteCapacity = (long)(Runtime.getRuntime().maxMemory() * .80);
   private static final Integer defaultByteCapacityBufferPercentage = 20;
 

--- a/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
@@ -19,7 +19,7 @@
 
 package org.apache.flume.channel;
 
-import org.apache.flume.Channel;
+import com.google.common.collect.ImmutableMap;
 import org.apache.flume.ChannelException;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
@@ -27,6 +27,7 @@ import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Transaction;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.event.EventBuilder;
+import org.apache.flume.event.SimpleEvent;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +40,7 @@ import static org.fest.reflect.core.Reflection.field;
 
 public class TestMemoryChannel {
 
-  private Channel channel;
+  private MemoryChannel channel;
 
   @Before
   public void setUp() {
@@ -263,6 +264,21 @@ public class TestMemoryChannel {
     transaction.commit();
     Assert.fail();
 
+  }
+
+  @Test
+  public void testByteCapacityAfterRollback() {
+    Context ctx = new Context(ImmutableMap.of("byteCapacity", "1000"));
+    Configurables.configure(channel,  ctx);
+
+    Assert.assertEquals(8, channel.getBytesRemainingValue());
+    Event e = new SimpleEvent();
+    Transaction t = channel.getTransaction();
+    t.begin();
+
+    channel.put(e);
+    t.rollback();
+    Assert.assertEquals(8, channel.getBytesRemainingValue());
   }
 
   public void testByteCapacityBufferEmptyingAfterTakeCommit() {


### PR DESCRIPTION
Fix semaphore leak causing `java.lang.Error: Maximum permit count exceeded` in `MemoryChannel`

``` java
Exception in thread "SinkRunner-PollingRunner-DefaultSinkProcessor" java.lang.Error: Maximum permit count exceeded
    at java.util.concurrent.Semaphore$Sync.tryReleaseShared(Semaphore.java:192)
    at java.util.concurrent.locks.AbstractQueuedSynchronizer.releaseShared(AbstractQueuedSynchronizer.java:1341)
    at java.util.concurrent.Semaphore.release(Semaphore.java:609)
    at org.apache.flume.channel.MemoryChannel$MemoryTransaction.doCommit(MemoryChannel.java:147)
    at org.apache.flume.channel.BasicTransactionSemantics.commit(BasicTransactionSemantics.java:151)
    at org.apache.flume.sink.AbstractRpcSink.process(AbstractRpcSink.java:379)
    at org.apache.flume.sink.DefaultSinkProcessor.process(DefaultSinkProcessor.java:68)
    at org.apache.flume.SinkRunner$PollingRunner.run(SinkRunner.java:147)
    at java.lang.Thread.run(Thread.java:745)
```

for more details and explanation see my comment on [FLUME-2812](https://issues.apache.org/jira/browse/FLUME-2812)
