### PR TITLE
FLUME-3023 {variable} substitution doesn't work for property 'fileSuffix'

### DIFF
--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
@@ -369,7 +369,9 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
             timeZone, needRounding, roundUnit, roundValue, useLocalTime);
         String realName = BucketPath.escapeString(fileName, event.getHeaders(),
             timeZone, needRounding, roundUnit, roundValue, useLocalTime);
-
+        String realSuffix = BucketPath.escapeString(suffix, event.getHeaders(), 
+            timeZone, needRounding, roundUnit, roundValue, useLocalTime);
+        
         String lookupPath = realPath + DIRECTORY_DELIMITER + realName;
         BucketWriter bucketWriter;
         HDFSWriter hdfsWriter = null;
@@ -390,7 +392,7 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
           // we haven't seen this file yet, so open it and cache the handle
           if (bucketWriter == null) {
             hdfsWriter = writerFactory.getWriter(fileType);
-            bucketWriter = initializeBucketWriter(realPath, realName,
+            bucketWriter = initializeBucketWriter(realPath, realName, realSuffix,
               lookupPath, hdfsWriter, closeCallback);
             sfWriters.put(lookupPath, bucketWriter);
           }
@@ -408,7 +410,7 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
           LOG.info("Bucket was closed while trying to append, " +
                    "reinitializing bucket and writing event.");
           hdfsWriter = writerFactory.getWriter(fileType);
-          bucketWriter = initializeBucketWriter(realPath, realName,
+          bucketWriter = initializeBucketWriter(realPath, realName, realSuffix,
             lookupPath, hdfsWriter, closeCallback);
           synchronized (sfWritersLock) {
             sfWriters.put(lookupPath, bucketWriter);
@@ -456,12 +458,12 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
   }
 
   private BucketWriter initializeBucketWriter(String realPath,
-      String realName, String lookupPath, HDFSWriter hdfsWriter,
+      String realName, String realSuffix, String lookupPath, HDFSWriter hdfsWriter,
       WriterCallback closeCallback) {
     BucketWriter bucketWriter = new BucketWriter(rollInterval,
         rollSize, rollCount,
         batchSize, context, realPath, realName, inUsePrefix, inUseSuffix,
-        suffix, codeC, compType, hdfsWriter, timedRollerPool,
+        realSuffix, codeC, compType, hdfsWriter, timedRollerPool,
         privExecutor, sinkCounter, idleTimeout, closeCallback,
         lookupPath, callTimeout, callTimeoutPool, retryInterval,
         tryCount);

--- a/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestBucketWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestBucketWriter.java
@@ -375,44 +375,6 @@ public class TestBucketWriter {
     Assert.assertTrue("Incorrect in use suffix", hdfsWriter.getOpenedFilePath().contains(SUFFIX));
   }
 
-  @Test
-  public void testTranslatedInUseSuffix() throws IOException, InterruptedException {
-    final int ROLL_INTERVAL = 1000; // seconds. Make sure it doesn't change in course of test
-    final String SUFFIX = "JAI_MATA_DI_%Y%m%d";
-    
-    // Need to override system time use for test so we know what to expect
-    final long testTime = System.currentTimeMillis();
-
-    Clock testClock = new Clock() {
-      public long currentTimeMillis() {
-        return testTime;
-      }
-    };
-    Clock prevClock = BucketPath.getClock();
-    
-    BucketPath.setClock(testClock);
-    
-    MockHDFSWriter hdfsWriter = new MockHDFSWriter();
-    
-
-    Event e = EventBuilder.withBody("foo", Charsets.UTF_8);
-    e.getHeaders().put("timestamp", String.valueOf(testTime));
-
-    String translatedSuffixString = BucketPath.escapeString(SUFFIX, e.getHeaders());
-    
-    BucketWriter bucketWriter = new BucketWriter(
-        ROLL_INTERVAL, 0, 0, 0, ctx, "/tmp", "file", "", translatedSuffixString, null, null,
-        SequenceFile.CompressionType.NONE, hdfsWriter, timedRollerPool, proxy,
-        new SinkCounter("test-bucket-writer-" + System.currentTimeMillis()), 0, null, null, 30000,
-        Executors.newSingleThreadExecutor(), 0, 0, testClock);
-    bucketWriter.append(e);
-    
-    BucketPath.setClock(prevClock);
-    
-    Assert.assertTrue("Incorrect translated in use suffix", 
-        hdfsWriter.getOpenedFilePath().contains(translatedSuffixString));
-    
-  }
   
   @Test
   public void testCallbackOnClose() throws IOException, InterruptedException {

--- a/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestBucketWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestBucketWriter.java
@@ -19,12 +19,14 @@
 package org.apache.flume.sink.hdfs;
 
 import com.google.common.base.Charsets;
+
 import org.apache.flume.Clock;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.auth.FlumeAuthenticationUtil;
 import org.apache.flume.auth.PrivilegedExecutor;
 import org.apache.flume.event.EventBuilder;
+import org.apache.flume.formatter.output.BucketPath;
 import org.apache.flume.instrumentation.SinkCounter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -377,19 +379,39 @@ public class TestBucketWriter {
   public void testTranslatedInUseSuffix() throws IOException, InterruptedException {
     final int ROLL_INTERVAL = 1000; // seconds. Make sure it doesn't change in course of test
     final String SUFFIX = "JAI_MATA_DI_%Y%m%d";
+    
+    // Need to override system time use for test so we know what to expect
+    final long testTime = System.currentTimeMillis();
 
+    Clock testClock = new Clock() {
+      public long currentTimeMillis() {
+        return testTime;
+      }
+    };
+    Clock prevClock = BucketPath.getClock();
+    
+    BucketPath.setClock(testClock);
+    
     MockHDFSWriter hdfsWriter = new MockHDFSWriter();
-    HDFSTextSerializer serializer = new HDFSTextSerializer();
-    BucketWriter bucketWriter = new BucketWriter(
-        ROLL_INTERVAL, 0, 0, 0, ctx, "/tmp", "file", "", SUFFIX, null, null,
-        SequenceFile.CompressionType.NONE, hdfsWriter, timedRollerPool, proxy,
-        new SinkCounter("test-bucket-writer-" + System.currentTimeMillis()), 0, null, null, 30000,
-        Executors.newSingleThreadExecutor(), 0, 0);
+    
 
     Event e = EventBuilder.withBody("foo", Charsets.UTF_8);
-    bucketWriter.append(e);
+    e.getHeaders().put("timestamp", String.valueOf(testTime));
 
-    Assert.assertTrue("Incorrect in use suffix", hdfsWriter.getOpenedFilePath().contains(SUFFIX));
+    String translatedSuffixString = BucketPath.escapeString(SUFFIX, e.getHeaders());
+    
+    BucketWriter bucketWriter = new BucketWriter(
+        ROLL_INTERVAL, 0, 0, 0, ctx, "/tmp", "file", "", translatedSuffixString, null, null,
+        SequenceFile.CompressionType.NONE, hdfsWriter, timedRollerPool, proxy,
+        new SinkCounter("test-bucket-writer-" + System.currentTimeMillis()), 0, null, null, 30000,
+        Executors.newSingleThreadExecutor(), 0, 0, testClock);
+    bucketWriter.append(e);
+    
+    BucketPath.setClock(prevClock);
+    
+    Assert.assertTrue("Incorrect translated in use suffix", 
+        hdfsWriter.getOpenedFilePath().contains(translatedSuffixString));
+    
   }
   
   @Test

--- a/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestBucketWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestBucketWriter.java
@@ -373,6 +373,25 @@ public class TestBucketWriter {
   }
 
   @Test
+  public void testTranslatedInUseSuffix() throws IOException, InterruptedException {
+    final int ROLL_INTERVAL = 1000; // seconds. Make sure it doesn't change in course of test
+    final String SUFFIX = "JAI_MATA_DI_%Y%m%d";
+
+    MockHDFSWriter hdfsWriter = new MockHDFSWriter();
+    HDFSTextSerializer serializer = new HDFSTextSerializer();
+    BucketWriter bucketWriter = new BucketWriter(
+        ROLL_INTERVAL, 0, 0, 0, ctx, "/tmp", "file", "", SUFFIX, null, null,
+        SequenceFile.CompressionType.NONE, hdfsWriter, timedRollerPool, proxy,
+        new SinkCounter("test-bucket-writer-" + System.currentTimeMillis()), 0, null, null, 30000,
+        Executors.newSingleThreadExecutor(), 0, 0);
+
+    Event e = EventBuilder.withBody("foo", Charsets.UTF_8);
+    bucketWriter.append(e);
+
+    Assert.assertTrue("Incorrect in use suffix", hdfsWriter.getOpenedFilePath().contains(SUFFIX));
+  }
+  
+  @Test
   public void testCallbackOnClose() throws IOException, InterruptedException {
     final int ROLL_INTERVAL = 1000; // seconds. Make sure it doesn't change in course of test
     final String SUFFIX = "WELCOME_TO_THE_EREBOR";


### PR DESCRIPTION
Escaped the suffix before passing it to bucket writer. 