### PR TITLE
FLUME-3083. Check byte position of file in update condition of Taildir Source

### DIFF
--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
@@ -248,7 +248,7 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
           long startPos = skipToEnd ? f.length() : 0;
           tf = openFile(f, headers, inode, startPos);
         } else {
-          boolean updated = tf.getLastUpdated() < f.lastModified();
+          boolean updated = tf.getLastUpdated() < f.lastModified() || tf.getPos() != f.length();
           if (updated) {
             if (tf.getRaf() == null) {
               tf = openFile(f, headers, inode, tf.getPos());


### PR DESCRIPTION
This is to resolve an edge case where events can be missed during tail file close. More details are provided at https://issues.apache.org/jira/browse/FLUME-3083.