### PR TITLE
FLUME-3092. Extend the FileChannel's monitoring metrics

### DIFF
--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
@@ -39,7 +39,6 @@ import org.apache.flume.channel.file.Log.Builder;
 import org.apache.flume.channel.file.encryption.EncryptionConfiguration;
 import org.apache.flume.channel.file.encryption.KeyProvider;
 import org.apache.flume.channel.file.encryption.KeyProviderFactory;
-import org.apache.flume.instrumentation.ChannelCounter;
 import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -270,6 +269,7 @@ public class FileChannel extends BasicChannelSemantics {
     if (channelCounter == null) {
       channelCounter = new FileChannelCounter(getName());
     }
+    channelCounter.setUnhealthy(false);
   }
 
   @Override
@@ -277,25 +277,7 @@ public class FileChannel extends BasicChannelSemantics {
     LOG.info("Starting {}...", this);
     channelCounter.start();
     try {
-      Builder builder = new Log.Builder();
-      builder.setCheckpointInterval(checkpointInterval);
-      builder.setMaxFileSize(maxFileSize);
-      builder.setMinimumRequiredSpace(minimumRequiredSpace);
-      builder.setQueueSize(capacity);
-      builder.setCheckpointDir(checkpointDir);
-      builder.setLogDirs(dataDirs);
-      builder.setChannelName(getName());
-      builder.setUseLogReplayV1(useLogReplayV1);
-      builder.setUseFastReplay(useFastReplay);
-      builder.setEncryptionKeyProvider(encryptionKeyProvider);
-      builder.setEncryptionKeyAlias(encryptionActiveKey);
-      builder.setEncryptionCipherProvider(encryptionCipherProvider);
-      builder.setUseDualCheckpoints(useDualCheckpoints);
-      builder.setCompressBackupCheckpoint(compressBackupCheckpoint);
-      builder.setBackupCheckpointDir(backupCheckpointDir);
-      builder.setFsyncPerTransaction(fsyncPerTransaction);
-      builder.setFsyncInterval(fsyncInterval);
-      builder.setCheckpointOnClose(checkpointOnClose);
+      Builder builder = createLogBuilder();
       log = builder.build();
       log.replay();
       setOpen(true);
@@ -307,6 +289,7 @@ public class FileChannel extends BasicChannelSemantics {
           + channelNameDescriptor);
     } catch (Throwable t) {
       setOpen(false);
+      channelCounter.setUnhealthy(true);
       startupError = t;
       LOG.error("Failed to start the file channel " + channelNameDescriptor, t);
       if (t instanceof Error) {
@@ -318,6 +301,31 @@ public class FileChannel extends BasicChannelSemantics {
       channelCounter.setChannelCapacity(capacity);
     }
     super.start();
+  }
+
+  @VisibleForTesting
+  Builder createLogBuilder() {
+    Builder builder = new Log.Builder();
+    builder.setCheckpointInterval(checkpointInterval);
+    builder.setMaxFileSize(maxFileSize);
+    builder.setMinimumRequiredSpace(minimumRequiredSpace);
+    builder.setQueueSize(capacity);
+    builder.setCheckpointDir(checkpointDir);
+    builder.setLogDirs(dataDirs);
+    builder.setChannelName(getName());
+    builder.setUseLogReplayV1(useLogReplayV1);
+    builder.setUseFastReplay(useFastReplay);
+    builder.setEncryptionKeyProvider(encryptionKeyProvider);
+    builder.setEncryptionKeyAlias(encryptionActiveKey);
+    builder.setEncryptionCipherProvider(encryptionCipherProvider);
+    builder.setUseDualCheckpoints(useDualCheckpoints);
+    builder.setCompressBackupCheckpoint(compressBackupCheckpoint);
+    builder.setBackupCheckpointDir(backupCheckpointDir);
+    builder.setFsyncPerTransaction(fsyncPerTransaction);
+    builder.setFsyncInterval(fsyncInterval);
+    builder.setCheckpointOnClose(checkpointOnClose);
+    builder.setChannelCounter(channelCounter);
+    return builder;
   }
 
   @Override
@@ -449,12 +457,12 @@ public class FileChannel extends BasicChannelSemantics {
     private final FlumeEventQueue queue;
     private final Semaphore queueRemaining;
     private final String channelNameDescriptor;
-    private final ChannelCounter channelCounter;
+    private final FileChannelCounter channelCounter;
     private final boolean fsyncPerTransaction;
 
     public FileBackedTransaction(Log log, long transactionID,
                                  int transCapacity, int keepAlive, Semaphore queueRemaining,
-                                 String name, boolean fsyncPerTransaction, ChannelCounter
+                                 String name, boolean fsyncPerTransaction, FileChannelCounter
                                      counter) {
       this.log = log;
       queue = log.getFlumeEventQueue();
@@ -503,6 +511,7 @@ public class FileChannel extends BasicChannelSemantics {
         queue.addWithoutCommit(ptr, transactionID);
         success = true;
       } catch (IOException e) {
+        channelCounter.incrementEventPutErrorCount();
         throw new ChannelException("Put failed due to IO error "
             + channelNameDescriptor, e);
       } finally {
@@ -549,6 +558,7 @@ public class FileChannel extends BasicChannelSemantics {
               Event event = log.get(ptr);
               return event;
             } catch (IOException e) {
+              channelCounter.incrementEventTakeErrorCount();
               throw new ChannelException("Take failed due to IO error "
                   + channelNameDescriptor, e);
             } catch (NoopRecordException e) {
@@ -556,6 +566,7 @@ public class FileChannel extends BasicChannelSemantics {
                   "tool found. Will retrieve next event", e);
               takeList.remove(ptr);
             } catch (CorruptEventException ex) {
+              channelCounter.incrementEventTakeErrorCount();
               if (fsyncPerTransaction) {
                 throw new ChannelException(ex);
               }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
@@ -269,7 +269,7 @@ public class FileChannel extends BasicChannelSemantics {
     if (channelCounter == null) {
       channelCounter = new FileChannelCounter(getName());
     }
-    channelCounter.setUnhealthy(false);
+    channelCounter.setUnhealthy(0);
   }
 
   @Override
@@ -289,7 +289,7 @@ public class FileChannel extends BasicChannelSemantics {
           + channelNameDescriptor);
     } catch (Throwable t) {
       setOpen(false);
-      channelCounter.setUnhealthy(true);
+      channelCounter.setUnhealthy(1);
       startupError = t;
       LOG.error("Failed to start the file channel " + channelNameDescriptor, t);
       if (t instanceof Error) {

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
@@ -23,9 +23,15 @@ import org.apache.flume.instrumentation.ChannelCounter;
 public class FileChannelCounter extends ChannelCounter implements FileChannelCounterMBean {
 
   private boolean open;
+  private boolean unhealthy;
+
+  private static final String EVENT_PUT_ERROR_COUNT = "channel.file.event.put.error";
+  private static final String EVENT_TAKE_ERROR_COUNT = "channel.file.event.take.error";
+  private static final String CHECKPOINT_WRITE_ERROR_COUNT = "channel.file.checkpoint.write.error";
 
   public FileChannelCounter(String name) {
-    super(name);
+    super(name, new String[] {
+        EVENT_PUT_ERROR_COUNT, EVENT_TAKE_ERROR_COUNT, CHECKPOINT_WRITE_ERROR_COUNT });
   }
 
   @Override
@@ -35,5 +41,46 @@ public class FileChannelCounter extends ChannelCounter implements FileChannelCou
 
   public void setOpen(boolean open) {
     this.open = open;
+  }
+
+  @Override
+  public int getClosed() {
+    return open ? 0 : 1;
+  }
+
+  @Override
+  public int getUnhealthy() {
+    return unhealthy ? 1 : 0;
+  }
+
+  public void setUnhealthy(boolean unhealthy) {
+    this.unhealthy = unhealthy;
+  }
+
+  @Override
+  public long getEventPutErrorCount() {
+    return get(EVENT_PUT_ERROR_COUNT);
+  }
+
+  public void incrementEventPutErrorCount() {
+    increment(EVENT_PUT_ERROR_COUNT);
+  }
+
+  @Override
+  public long getEventTakeErrorCount() {
+    return get(EVENT_TAKE_ERROR_COUNT);
+  }
+
+  public void incrementEventTakeErrorCount() {
+    increment(EVENT_TAKE_ERROR_COUNT);
+  }
+
+  @Override
+  public long getCheckpointWriteErrorCount() {
+    return get(CHECKPOINT_WRITE_ERROR_COUNT);
+  }
+
+  public void incrementCheckpointWriteErrorCount() {
+    increment(CHECKPOINT_WRITE_ERROR_COUNT);
   }
 }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounter.java
@@ -23,7 +23,7 @@ import org.apache.flume.instrumentation.ChannelCounter;
 public class FileChannelCounter extends ChannelCounter implements FileChannelCounterMBean {
 
   private boolean open;
-  private boolean unhealthy;
+  private int unhealthy;
 
   private static final String EVENT_PUT_ERROR_COUNT = "channel.file.event.put.error";
   private static final String EVENT_TAKE_ERROR_COUNT = "channel.file.event.take.error";
@@ -50,10 +50,10 @@ public class FileChannelCounter extends ChannelCounter implements FileChannelCou
 
   @Override
   public int getUnhealthy() {
-    return unhealthy ? 1 : 0;
+    return unhealthy;
   }
 
-  public void setUnhealthy(boolean unhealthy) {
+  public void setUnhealthy(int unhealthy) {
     this.unhealthy = unhealthy;
   }
 

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounterMBean.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounterMBean.java
@@ -23,4 +23,14 @@ import org.apache.flume.instrumentation.ChannelCounterMBean;
 public interface FileChannelCounterMBean extends ChannelCounterMBean {
 
   boolean isOpen();
+
+  int getClosed();
+
+  int getUnhealthy();
+
+  long getEventPutErrorCount();
+
+  long getEventTakeErrorCount();
+
+  long getCheckpointWriteErrorCount();
 }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounterMBean.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/instrumentation/FileChannelCounterMBean.java
@@ -18,19 +18,48 @@
  */
 package org.apache.flume.channel.file.instrumentation;
 
+import org.apache.flume.Event;
 import org.apache.flume.instrumentation.ChannelCounterMBean;
 
 public interface FileChannelCounterMBean extends ChannelCounterMBean {
 
   boolean isOpen();
 
+  /**
+   * The numeric representation (0/1) of the negated value of the open flag.
+   */
   int getClosed();
 
+  /**
+   * A value of 0 represents that the channel is in a healthy state: it is either starting
+   * up (i.e. the replay is running) or already started up successfully.
+   * A value of 1 represents that the channel is in a permanently failed state, which means that
+   * the startup was unsuccessful due to an exception during the replay.
+   * Once the channel started up successfully the *ErrorCount (or the ratio of the *AttemptCount
+   * and *SuccessCount) counters should be used to check whether it is functioning properly.
+   *
+   * Note: this flag doesn't report the channel as unhealthy if the configuration failed because the
+   * ChannelCounter might not have been instantiated/started yet.
+   */
   int getUnhealthy();
 
+  /**
+   * A count of the number of IOExceptions encountered while trying to put() onto the channel.
+   * @see org.apache.flume.channel.file.FileChannel.FileBackedTransaction#doPut(Event)
+   */
   long getEventPutErrorCount();
 
+  /**
+   * A count of the number of errors encountered while trying to take() from the channel,
+   * including IOExceptions and corruption-related errors.
+   * @see org.apache.flume.channel.file.FileChannel.FileBackedTransaction#doTake()
+   */
   long getEventTakeErrorCount();
 
+  /**
+   * A count of the number of errors encountered while trying to write the checkpoints. This
+   * includes any Throwables.
+   * @see org.apache.flume.channel.file.Log.BackgroundWorker#run()
+   */
   long getCheckpointWriteErrorCount();
 }

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelBase.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelBase.java
@@ -32,6 +32,7 @@ import com.google.common.io.Files;
 
 public class TestFileChannelBase {
 
+  private final int dataDirCount;
   protected FileChannel channel;
   protected File baseDir;
   protected File checkpointDir;
@@ -40,6 +41,14 @@ public class TestFileChannelBase {
   protected File backupDir;
   protected File uncompressedBackupCheckpoint;
   protected File compressedBackupCheckpoint;
+
+  public TestFileChannelBase() {
+    this(3);
+  }
+
+  public TestFileChannelBase(int dataDirCount) {
+    this.dataDirCount = dataDirCount;
+  }
 
   @Before
   public void setup() throws Exception {
@@ -51,7 +60,7 @@ public class TestFileChannelBase {
       "checkpoint.snappy");
     Assert.assertTrue(checkpointDir.mkdirs() || checkpointDir.isDirectory());
     Assert.assertTrue(backupDir.mkdirs() || backupDir.isDirectory());
-    dataDirs = new File[3];
+    dataDirs = new File[dataDirCount];
     dataDir = "";
     for (int i = 0; i < dataDirs.length; i++) {
       dataDirs[i] = new File(baseDir, "data" + (i + 1));

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelBase.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelBase.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
 import org.apache.flume.Context;
 import org.junit.After;
@@ -43,10 +44,11 @@ public class TestFileChannelBase {
   protected File compressedBackupCheckpoint;
 
   public TestFileChannelBase() {
-    this(3);
+    this(3); // By default the tests run with multiple data directories
   }
 
   public TestFileChannelBase(int dataDirCount) {
+    Preconditions.checkArgument(dataDirCount > 0, "Invalid dataDirCount");
     this.dataDirCount = dataDirCount;
   }
 

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelErrorMetrics.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelErrorMetrics.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.channel.file;
+
+import junit.framework.Assert;
+import org.apache.commons.io.FileUtils;
+import org.apache.flume.ChannelException;
+import org.apache.flume.Transaction;
+import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
+import org.apache.flume.event.EventBuilder;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+
+public class TestFileChannelErrorMetrics extends TestFileChannelBase {
+
+  public TestFileChannelErrorMetrics() {
+    super(1);
+  }
+
+  /**
+   * This tests multiple successful and failed put and take operations
+   * and checks the values of the channel's counters.
+   */
+  @Test
+  public void testEventTakePutErrorCount() throws Exception {
+    final long usableSpaceRefreshInterval = 1;
+    FileChannel channel = Mockito.spy(createFileChannel());
+    Mockito.when(channel.createLogBuilder()).then(new Answer<Log.Builder>() {
+      @Override
+      public Log.Builder answer(InvocationOnMock invocation) throws Throwable {
+        Log.Builder ret = (Log.Builder) invocation.callRealMethod();
+        ret.setUsableSpaceRefreshInterval(usableSpaceRefreshInterval);
+        return ret;
+      }
+    });
+    channel.start();
+
+    FileChannelCounter channelCounter = channel.getChannelCounter();
+
+    Transaction tx = channel.getTransaction();
+    tx.begin();
+    channel.put(EventBuilder.withBody("test1".getBytes()));
+    channel.put(EventBuilder.withBody("test2".getBytes()));
+    tx.commit();
+    tx.close();
+    assertEquals(2, channelCounter.getEventPutAttemptCount());
+    assertEquals(2, channelCounter.getEventPutSuccessCount());
+    assertEquals(0, channelCounter.getEventPutErrorCount());
+
+    tx = channel.getTransaction();
+    tx.begin();
+    channel.take();
+    tx.commit();
+    tx.close();
+    assertEquals(1, channelCounter.getEventTakeAttemptCount());
+    assertEquals(1, channelCounter.getEventTakeSuccessCount());
+    assertEquals(0, channelCounter.getEventTakeErrorCount());
+
+    FileUtils.deleteDirectory(baseDir);
+    Thread.sleep(2 * usableSpaceRefreshInterval);
+
+    tx = channel.getTransaction();
+    tx.begin();
+    ChannelException putException = null;
+    try {
+      channel.put(EventBuilder.withBody("test".getBytes()));
+    } catch (ChannelException ex) {
+      putException = ex;
+    }
+    assertNotNull(putException);
+    assertTrue(putException.getCause() instanceof IOException);
+    assertEquals(3, channelCounter.getEventPutAttemptCount());
+    assertEquals(2, channelCounter.getEventPutSuccessCount());
+    assertEquals(1, channelCounter.getEventPutErrorCount());
+
+    ChannelException takeException = null;
+    try {
+      channel.take();
+    } catch (ChannelException ex) {
+      takeException = ex;
+    }
+    assertNotNull(takeException);
+    assertTrue(takeException.getCause() instanceof IOException);
+    assertEquals(2, channelCounter.getEventTakeAttemptCount());
+    assertEquals(1, channelCounter.getEventTakeSuccessCount());
+    assertEquals(1, channelCounter.getEventTakeErrorCount());
+  }
+
+  /**
+   * Test the FileChannelCounter.eventTakeErrorCount value if the data file
+   * contains an invalid record thus CorruptEventException is thrown during
+   * the take() operation.
+   * The first byte of the record (= the first byte of the file in this case)
+   * is the operation byte, changing it to an unexpected value will cause the
+   * CorruptEventException to be thrown.
+   */
+  @Test
+  public void testCorruptEventTaken() throws Exception {
+    FileChannel channel = createFileChannel(
+        Collections.singletonMap(FileChannelConfiguration.FSYNC_PER_TXN, "false"));
+    channel.start();
+
+    FileChannelCounter channelCounter = channel.getChannelCounter();
+
+    Transaction tx = channel.getTransaction();
+    tx.begin();
+    channel.put(EventBuilder.withBody("test".getBytes()));
+    tx.commit();
+    tx.close();
+
+    byte[] data = FileUtils.readFileToByteArray(new File(dataDirs[0], "log-1"));
+    data[0] = LogFile.OP_EOF; // change the first (operation) byte to unexpected value
+    FileUtils.writeByteArrayToFile(new File(dataDirs[0], "log-1"), data);
+
+    tx = channel.getTransaction();
+    tx.begin();
+
+    try {
+      channel.take();
+    } catch (Throwable t) {
+      // If fsyncPerTransaction is false then Log.get throws the CorruptEventException
+      // without wrapping it to IOException (which is the case when fsyncPerTransaciton is true)
+      // but in this case it is swallowed in FileBackedTransaction.doTake()
+      // The eventTakeErrorCount should be increased regardless of this.
+      Assert.fail("No exception should be thrown as fsyncPerTransaction is false");
+    }
+
+    assertEquals(1, channelCounter.getEventTakeAttemptCount());
+    assertEquals(0, channelCounter.getEventTakeSuccessCount());
+    assertEquals(1, channelCounter.getEventTakeErrorCount());
+  }
+
+  @Test
+  public void testCheckpointWriteErrorCount() throws Exception {
+    int checkpointInterval = 1000;
+    FileChannel channel = createFileChannel(Collections.singletonMap(
+        FileChannelConfiguration.CHECKPOINT_INTERVAL, String.valueOf(checkpointInterval)));
+    channel.start();
+
+    Transaction tx = channel.getTransaction();
+    tx.begin();
+    channel.put(EventBuilder.withBody("test".getBytes()));
+    tx.commit();
+    tx.close();
+
+    long beforeCheckpointWrite = System.currentTimeMillis();
+
+    // first checkpoint should be written successfully -> the counter should remain 0
+    Thread.sleep(checkpointInterval + 100);
+    assertEquals(0, channel.getChannelCounter().getCheckpointWriteErrorCount());
+    assertTrue(new File(checkpointDir, "checkpoint").lastModified() > beforeCheckpointWrite);
+
+    FileUtils.deleteDirectory(baseDir);
+    Thread.sleep(checkpointInterval + 100);
+
+    // the channel's directory has been deleted so the checkpoint write should have been failed
+    assertEquals(1, channel.getChannelCounter().getCheckpointWriteErrorCount());
+  }
+
+  /**
+   * Test the value of the FileChannelCounter.unhealthy flag after normal startup.
+   * It is expected to be 0
+   */
+  @Test
+  public void testHealthy() throws Exception {
+    FileChannel channel = createFileChannel();
+    assertEquals(0, channel.getChannelCounter().getUnhealthy());
+    assertEquals(1, channel.getChannelCounter().getClosed());
+    assertFalse(channel.getChannelCounter().isOpen());
+
+    channel.start();
+    assertEquals(0, channel.getChannelCounter().getUnhealthy());
+    assertEquals(0, channel.getChannelCounter().getClosed());
+    assertTrue(channel.getChannelCounter().isOpen());
+  }
+
+  /**
+   * Test the value of the FileChannelCounter.unhealthy flag after a failed startup.
+   * It is expected to be 1
+   */
+  @Test
+  public void testUnhealthy() throws Exception {
+    FileChannel channel = createFileChannel();
+    assertEquals(0, channel.getChannelCounter().getUnhealthy());
+    assertEquals(1, channel.getChannelCounter().getClosed());
+    assertFalse(channel.getChannelCounter().isOpen());
+
+    FileUtils.write(new File(dataDirs[0], "log-1"), "invalid data file content");
+
+    channel.start();
+    assertEquals(1, channel.getChannelCounter().getUnhealthy());
+    assertEquals(1, channel.getChannelCounter().getClosed());
+    assertFalse(channel.getChannelCounter().isOpen());
+  }
+}

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestLog.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestLog.java
@@ -21,6 +21,7 @@ package org.apache.flume.channel.file;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
+import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,6 +64,7 @@ public class TestLog {
                            .setLogDirs(dataDirs)
                            .setCheckpointOnClose(false)
                            .setChannelName("testlog")
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     log.replay();
   }
@@ -141,6 +143,7 @@ public class TestLog {
                            .setCheckpointDir(checkpointDir)
                            .setLogDirs(dataDirs)
                            .setChannelName("testlog")
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     log.replay();
     takeAndVerify(eventPointerIn, eventIn);
@@ -163,6 +166,7 @@ public class TestLog {
                            .setCheckpointDir(checkpointDir)
                            .setLogDirs(dataDirs)
                            .setChannelName("testlog")
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     log.replay();
     FlumeEventQueue queue = log.getFlumeEventQueue();
@@ -180,6 +184,7 @@ public class TestLog {
                            .setLogDirs(dataDirs)
                            .setChannelName("testlog")
                            .setMinimumRequiredSpace(Long.MAX_VALUE)
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     try {
       log.replay();
@@ -219,6 +224,7 @@ public class TestLog {
                            .setChannelName("testlog")
                            .setMinimumRequiredSpace(minimumRequiredSpace)
                            .setUsableSpaceRefreshInterval(1L)
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     log.replay();
     File filler = new File(checkpointDir, "filler");
@@ -259,6 +265,7 @@ public class TestLog {
                      .setCheckpointDir(checkpointDir)
                      .setLogDirs(dataDirs)
                      .setChannelName("testlog")
+                     .setChannelCounter(new FileChannelCounter("testlog"))
                      .build();
     log.replay();
     FlumeEventQueue queue = log.getFlumeEventQueue();
@@ -298,6 +305,7 @@ public class TestLog {
                      .setLogDirs(dataDirs)
                      .setChannelName("testlog")
                      .setUseLogReplayV1(useLogReplayV1)
+                     .setChannelCounter(new FileChannelCounter("testlog"))
                      .build();
     log.replay();
     takeAndVerify(eventPointerIn, eventIn);
@@ -314,6 +322,7 @@ public class TestLog {
                      .setCheckpointDir(checkpointDir)
                      .setLogDirs(dataDirs)
                      .setChannelName("testlog")
+                     .setChannelCounter(new FileChannelCounter("testlog"))
                      .build();
     log.replay();
     FlumeEventQueue queue = log.getFlumeEventQueue();
@@ -332,6 +341,7 @@ public class TestLog {
                      .setCheckpointDir(checkpointDir)
                      .setLogDirs(dataDirs)
                      .setChannelName("testlog")
+                     .setChannelCounter(new FileChannelCounter("testlog"))
                      .build();
     log.replay();
     FlumeEventQueue queue = log.getFlumeEventQueue();
@@ -350,6 +360,7 @@ public class TestLog {
                      .setCheckpointDir(checkpointDir)
                      .setLogDirs(dataDirs)
                      .setChannelName("testlog")
+                     .setChannelCounter(new FileChannelCounter("testlog"))
                      .build();
     log.replay();
     FlumeEventQueue queue = log.getFlumeEventQueue();
@@ -402,6 +413,7 @@ public class TestLog {
                            .setLogDirs(dataDirs)
                            .setChannelName("testlog")
                            .setUseFastReplay(useFastReplay)
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     log.replay();
     FlumeEvent eventIn = TestUtils.newPersistableEvent();
@@ -430,6 +442,7 @@ public class TestLog {
                            .setLogDirs(dataDirs)
                            .setChannelName("testlog")
                            .setUseFastReplay(useFastReplay)
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     try {
       log.replay();
@@ -455,6 +468,7 @@ public class TestLog {
                            .setCheckpointDir(checkpointDir)
                            .setLogDirs(dataDirs)
                            .setChannelName("testlog")
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     doTestReplaySucceedsWithUnusedEmptyLogMetaData(eventIn, eventPointer);
   }
@@ -477,6 +491,7 @@ public class TestLog {
                            .setLogDirs(dataDirs)
                            .setChannelName("testlog")
                            .setUseFastReplay(true)
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     doTestReplaySucceedsWithUnusedEmptyLogMetaData(eventIn, eventPointer);
   }
@@ -529,6 +544,7 @@ public class TestLog {
                            .setLogDirs(dataDirs)
                            .setCheckpointOnClose(true)
                            .setChannelName("testLog")
+                           .setChannelCounter(new FileChannelCounter("testlog"))
                            .build();
     log.replay();
 


### PR DESCRIPTION
This patch adds the following new metrics to the FileChannel's counters:
- eventPutErrorCount: incremented if an IOException occurs during put operation.
- eventTakeErrorCount: incremented if an IOException or CorruptEventException occurs
  during take operation.
- checkpointWriteErrorCount: incremented if an exception occurs during checkpoint write.
- unhealthy: this flag represents whether the channel has started successfully
  (i.e. the replay ran without any problem), so the channel is capable for normal operation
- closed flag: the numeric representation (1: closed, 0: open) of the negated open flag.