### PR TITLE
fix "eventCounter" increase bug in append()

### DIFF
--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
@@ -574,13 +574,14 @@ class BucketWriter {
     }
 
     // update statistics
-    processSize += event.getBody().length;
-    eventCounter++;
+    processSize += event.getBody().length;    
     batchCounter++;
 
     if (batchCounter == batchSize) {
       flush();
     }
+    
+    eventCounter++;
   }
 
   /**


### PR DESCRIPTION
In append() function, when the "batchCounter" is equal to batchSize, flush() will be called, which may throw exceptions when the network jitter happens on HDFS. Once exception happens, the event appended to the batch will be rollback, but the "eventCounter" has already been increased, which will make the "eventCounter" wrong value. So, the "eventCounter" should be increased after flush() happens.