### PR TITLE
"idleFuture" should reset to "null" after idle bucket closed

### DIFF
--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
@@ -440,6 +440,7 @@ class BucketWriter {
               if (isOpen) {
                 close(true);
               }
+              idleFuture = null;
               return null;
             }
           };


### PR DESCRIPTION
If we use "idleTimeout" to roll file, once the flush() method called, it will start a delayed thread to close the idle bucketWriter. The delayed thread will call close() method to check whether the "idleFuture" is done, and close opened file. If the "idleFuture" is running when checking, the idleFuture.isDone() method will return false, and the idleFuture won't be set to "null". When the bucketWriter calls flush() on the next time, the "idleFuture" is not "null" and idleFutrue.cancel(false) method returns false due to the "idleFuture" has completed in the last call. So new thread won't be created to close current idle bucketWriter and keeps current file openning.