### PR TITLE
bugfix: when loglevel is debug, Kafka Sink will throw NPE because of …

### DIFF
--- a/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
+++ b/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
@@ -756,8 +756,10 @@ class ChannelCallback implements Callback {
     }
     if (log.isDebugEnabled()) {
       long batchElapsedTime = System.currentTimeMillis() - startTime;
-      log.debug("Acked message_no " + index + ": " + metadata.topic() + "-" +
+      if (metadata != null) {
+        log.debug("Acked message_no " + index + ": " + metadata.topic() + "-" +
                 metadata.partition() + "-" + metadata.offset() + "-" + batchElapsedTime);
+      }
     }
   }
 }

--- a/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
@@ -453,7 +453,10 @@ class SinkCallback implements Callback {
 
     if (logger.isDebugEnabled()) {
       long eventElapsedTime = System.currentTimeMillis() - startTime;
-      logger.debug("Acked message partition:{} ofset:{}",  metadata.partition(), metadata.offset());
+      if (metadata != null) {
+        logger.debug("Acked message partition:{} ofset:{}", metadata.partition(),
+                metadata.offset());
+      }
       logger.debug("Elapsed time for send: {}", eventElapsedTime);
     }
   }

--- a/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
@@ -453,7 +453,9 @@ class SinkCallback implements Callback {
 
     if (logger.isDebugEnabled()) {
       long eventElapsedTime = System.currentTimeMillis() - startTime;
-      logger.debug("Acked message partition:{} ofset:{}",  metadata.partition(), metadata.offset());
+      if (metadata != null) {
+        logger.debug("Acked message partition:{} ofset:{}", metadata.partition(), metadata.offset());
+      }
       logger.debug("Elapsed time for send: {}", eventElapsedTime);
     }
   }


### PR DESCRIPTION
When we send a event with SinkCallback to kafka under DEBUG level of log4j, if kafka reponses a result with exception but not a RecordMetadata. Kafka Sink will throw NPE.
code in SinkCallback:
if (logger.isDebugEnabled()) {
  long eventElapsedTime = System.currentTimeMillis() - startTime;
  logger.debug("Acked message partition:{} ofset:{}",  metadata.partition(), metadata.offset());
  logger.debug("Elapsed time for send: {}", eventElapsedTime);
}
code in Kafka Producer:
if (exception == null) { 
  RecordMetadata metadata = new RecordMetadata(...);
  thunk.callback.onCompletion(metadata, null);
} else {
  thunk.callback.onCompletion(null, exception);
}

I've already created this issue on jira.
https://issues.apache.org/jira/browse/FLUME-3043?jql=project%20%3D%20FLUME