### PR TITLE
Doc fix: Size of files created by HDFS Sink won't necessarily match the configured rollSize value

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -2000,7 +2000,9 @@ hdfs.inUsePrefix        --            Prefix that is used for temporal files tha
 hdfs.inUseSuffix        ``.tmp``      Suffix that is used for temporal files that flume actively writes into
 hdfs.rollInterval       30            Number of seconds to wait before rolling current file
                                       (0 = never roll based on time interval)
-hdfs.rollSize           1024          File size to trigger roll, in bytes (0: never roll based on file size)
+hdfs.rollSize           1024          Cummulated event size to trigger file roll, in bytes (0: never roll based on size).
+                                      The size is calculated by summing the size of the incoming events' bodies (excluding headers) which might not match the size of the resulting files,
+                                      especially if compression or any other postprocessing is used.
 hdfs.rollCount          10            Number of events written to file before it rolled
                                       (0 = never roll based on number of events)
 hdfs.idleTimeout        0             Timeout after which inactive files get closed


### PR DESCRIPTION
Updated the description of the HDFS Sink's `hdfs.rollSize` property to reflect the actual behaviour: it keeps track of the size of the incoming events' body thus the size of the created files won't necessarily match the configured value.