### PR TITLE
Added support for Filter Queries read from config file

### DIFF
--- a/flume-ng-sources/flume-twitter-source/src/main/java/org/apache/flume/source/twitter/TwitterSource.java
+++ b/flume-ng-sources/flume-twitter-source/src/main/java/org/apache/flume/source/twitter/TwitterSource.java
@@ -54,6 +54,8 @@ import twitter4j.TwitterStream;
 import twitter4j.TwitterStreamFactory;
 import twitter4j.User;
 import twitter4j.auth.AccessToken;
+import twitter4j.FilterQuery;
+
 
 /**
  * Demo Flume source that connects via Streaming API to the 1% sample twitter
@@ -72,7 +74,8 @@ public class TwitterSource
 
   private TwitterStream twitterStream;
   private Schema avroSchema;
-
+  private String[] filterKeywords = new String[0];
+  
   private long docCount = 0;
   private long startTime = 0;
   private long exceptionCount = 0;
@@ -106,12 +109,21 @@ public class TwitterSource
     String consumerSecret = context.getString("consumerSecret");
     String accessToken = context.getString("accessToken");
     String accessTokenSecret = context.getString("accessTokenSecret");
-
+    String keywordsString = context.getString("keywords");
+    LOGGER.info("Provided Keywords: " + keywordsString);
+    if (keywordsString != null && !keywordsString.equals("")) {
+      filterKeywords = keywordsString.split(",");
+    }
+    
+    
     twitterStream = new TwitterStreamFactory().getInstance();
     twitterStream.setOAuthConsumer(consumerKey, consumerSecret);
     twitterStream.setOAuthAccessToken(new AccessToken(accessToken,
                                                       accessTokenSecret));
     twitterStream.addListener(this);
+
+   
+    
     avroSchema = createAvroSchema();
     dataFileWriter = new DataFileWriter<GenericRecord>(
         new GenericDatumWriter<GenericRecord>(avroSchema));
@@ -130,7 +142,17 @@ public class TwitterSource
     totalTextIndexed = 0;
     skippedDocs = 0;
     batchEndTime = System.currentTimeMillis() + maxBatchDurationMillis;
-    twitterStream.sample();
+    
+   
+    if (filterKeywords != null && filterKeywords.length > 0) {
+      FilterQuery fq = new FilterQuery();
+      fq.track(filterKeywords);
+      twitterStream.filter(fq);
+    } else {
+      twitterStream.sample();
+    }
+    
+    
     LOGGER.info("Twitter source {} started.", getName());
     // This should happen at the end of the start method, since this will 
     // change the lifecycle status of the component to tell the Flume 


### PR DESCRIPTION
Added support for optional property in config file for Twitter Source. E.g. if keywords property is provided:
...
a1.sources.r1.type = org.apache.flume.source.twitter.TwitterSource
a1.sources.r1.keywords = word1,word2,word3
...

Otherwise, existing functionality of twitterStream.sample() is invoked.