### PR TITLE
add captity unit

### DIFF
--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
@@ -201,12 +201,12 @@ public class FileChannel extends BasicChannelSemantics {
 
     // cannot be over FileChannelConfiguration.DEFAULT_MAX_FILE_SIZE
     maxFileSize = Math.min(
-        context.getLong(FileChannelConfiguration.MAX_FILE_SIZE,
+        context.getByteLong(FileChannelConfiguration.MAX_FILE_SIZE,
             FileChannelConfiguration.DEFAULT_MAX_FILE_SIZE),
         FileChannelConfiguration.DEFAULT_MAX_FILE_SIZE);
 
     minimumRequiredSpace = Math.max(
-        context.getLong(FileChannelConfiguration.MINIMUM_REQUIRED_SPACE,
+        context.getByteLong(FileChannelConfiguration.MINIMUM_REQUIRED_SPACE,
             FileChannelConfiguration.DEFAULT_MINIMUM_REQUIRED_SPACE),
         FileChannelConfiguration.FLOOR_MINIMUM_REQUIRED_SPACE);
 

--- a/flume-ng-channels/flume-spillable-memory-channel/src/main/java/org/apache/flume/channel/SpillableMemoryChannel.java
+++ b/flume-ng-channels/flume-spillable-memory-channel/src/main/java/org/apache/flume/channel/SpillableMemoryChannel.java
@@ -674,8 +674,8 @@ public class SpillableMemoryChannel extends FileChannel {
     }
 
     try {
-      avgEventSize = context.getInteger(AVG_EVENT_SIZE, defaultAvgEventSize);
-    } catch (NumberFormatException e) {
+      avgEventSize = context.getByteInteger(AVG_EVENT_SIZE, defaultAvgEventSize);
+    } catch (IllegalArgumentException e) {
       LOGGER.warn("Error parsing " + AVG_EVENT_SIZE + " for " + getName()
           + ". Using default = " + defaultAvgEventSize + ". "
           + e.getMessage());
@@ -683,12 +683,12 @@ public class SpillableMemoryChannel extends FileChannel {
     }
 
     try {
-      byteCapacity = (int) ((context.getLong(BYTE_CAPACITY, defaultByteCapacity) *
+      byteCapacity = (int) ((context.getByteLong(BYTE_CAPACITY, defaultByteCapacity) *
                             (1 - byteCapacityBufferPercentage * .01)) / avgEventSize);
       if (byteCapacity < 1) {
         byteCapacity = Integer.MAX_VALUE;
       }
-    } catch (NumberFormatException e) {
+    } catch (IllegalArgumentException e) {
       LOGGER.warn("Error parsing " + BYTE_CAPACITY + " setting for " + getName()
           + ". Using default = " + defaultByteCapacity + ". "
           + e.getMessage());

--- a/flume-ng-configuration/src/main/java/org/apache/flume/Context.java
+++ b/flume-ng-configuration/src/main/java/org/apache/flume/Context.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.flume.conf.UnitUtils;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -207,6 +209,69 @@ public class Context {
    */
   public Long getLong(String key) {
     return getLong(key, null);
+  }
+  /**
+   * Gets capatity value mapped to key, returning null if unmapped.
+   * @param key to be found
+   * @return value associated with key or null if unmapped
+   */
+  public Long getByteLong(String key){
+    return getByteLong(key,null);
+  }
+  /**
+   * Gets capatity value mapped to key, returning defaultValue if unmapped.
+   * @param key to be found
+   * @param defaultValue returned if key is unmapped
+   * @return value associated with key
+   */
+  public Long getByteLong(String key,Long defaultValue){
+    String value = get(key);
+    if (value != null) {
+      return UnitUtils.parseBytes(value.trim());
+    }
+    return defaultValue;
+  }
+  /**
+   * Gets capatity value mapped to key, returning null if unmapped.
+   * @param key to be found
+   * @return value associated with key or null if unmapped
+   */
+  public Integer getByteInteger(String key){
+    return getByteInteger(key,null);
+  }
+  /**
+   * Gets capatity value mapped to key, returning defaultValue if unmapped.
+   * @param key to be found
+   * @param defaultValue returned if key is unmapped
+   * @return value associated with key
+   */
+  public Integer getByteInteger(String key,Integer defaultValue){
+    String value = get(key);
+    if (value != null) {
+      return UnitUtils.parseBytes(value.trim()).intValue();
+    }
+    return defaultValue;
+  }
+  /**
+   * Gets time value mapped to key, returning null if unmapped.
+   * @param key to be found
+   * @return value associated with key or null if unmapped
+   */
+  public Long getMilliseconds(String key){
+    return getMilliseconds(key,null);
+  }
+  /**
+   * Gets time value mapped to key, returning defaultValue if unmapped.
+   * @param key to be found
+   * @param defaultValue returned if key is unmapped
+   * @return value associated with key
+   */
+  public Long getMilliseconds(String key,Long defaultValue){
+    String value = get(key);
+    if (value != null) {
+      return UnitUtils.parseMillisecond(value.trim());
+    }
+    return defaultValue;
   }
   /**
    * Gets value mapped to key, returning defaultValue if unmapped.

--- a/flume-ng-configuration/src/main/java/org/apache/flume/conf/UnitUtils.java
+++ b/flume-ng-configuration/src/main/java/org/apache/flume/conf/UnitUtils.java
@@ -1,0 +1,99 @@
+package org.apache.flume.conf;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * <p>
+ * UnitUtils is a tool class that converts a string with multiple units into a minimum unit value 
+ * </p>
+ * 
+ * @author Lisheng Xia
+ *
+ */
+public class UnitUtils {
+  /**
+   * the
+   */
+  private static final Pattern CAPACITY_PATTERN=Pattern.compile("((?<g>\\d+(\\.\\d+)?)(g|G))?((?<m>\\d+(\\.\\d+)?)(m|M))?((?<k>\\d+(\\.\\d+)?)(k|K))?((?<b>\\d+)(b|B|byte|BYTE)?)?");
+  private static final Pattern TIME_PATTERN=Pattern.compile("((?<h>\\d+(\\.\\d+)?)(h|H))?((?<m>\\d+(\\.\\d+)?)(m|M))?((?<s>\\d+(\\.\\d+)?)(s|S))?((?<ms>\\d+)(ms|MS)?)?");
+  
+  private static final int CAPACITY_RATE=1024;
+  
+  /**
+   * <p>
+   * capacity units are g/G,m/M,k/K,b/B/byte/BYTE
+   * </p>
+   * <ul><li>2g or 2G -> 2147483648
+   * <li>1.5g400m or 1.5G400M -> 2030043136
+   * <li>200m1024b or 200M1024 ->  209716224(If there is no specified capacity unit, the default is byte)</ul>
+   * 
+   * @param value A string to be converted into bytes
+   * @return result of the conversion
+   */
+  public static Long parseBytes(String value){
+    Objects.requireNonNull(value);
+    Matcher matcher = CAPACITY_PATTERN.matcher(value);
+    if(matcher.matches()){
+      long bytes=0;
+      String gib=matcher.group("g");
+      String mib=matcher.group("m");
+      String kib=matcher.group("k");
+      String b=matcher.group("b");
+      if(gib!=null){
+        bytes+=Math.round(Double.parseDouble(gib)*Math.pow(CAPACITY_RATE, 3));
+      }
+      if(mib!=null){
+        bytes+=Math.round(Double.parseDouble(mib)*Math.pow(CAPACITY_RATE, 2));
+      }
+      if(kib!=null){
+        bytes+=Math.round(Double.parseDouble(kib)*Math.pow(CAPACITY_RATE, 1));
+      }
+      if(b!=null){
+        bytes+=Integer.parseInt(b);
+      }
+      return bytes;
+    }else{
+      throw new IllegalArgumentException("Invalid capacity specified.");
+    }
+  }
+  
+  /**
+   * <p>
+   * time units are h/H,m/M,s/S,ms/MS
+   * </p>
+   * <ul><li>1h or 1H -> 3600000 
+   * <li>1.5h or 1.5H or 1h30m -> 5400000 
+   * <li>3s or 3S -> 3000 </ul>
+   * @param value A string to be converted into milliseconds
+   * @return result of the conversion
+   */
+  public static Long parseMillisecond(String value){
+    Objects.requireNonNull(value);
+    Matcher matcher = TIME_PATTERN.matcher(value);
+    if(matcher.matches()){
+      long millisecond=0;
+      String hour=matcher.group("h");
+      String minute=matcher.group("m");
+      String second=matcher.group("s");
+      String ms=matcher.group("ms");
+      if(hour!=null){
+        millisecond+=Math.round(Double.parseDouble(hour)*60*60*1000);
+      }
+      if(minute!=null){
+        millisecond+=Math.round(Double.parseDouble(minute)*60*1000);
+      }
+      if(second!=null){
+        millisecond+=Math.round(Double.parseDouble(second)*1000);
+      }
+      if(ms!=null){
+        millisecond+=Integer.parseInt(ms);
+      }
+      return millisecond;
+    }else{
+      throw new IllegalArgumentException("Invalid time specified.");
+    }
+  }
+}

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
@@ -261,12 +261,12 @@ public class MemoryChannel extends BasicChannelSemantics {
     }
 
     try {
-      byteCapacity = (int) ((context.getLong("byteCapacity", defaultByteCapacity).longValue() *
+      byteCapacity = (int) ((context.getByteLong("byteCapacity", defaultByteCapacity).longValue() *
           (1 - byteCapacityBufferPercentage * .01)) / byteCapacitySlotSize);
       if (byteCapacity < 1) {
         byteCapacity = Integer.MAX_VALUE;
       }
-    } catch (NumberFormatException e) {
+    } catch (IllegalArgumentException e) {
       byteCapacity = (int) ((defaultByteCapacity * (1 - byteCapacityBufferPercentage * .01)) /
           byteCapacitySlotSize);
     }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
@@ -93,7 +93,7 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
     numProcessors = context.getInteger(
             SyslogSourceConfigurationConstants.CONFIG_NUMPROCESSORS);
 
-    maxEventSize = context.getInteger(
+    maxEventSize = context.getByteInteger(
         SyslogSourceConfigurationConstants.CONFIG_EVENTSIZE,
         SyslogUtils.DEFAULT_SIZE);
 

--- a/flume-ng-core/src/main/java/org/apache/flume/source/NetcatSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/NetcatSource.java
@@ -140,7 +140,7 @@ public class NetcatSource extends AbstractSource implements Configurable,
     hostName = context.getString(hostKey);
     port = context.getInteger(portKey);
     ackEveryEvent = context.getBoolean(ackEventKey, true);
-    maxLineLength = context.getInteger(
+    maxLineLength = context.getByteInteger(
         NetcatSourceConfigurationConstants.CONFIG_MAX_LINE_LENGTH,
         NetcatSourceConfigurationConstants.DEFAULT_MAX_LINE_LENGTH);
     sourceEncoding = context.getString(

--- a/flume-ng-core/src/main/java/org/apache/flume/source/StressSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/StressSource.java
@@ -87,7 +87,7 @@ public class StressSource extends AbstractPollableSource implements Configurable
     /* Set max events in a batch submission */
     batchSize = context.getInteger("batchSize", 1);
     /* Size of events to be generated. */
-    int size = context.getInteger("size", 500);
+    int size = context.getByteInteger("size", 500);
 
     prepEventData(size);
   }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogTcpSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogTcpSource.java
@@ -160,7 +160,7 @@ public class SyslogTcpSource extends AbstractSource
         SyslogSourceConfigurationConstants.CONFIG_PORT);
     port = context.getInteger(SyslogSourceConfigurationConstants.CONFIG_PORT);
     host = context.getString(SyslogSourceConfigurationConstants.CONFIG_HOST);
-    eventSize = context.getInteger("eventSize", SyslogUtils.DEFAULT_SIZE);
+    eventSize = context.getByteInteger("eventSize", SyslogUtils.DEFAULT_SIZE);
     formaterProp = context.getSubProperties(
         SyslogSourceConfigurationConstants.CONFIG_FORMAT_PREFIX);
     keepFields = SyslogUtils.chooseFieldsToKeep(

--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/AvroEventSerializer.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/AvroEventSerializer.java
@@ -91,7 +91,7 @@ public class AvroEventSerializer implements EventSerializer, Configurable {
   @Override
   public void configure(Context context) {
     syncIntervalBytes =
-        context.getInteger(SYNC_INTERVAL_BYTES, DEFAULT_SYNC_INTERVAL_BYTES);
+        context.getByteInteger(SYNC_INTERVAL_BYTES, DEFAULT_SYNC_INTERVAL_BYTES);
     compressionCodec =
         context.getString(COMPRESSION_CODEC, DEFAULT_COMPRESSION_CODEC);
     staticSchemaURL = context.getString(STATIC_SCHEMA_URL, DEFAULT_STATIC_SCHEMA_URL);

--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/src/main/java/org/apache/flume/sink/solr/morphline/BlobDeserializer.java
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/src/main/java/org/apache/flume/sink/solr/morphline/BlobDeserializer.java
@@ -56,7 +56,7 @@ public class BlobDeserializer implements EventDeserializer {
       
   protected BlobDeserializer(Context context, ResettableInputStream in) {
     this.in = in;
-    this.maxBlobLength = context.getInteger(MAX_BLOB_LENGTH_KEY, MAX_BLOB_LENGTH_DEFAULT);
+    this.maxBlobLength = context.getByteInteger(MAX_BLOB_LENGTH_KEY, MAX_BLOB_LENGTH_DEFAULT);
     if (this.maxBlobLength <= 0) {
       throw new ConfigurationException("Configuration parameter " + MAX_BLOB_LENGTH_KEY
           + " must be greater than zero: " + maxBlobLength);

--- a/flume-ng-sources/flume-scribe-source/src/main/java/org/apache/flume/source/scribe/ScribeSource.java
+++ b/flume-ng-sources/flume-scribe-source/src/main/java/org/apache/flume/source/scribe/ScribeSource.java
@@ -73,7 +73,7 @@ public class ScribeSource extends AbstractSource implements
   @Override
   public void configure(Context context) {
     port = context.getInteger("port", DEFAULT_PORT);
-    maxReadBufferBytes = context.getInteger("maxReadBufferBytes", DEFAULT_MAX_READ_BUFFER_BYTES);
+    maxReadBufferBytes = context.getByteInteger("maxReadBufferBytes", DEFAULT_MAX_READ_BUFFER_BYTES);
     if(maxReadBufferBytes <= 0){
       maxReadBufferBytes = DEFAULT_MAX_READ_BUFFER_BYTES;
     }


### PR DESCRIPTION
FLUME-3095
In the configuration file, the capacity and time-related configuration can not set the unit, only the default unit, the default unit of capacity is byte, the default unit of time is milliseconds, so need to convert (for example, 2g converted to 2147483648), so not It is easy to configure the attribute is not easy to read again, so prepare the capacity type configuration new unit: g / m / k / b (no unit defaults to byte), the time type configuration new unit: h / m / s / ms ( No unit defaults to ms).