### PR TITLE
FLUME-3025: Expose FileChannel.open JMX

### DIFF
--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
@@ -40,6 +40,7 @@ import org.apache.flume.channel.file.encryption.EncryptionConfiguration;
 import org.apache.flume.channel.file.encryption.KeyProvider;
 import org.apache.flume.channel.file.encryption.KeyProviderFactory;
 import org.apache.flume.instrumentation.ChannelCounter;
+import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -267,13 +268,14 @@ public class FileChannel extends BasicChannelSemantics {
     }
 
     if (channelCounter == null) {
-      channelCounter = new ChannelCounter(getName());
+      channelCounter = new FileChannelCounter(this);
     }
   }
 
   @Override
   public synchronized void start() {
     LOG.info("Starting {}...", this);
+    channelCounter.start();
     try {
       Builder builder = new Log.Builder();
       builder.setCheckpointInterval(checkpointInterval);
@@ -312,7 +314,6 @@ public class FileChannel extends BasicChannelSemantics {
       }
     }
     if (open) {
-      channelCounter.start();
       channelCounter.setChannelSize(getDepth());
       channelCounter.setChannelCapacity(capacity);
     }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
@@ -94,7 +94,7 @@ public class FileChannel extends BasicChannelSemantics {
   private final ThreadLocal<FileBackedTransaction> transactions =
       new ThreadLocal<FileBackedTransaction>();
   private String channelNameDescriptor = "[channel=unknown]";
-  private ChannelCounter channelCounter;
+  private FileChannelCounter channelCounter;
   private boolean useLogReplayV1;
   private boolean useFastReplay = false;
   private KeyProvider encryptionKeyProvider;
@@ -417,6 +417,11 @@ public class FileChannel extends BasicChannelSemantics {
   @VisibleForTesting
   Log getLog() {
     return log;
+  }
+
+  @VisibleForTesting
+  FileChannelCounter getChannelCounter() {
+    return channelCounter;
   }
 
   /**

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
@@ -18,20 +18,22 @@
  */
 package org.apache.flume.channel.file.instrumentation;
 
-import org.apache.flume.channel.file.FileChannel;
 import org.apache.flume.instrumentation.ChannelCounter;
 
 public class FileChannelCounter extends ChannelCounter implements FileChannelCounterMBean {
 
-  private final FileChannel fileChannel;
+  private boolean open;
 
-  public FileChannelCounter(FileChannel fileChannel) {
-    super(fileChannel.getName());
-    this.fileChannel = fileChannel;
+  public FileChannelCounter(String name) {
+    super(name);
   }
 
+  @Override
   public boolean isOpen() {
-    return fileChannel.isOpen();
+    return open;
   }
 
+  public void setOpen(boolean open) {
+    this.open = open;
+  }
 }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
@@ -1,9 +1,4 @@
-package org.apache.flume.channel.file.instrumentation;
-
-import org.apache.flume.channel.file.FileChannel;
-import org.apache.flume.instrumentation.ChannelCounter;
-
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -11,15 +6,21 @@ import org.apache.flume.instrumentation.ChannelCounter;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+package org.apache.flume.channel.file.instrumentation;
+
+import org.apache.flume.channel.file.FileChannel;
+import org.apache.flume.instrumentation.ChannelCounter;
+
 public class FileChannelCounter extends ChannelCounter implements FileChannelCounterMBean {
 
   private final FileChannel fileChannel;

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
@@ -1,0 +1,36 @@
+package org.apache.flume.channel.file.instrumentation;
+
+import org.apache.flume.channel.file.FileChannel;
+import org.apache.flume.instrumentation.ChannelCounter;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class FileChannelCounter extends ChannelCounter implements FileChannelCounterMBean {
+
+  private final FileChannel fileChannel;
+
+  public FileChannelCounter(FileChannel fileChannel) {
+    super(fileChannel.getName());
+    this.fileChannel = fileChannel;
+  }
+
+  public boolean isOpen() {
+    return fileChannel.isOpen();
+  }
+
+}

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounterMBean.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounterMBean.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flume.channel.file.instrumentation;
+
+import org.apache.flume.instrumentation.ChannelCounterMBean;
+
+public interface FileChannelCounterMBean extends ChannelCounterMBean {
+
+  boolean isOpen();
+}

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounterMBean.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounterMBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -7,13 +7,14 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.flume.channel.file.instrumentation;
 

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannel.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannel.java
@@ -26,6 +26,7 @@ import org.apache.flume.Event;
 import org.apache.flume.Transaction;
 import org.apache.flume.channel.file.FileChannel.FileBackedTransaction;
 import org.apache.flume.channel.file.FlumeEventQueue.InflightEventWrapper;
+import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.event.EventBuilder;
 import org.junit.After;
@@ -630,6 +631,19 @@ public class TestFileChannel extends TestFileChannelBase {
       // returned
       Assert.assertEquals(99, events.size());
     }
+  }
+
+  @Test
+  public void testFileChannelCounterIsOpen() {
+    FileChannel channel = createFileChannel();
+    FileChannelCounter counter = channel.getChannelCounter();
+    Assert.assertEquals(counter.isOpen(), false);
+
+    channel.start();
+    Assert.assertEquals(counter.isOpen(), true);
+
+    channel.stop();
+    Assert.assertEquals(counter.isOpen(), false);
   }
 
 }


### PR DESCRIPTION
This patch exposes the `FileChannel`'s `open` flag on JMX to make it possible to detect when it wasn't able to start up (thus its `open` flag is `false`).