### PR TITLE
FLUME-3072 Add IP address to headers in flume log4j appender

### DIFF
--- a/flume-ng-clients/flume-ng-log4jappender/src/main/java/org/apache/flume/clients/log4jappender/LoadBalancingLog4jAppender.java
+++ b/flume-ng-clients/flume-ng-log4jappender/src/main/java/org/apache/flume/clients/log4jappender/LoadBalancingLog4jAppender.java
@@ -135,7 +135,7 @@ public class LoadBalancingLog4jAppender extends Log4jAppender {
       }
       throw new FlumeException(e);
     }
-
+    initializeClientAddress();
   }
 
   private Properties getProperties(String hosts, String selector,

--- a/flume-ng-clients/flume-ng-log4jappender/src/main/java/org/apache/flume/clients/log4jappender/Log4jAppender.java
+++ b/flume-ng-clients/flume-ng-log4jappender/src/main/java/org/apache/flume/clients/log4jappender/Log4jAppender.java
@@ -20,6 +20,8 @@ package org.apache.flume.clients.log4jappender;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
@@ -78,6 +80,7 @@ public class Log4jAppender extends AppenderSkeleton {
   private long timeout = RpcClientConfigurationConstants.DEFAULT_REQUEST_TIMEOUT_MILLIS;
   private boolean avroReflectionEnabled;
   private String avroSchemaUrl;
+  private String clientAddress;
 
   RpcClient rpcClient = null;
 
@@ -135,7 +138,7 @@ public class Log4jAppender extends AppenderSkeleton {
     hdrs.put(Log4jAvroHeaders.LOGGER_NAME.toString(), event.getLoggerName());
     hdrs.put(Log4jAvroHeaders.TIMESTAMP.toString(),
         String.valueOf(event.timeStamp));
-
+    hdrs.put(Log4jAvroHeaders.ADDRESS.toString(), clientAddress);
     //To get the level back simply use
     //LoggerEvent.toLevel(hdrs.get(Integer.parseInt(
     //Log4jAvroHeaders.LOG_LEVEL.toString()))
@@ -315,6 +318,24 @@ public class Log4jAppender extends AppenderSkeleton {
         return;
       }
       throw e;
+    }
+    initializeClientAddress();
+  }
+
+  /**
+   * Resolves local host address so it can be included in event headers.
+   * @throws FlumeException if local host address can not be resolved.
+   */
+  protected void initializeClientAddress() throws FlumeException {
+    try {
+      clientAddress = InetAddress.getLocalHost().getHostAddress();
+    } catch (UnknownHostException e) {
+      String errormsg = "Failed to resolve local host address! " + e.getMessage();
+      LogLog.error(errormsg);
+      if (unsafeMode) {
+        return;
+      }
+      throw new FlumeException(e);
     }
   }
 

--- a/flume-ng-clients/flume-ng-log4jappender/src/main/java/org/apache/flume/clients/log4jappender/Log4jAppender.java
+++ b/flume-ng-clients/flume-ng-log4jappender/src/main/java/org/apache/flume/clients/log4jappender/Log4jAppender.java
@@ -80,7 +80,7 @@ public class Log4jAppender extends AppenderSkeleton {
   private long timeout = RpcClientConfigurationConstants.DEFAULT_REQUEST_TIMEOUT_MILLIS;
   private boolean avroReflectionEnabled;
   private String avroSchemaUrl;
-  private String clientAddress;
+  private String clientAddress = "";
 
   RpcClient rpcClient = null;
 

--- a/flume-ng-clients/flume-ng-log4jappender/src/main/java/org/apache/flume/clients/log4jappender/Log4jAvroHeaders.java
+++ b/flume-ng-clients/flume-ng-log4jappender/src/main/java/org/apache/flume/clients/log4jappender/Log4jAvroHeaders.java
@@ -25,6 +25,7 @@ public enum Log4jAvroHeaders {
   LOGGER_NAME("flume.client.log4j.logger.name"),
   LOG_LEVEL("flume.client.log4j.log.level"),
   MESSAGE_ENCODING("flume.client.log4j.message.encoding"),
+  ADDRESS("flume.client.log4j.address"),
   TIMESTAMP("flume.client.log4j.timestamp"),
   AVRO_SCHEMA_LITERAL("flume.avro.schema.literal"),
   AVRO_SCHEMA_URL("flume.avro.schema.url");

--- a/flume-ng-clients/flume-ng-log4jappender/src/test/java/org/apache/flume/clients/log4jappender/TestLoadBalancingLog4jAppender.java
+++ b/flume-ng-clients/flume-ng-log4jappender/src/test/java/org/apache/flume/clients/log4jappender/TestLoadBalancingLog4jAppender.java
@@ -254,6 +254,8 @@ public class TestLoadBalancingLog4jAppender {
 
       Assert.assertNotNull(hdrs.get(Log4jAvroHeaders.TIMESTAMP.toString()));
 
+      Assert.assertNotNull(hdrs.get(Log4jAvroHeaders.ADDRESS.toString()));
+
       Assert.assertEquals(Level.toLevel(level),
           Level.toLevel(hdrs.get(Log4jAvroHeaders.LOG_LEVEL.toString())));
 

--- a/flume-ng-clients/flume-ng-log4jappender/src/test/java/org/apache/flume/clients/log4jappender/TestLog4jAppender.java
+++ b/flume-ng-clients/flume-ng-log4jappender/src/test/java/org/apache/flume/clients/log4jappender/TestLog4jAppender.java
@@ -115,6 +115,7 @@ public class TestLog4jAppender {
           Level.toLevel(Integer.valueOf(hdrs.get(Log4jAvroHeaders.LOG_LEVEL
               .toString()))
           ));
+      Assert.assertNotNull(hdrs.get(Log4jAvroHeaders.ADDRESS.toString()));
 
       Assert.assertEquals(logger.getName(),
           hdrs.get(Log4jAvroHeaders.LOGGER_NAME.toString()));


### PR DESCRIPTION
Log4jAppender and LoadBalancingLog4jAppender resolve local hosts address at startup.
The hostname is added to each event's header with the key "flume.client.log4j.address".