### PR TITLE
flume-checkstyle module should use ASF root pom as parent

### DIFF
--- a/flume-checkstyle/pom.xml
+++ b/flume-checkstyle/pom.xml
@@ -20,7 +20,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>18</version>
+  </parent>
   <groupId>org.apache.flume</groupId>
   <artifactId>flume-checkstyle</artifactId>
   <name>Flume checkstyle project</name>


### PR DESCRIPTION
The flume-checkstyle module doesn't currently declare a parent pom. This
will be a problem when we try to deploy our artifacts because we are
missing a distributionManagement section in the flume-checkstyle module.
The deploy will fail with an error message that looks something like:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy (default-deploy)
on project flume-checkstyle: Deployment failed: repository element was not specified in the POM inside
distributionManagement element or in -DaltDeploymentRepository=id::layout::url parameter

This patch should solve the problem.