### PR TITLE
"[FLUME-3067][Shell]Defalut JAVA_OPTS "-Xmx20m" may be conflicted with cuctom defines."

### DIFF
--- a/bin/flume-ng
+++ b/bin/flume-ng
@@ -227,7 +227,7 @@ run_flume() {
 FLUME_CLASSPATH=""
 FLUME_JAVA_LIBRARY_PATH=""
 JAVA_OPTS=""
-JAVA_HEAP_MAX ="-Xmx20m"
+JAVA_HEAP_MAX="-Xmx20m"
 LD_LIBRARY_PATH=""
 
 opt_conf=""

--- a/bin/flume-ng
+++ b/bin/flume-ng
@@ -212,7 +212,7 @@ run_flume() {
     set -x
   fi
   
-  if [[ $FLUME_JAVA_OPTS =~ "Xmx" ]] || [[ $JAVA_OPTS =~ "Xmx" ]]; then
+  if [[ $FLUME_JAVA_OPTS =~ Xmx[0-9]+ ]] || [[ $JAVA_OPTS =~ Xmx[0-9]+ ]]; then
     unset JAVA_HEAP_MAX 
   fi
   $EXEC $JAVA_HOME/bin/java $JAVA_HEAP_MAX $JAVA_OPTS $FLUME_JAVA_OPTS "${arr_java_props[@]}" -cp "$FLUME_CLASSPATH" \

--- a/bin/flume-ng
+++ b/bin/flume-ng
@@ -212,10 +212,10 @@ run_flume() {
     set -x
   fi
   
-  if [[ $FLUME_JAVA_OPTS =~ "Xmx" ]]; then
-    unset JAVA_OPTS
+  if [[ $FLUME_JAVA_OPTS =~ "Xmx" ]] || [[ $JAVA_OPTS =~ "Xmx" ]]; then
+    unset JAVA_HEAP_MAX 
   fi
-  $EXEC $JAVA_HOME/bin/java $JAVA_OPTS $FLUME_JAVA_OPTS "${arr_java_props[@]}" -cp "$FLUME_CLASSPATH" \
+  $EXEC $JAVA_HOME/bin/java $JAVA_HEAP_MAX $JAVA_OPTS $FLUME_JAVA_OPTS "${arr_java_props[@]}" -cp "$FLUME_CLASSPATH" \
       -Djava.library.path=$FLUME_JAVA_LIBRARY_PATH "$FLUME_APPLICATION_CLASS" $*
 }
 
@@ -226,7 +226,8 @@ run_flume() {
 # set default params
 FLUME_CLASSPATH=""
 FLUME_JAVA_LIBRARY_PATH=""
-JAVA_OPTS="-Xmx20m"
+JAVA_OPTS=""
+JAVA_HEAP_MAX ="-Xmx20m"
 LD_LIBRARY_PATH=""
 
 opt_conf=""

--- a/bin/flume-ng
+++ b/bin/flume-ng
@@ -211,6 +211,10 @@ run_flume() {
   if [ ${CLEAN_FLAG} -ne 0 ]; then
     set -x
   fi
+  
+  if [[ $FLUME_JAVA_OPTS =~ "Xmx" ]]; then
+    unset JAVA_OPTS
+  fi
   $EXEC $JAVA_HOME/bin/java $JAVA_OPTS $FLUME_JAVA_OPTS "${arr_java_props[@]}" -cp "$FLUME_CLASSPATH" \
       -Djava.library.path=$FLUME_JAVA_LIBRARY_PATH "$FLUME_APPLICATION_CLASS" $*
 }


### PR DESCRIPTION
When write a Flume bootstrap shell, set the environment variable FLUME_JAVA_OPTS with the defined values as the min(-Xms) 
and max(-Xmx) heap size for the JVM, then call "bin/flime-ng" to start Flume. 
Succeed to start, but the defalut "-Xmx20m" is still in process JVM options.