### PR TITLE
FLUME-3085: HDFS Sink can skip flushing some BucketWriters, might lead to data loss

### DIFF
--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
@@ -22,8 +22,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
@@ -40,7 +42,6 @@ import org.apache.flume.EventDeliveryException;
 import org.apache.flume.SystemClock;
 import org.apache.flume.Transaction;
 import org.apache.flume.auth.FlumeAuthenticationUtil;
-import org.apache.flume.auth.FlumeAuthenticator;
 import org.apache.flume.auth.PrivilegedExecutor;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.formatter.output.BucketPath;
@@ -55,7 +56,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 public class HDFSEventSink extends AbstractSink implements Configurable {
@@ -354,9 +354,9 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
   public Status process() throws EventDeliveryException {
     Channel channel = getChannel();
     Transaction transaction = channel.getTransaction();
-    List<BucketWriter> writers = Lists.newArrayList();
     transaction.begin();
     try {
+      Set<BucketWriter> writers = new LinkedHashSet<>();
       int txnEventCount = 0;
       for (txnEventCount = 0; txnEventCount < batchSize; txnEventCount++) {
         Event event = channel.take();
@@ -396,11 +396,6 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
           }
         }
 
-        // track the buckets getting written in this transaction
-        if (!writers.contains(bucketWriter)) {
-          writers.add(bucketWriter);
-        }
-
         // Write the data to HDFS
         try {
           bucketWriter.append(event);
@@ -415,6 +410,9 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
           }
           bucketWriter.append(event);
         }
+
+        // track the buckets getting written in this transaction
+        writers.add(bucketWriter);
       }
 
       if (txnEventCount == 0) {
@@ -455,7 +453,8 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
     }
   }
 
-  private BucketWriter initializeBucketWriter(String realPath,
+  @VisibleForTesting
+  BucketWriter initializeBucketWriter(String realPath,
       String realName, String lookupPath, HDFSWriter hdfsWriter,
       WriterCallback closeCallback) {
     BucketWriter bucketWriter = new BucketWriter(rollInterval,

--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
@@ -412,7 +412,9 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
         }
 
         // track the buckets getting written in this transaction
-        writers.add(bucketWriter);
+        if (!writers.contains(bucketWriter)) {
+          writers.add(bucketWriter);
+        }
       }
 
       if (txnEventCount == 0) {

--- a/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSink.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericData;
@@ -67,6 +68,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1544,5 +1548,62 @@ public class TestHDFSEventSink {
     sink.stop();
     Assert.assertEquals(6, totalRenameAttempts);
 
+  }
+
+  /**
+   * BucketWriter.append() can throw a BucketClosedException when called from
+   * HDFSEventSink.process() due to a race condition between HDFSEventSink.process() and the
+   * BucketWriter's close threads.
+   * This test case tests whether if this happens the newly created BucketWriter will be flushed.
+   * For more details see FLUME-3085
+   */
+  @Test
+  public void testFlushedIfAppendFailedWithBucketClosedException() throws Exception {
+    sink = new HDFSEventSink() {
+      @Override
+      BucketWriter initializeBucketWriter(String realPath, String realName, String lookupPath,
+                                          HDFSWriter hdfsWriter, WriterCallback closeCallback) {
+        BucketWriter bw = Mockito.spy(super.initializeBucketWriter(realPath, realName, lookupPath,
+            hdfsWriter, closeCallback));
+        try {
+          // create mock BucketWriters where the first append() succeeds but the
+          // the second call throws a BucketClosedException
+          Mockito.doCallRealMethod()
+              .doThrow(BucketClosedException.class)
+              .when(bw).append(Mockito.any(Event.class));
+        } catch (IOException | InterruptedException e) {
+          Assert.fail("This shouldn't happen, as append() is called during mocking.");
+        }
+        return bw;
+      }
+    };
+
+    Context context = new Context(ImmutableMap.of("hdfs.path", testPath));
+    Configurables.configure(sink, context);
+
+    MemoryChannel channel = new MemoryChannel();
+    Configurables.configure(channel, new Context());
+
+    sink.setChannel(channel);
+    sink.start();
+
+    Transaction txn = channel.getTransaction();
+    txn.begin();
+    channel.put(EventBuilder.withBody("test".getBytes()));
+    channel.put(EventBuilder.withBody("test".getBytes()));
+    txn.commit();
+    txn.close();
+
+    sink.process();
+
+    // After processing the events the only BucketWriter in the sfWriters map is
+    // the one which was created after the first one threw the BucketClosedException.
+    // It is expected that its flush() method was called exactly once.
+    Map<String, BucketWriter> bucketWriterMap = sink.getSfWriters();
+    Assert.assertEquals(1, bucketWriterMap.size());
+    BucketWriter bw = bucketWriterMap.values().iterator().next();
+    Mockito.verify(bw, Mockito.times(1)).flush();
+
+    sink.stop();
   }
 }


### PR DESCRIPTION
This commit fixes the issue when in `HDFSEventSink.process()` a `BucketWriter.append()` call threw a `BucketClosedException` then the newly created `BucketWriter` wasn't flushed after the processing loop.