### PR TITLE
Change how we build and sign release artifacts

### DIFF
--- a/dev-support/create-source-archive.sh
+++ b/dev-support/create-source-archive.sh
@@ -21,13 +21,9 @@
 # The contract of this script is that it outputs the location of the generated
 # tarball to stdout upon successful completion.
 ################################################################################
+DEV_SUPPORT=$(cd $(dirname $0); pwd)
+source "$DEV_SUPPORT/includes.sh"
 
-error() {
-  echo $1 1>&2
-  exit 1
-}
-
-ROOT=$(cd $(dirname $0); pwd)
 VERSION_NUMBER=$1
 GIT_TAG=$2
 OUTPUT_DIR=$3
@@ -46,7 +42,7 @@ ARTIFACT_NAME=apache-flume-${VERSION_NUMBER}-src
 ARTIFACT_PATH=$ABS_OUTPUT_DIR/$ARTIFACT_NAME.$EXT
 
 # Need to call git archive from the root of the tree.
-cd $ROOT/..
+cd $DEV_SUPPORT/..
 
 echo git archive --prefix=$ARTIFACT_NAME/ --output=$ARTIFACT_PATH --format "$EXT" "$GIT_TAG" 1>&2
 git archive --prefix=$ARTIFACT_NAME/ --output=$ARTIFACT_PATH --format "$EXT" "$GIT_TAG"

--- a/dev-support/create-source-archive.sh
+++ b/dev-support/create-source-archive.sh
@@ -1,5 +1,22 @@
 #!/bin/bash -e
 ################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+################################################################################
 # Script to generate a source release tarball.
 # The contract of this script is that it outputs the location of the generated
 # tarball to stdout upon successful completion.

--- a/dev-support/create-source-archive.sh
+++ b/dev-support/create-source-archive.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+################################################################################
+# Script to generate a source release tarball.
+# The contract of this script is that it outputs the location of the generated
+# tarball to stdout upon successful completion.
+################################################################################
+
+error() {
+  echo $1 1>&2
+  exit 1
+}
+
+ROOT=$(cd $(dirname $0); pwd)
+VERSION_NUMBER=$1
+GIT_TAG=$2
+OUTPUT_DIR=$3
+
+if [[ -z "$VERSION_NUMBER" || -z "$GIT_TAG" || -z "$OUTPUT_DIR" ]]; then
+  echo "Usage: $0 VERSION_NUMBER GIT_TAG OUTPUT_DIR" 1>&2
+  echo "Example: $0 1.7.0 release-1.7.0-rc1 target" 1>&2
+  exit 1
+fi
+
+[ ! -d "$OUTPUT_DIR" ] && error "Output directory $OUTPUT_DIR does not exist."
+ABS_OUTPUT_DIR=$(cd $OUTPUT_DIR; pwd)
+
+EXT=tar.gz
+ARTIFACT_NAME=apache-flume-${VERSION_NUMBER}-src
+ARTIFACT_PATH=$ABS_OUTPUT_DIR/$ARTIFACT_NAME.$EXT
+
+# Need to call git archive from the root of the tree.
+cd $ROOT/..
+
+echo git archive --prefix=$ARTIFACT_NAME/ --output=$ARTIFACT_PATH --format "$EXT" "$GIT_TAG" 1>&2
+git archive --prefix=$ARTIFACT_NAME/ --output=$ARTIFACT_PATH --format "$EXT" "$GIT_TAG"
+
+echo $ARTIFACT_PATH
+exit 0

--- a/dev-support/generate-source-release.sh
+++ b/dev-support/generate-source-release.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+################################################################################
+# Script to generate and sign a source release.
+################################################################################
+
+error() {
+  echo $1 1>&2
+  exit 1
+}
+
+ROOT=$(cd $(dirname $0); pwd)
+VERSION_NUMBER=$1
+GIT_TAG=$2
+OUTPUT_DIR=$3
+
+if [[ -z "$VERSION_NUMBER" || -z "$GIT_TAG" || -z "$OUTPUT_DIR" ]]; then
+  echo "Usage: $0 VERSION_NUMBER GIT_TAG OUTPUT_DIR"
+  echo "Example: $0 1.7.0 release-1.7.0-rc1 target"
+  exit 1
+fi
+
+# Generate the source artifact.
+echo "Creating source archive..."
+CREATE_ARCHIVE=$ROOT/create-source-archive.sh
+ARCHIVE_PATH=$($CREATE_ARCHIVE "$VERSION_NUMBER" "$GIT_TAG" "$OUTPUT_DIR")
+[ $? != 0 ] && error "Failed to generate source archive. $CREATE_ARCHIVE returned $?"
+[ ! -r $ARCHIVE_PATH ] && error "Failed to generate source archive. Unknown error."
+
+# Sign and checksum the source artifact.
+echo "Signing source artifact..."
+SIGN_ARTIFACT=$ROOT/sign-checksum-artifact.sh
+$SIGN_ARTIFACT "$ARCHIVE_PATH"
+
+echo "Release artifacts generated in $OUTPUT_DIR"
+exit 0
+

--- a/dev-support/generate-source-release.sh
+++ b/dev-support/generate-source-release.sh
@@ -1,5 +1,22 @@
 #!/bin/bash -e
 ################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+################################################################################
 # Script to generate and sign a source release.
 ################################################################################
 

--- a/dev-support/includes.sh
+++ b/dev-support/includes.sh
@@ -17,33 +17,24 @@
 # specific language governing permissions and limitations
 # under the License.
 ################################################################################
-# Script to generate and sign a source release.
+# Utilities for dev-support scripts.
 ################################################################################
-DEV_SUPPORT=$(cd $(dirname $0); pwd)
-source "$DEV_SUPPORT/includes.sh"
 
-VERSION_NUMBER=$1
-GIT_TAG=$2
-OUTPUT_DIR=$3
-
-if [[ -z "$VERSION_NUMBER" || -z "$GIT_TAG" || -z "$OUTPUT_DIR" ]]; then
-  echo "Usage: $0 VERSION_NUMBER GIT_TAG OUTPUT_DIR"
-  echo "Example: $0 1.7.0 release-1.7.0-rc1 target"
+# Print an error message and exit.
+error() {
+  echo $1 1>&2
   exit 1
-fi
+}
 
-# Generate the source artifact.
-echo "Creating source archive..."
-CREATE_ARCHIVE=$DEV_SUPPORT/create-source-archive.sh
-ARCHIVE_PATH=$($CREATE_ARCHIVE "$VERSION_NUMBER" "$GIT_TAG" "$OUTPUT_DIR")
-[ $? != 0 ] && error "Failed to generate source archive. $CREATE_ARCHIVE returned $?"
-[ ! -r $ARCHIVE_PATH ] && error "Failed to generate source archive. Unknown error."
-
-# Sign and checksum the source artifact.
-echo "Signing source artifact..."
-SIGN_ARTIFACT=$DEV_SUPPORT/sign-checksum-artifact.sh
-$SIGN_ARTIFACT "$ARCHIVE_PATH"
-
-echo "Release artifacts generated in $OUTPUT_DIR"
-exit 0
-
+# Searches the PATH for each command name passed, and returns the path of the
+# first one found.
+find_in_path() {
+  for COMMAND in "$@"; do
+    FOUND=$(which $COMMAND)
+    if [ -n "$FOUND" ]; then
+      echo "$FOUND"
+      return
+    fi
+  done
+  error "Cannot find $1. Please install $1 to continue."
+}

--- a/dev-support/sign-checksum-artifact.sh
+++ b/dev-support/sign-checksum-artifact.sh
@@ -1,7 +1,24 @@
 #!/bin/bash -e
-###########################################################
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+################################################################################
 # Sign and checksum release artifacts.
-###########################################################
+################################################################################
 
 usage() {
   echo "Usage: $0 RELEASE_ARTIFACT" 1>&2

--- a/dev-support/sign-checksum-artifact.sh
+++ b/dev-support/sign-checksum-artifact.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+###########################################################
+# Sign and checksum release artifacts.
+###########################################################
+
+usage() {
+  echo "Usage: $0 RELEASE_ARTIFACT" 1>&2
+  echo "Example: $0 ./apache-flume-1.7.0-bin.tar.gz" 1>&2
+  exit 1
+}
+
+error() {
+  echo $1 1>&2
+  exit 1
+}
+
+ARTIFACT=$1
+if [ ! -r "$ARTIFACT" ]; then
+  echo "The artifact at $ARTIFACT does not exist or is not readable." 1>&2
+  usage
+fi
+
+# Find GnuPG.
+GPG=$(which gpg)
+[ -z "$GPG" ] && error "Cannot find gpg. Please install GnuPG to continue."
+
+# Find md5.
+MD5=$(which md5sum)
+[ -z "$MD5" ] && MD5=$(which md5)
+[ -z "$MD5" ] && error "Cannot find md5sum. Please install the md5sum program to continue."
+
+# Find sha1.
+SHA1=$(which sha1sum)
+[ -z "$SHA1" ] && SHA1=$(which shasum)
+[ -z "$SHA1" ] && error "Cannot find sha1sum. Please install the sha1sum program to continue."
+
+# Now sign and checksum the artifact.
+set -x
+$GPG --sign $ARTIFACT
+$MD5 < $ARTIFACT > $ARTIFACT.md5
+$SHA1 < $ARTIFACT > $ARTIFACT.sha1
+
+exit 0

--- a/dev-support/sign-checksum-artifact.sh
+++ b/dev-support/sign-checksum-artifact.sh
@@ -19,15 +19,12 @@
 ################################################################################
 # Sign and checksum release artifacts.
 ################################################################################
+DEV_SUPPORT=$(cd $(dirname $0); pwd)
+source "$DEV_SUPPORT/includes.sh"
 
 usage() {
   echo "Usage: $0 RELEASE_ARTIFACT" 1>&2
   echo "Example: $0 ./apache-flume-1.7.0-bin.tar.gz" 1>&2
-  exit 1
-}
-
-error() {
-  echo $1 1>&2
   exit 1
 }
 
@@ -37,24 +34,13 @@ if [ ! -r "$ARTIFACT" ]; then
   usage
 fi
 
-# Find GnuPG.
-GPG=$(which gpg)
-[ -z "$GPG" ] && error "Cannot find gpg. Please install GnuPG to continue."
-
-# Find md5.
-MD5=$(which md5sum)
-[ -z "$MD5" ] && MD5=$(which md5)
-[ -z "$MD5" ] && error "Cannot find md5sum. Please install the md5sum program to continue."
-
-# Find sha1.
-SHA1=$(which sha1sum)
-[ -z "$SHA1" ] && SHA1=$(which shasum)
-[ -z "$SHA1" ] && error "Cannot find sha1sum. Please install the sha1sum program to continue."
+# The tools we need.
+GPG=$(find_in_path gpg)
+MD5=$(find_in_path md5sum md5)
+SHA1=$(find_in_path sha1sum shasum)
 
 # Now sign and checksum the artifact.
 set -x
 $GPG --sign $ARTIFACT
 $MD5 < $ARTIFACT > $ARTIFACT.md5
 $SHA1 < $ARTIFACT > $ARTIFACT.sha1
-
-exit 0


### PR DESCRIPTION
These simple scripts automate creation and signing of the release
artifacts. They help guarantee that the source artifacts published match
the Git tag.

Updated the How To Release documentation to explain how to use the
scripts.