### PR TITLE
Remove `hostHeader = hostname` property from Host interceptor example

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -3875,7 +3875,6 @@ Example for agent named a1:
   a1.channels = c1
   a1.sources.r1.interceptors = i1
   a1.sources.r1.interceptors.i1.type = host
-  a1.sources.r1.interceptors.i1.hostHeader = hostname
 
 Static Interceptor
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We are overriding the host header name from `host` to `hostname` in the example usage section. Due to this example users are overriding the header name too but still use the `%{host}` substitution as shown in the HDFS Sink section. This won't work for them.

This change removes this config line.