### PR TITLE
DEFAULT_AUTO_OFFSET_RESET should be "latest" according to official do…

### DIFF
--- a/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannelConfiguration.java
+++ b/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannelConfiguration.java
@@ -44,7 +44,7 @@ public class KafkaChannelConfiguration {
 
   public static final String KEY_HEADER = "key";
 
-  public static final String DEFAULT_AUTO_OFFSET_RESET = "earliest";
+  public static final String DEFAULT_AUTO_OFFSET_RESET = "latest";
 
   public static final String PARSE_AS_FLUME_EVENT = "parseAsFlumeEvent";
   public static final boolean DEFAULT_PARSE_AS_FLUME_EVENT = true;


### PR DESCRIPTION
In the official document, the default value of "kafka.consumer.auto.offset.reset" is "latest", but in the source code, "DEFAULT_AUTO_OFFSET_RESET" is "earliest".