### PR TITLE
HttpSink. Fix bad response handling. 

### DIFF
--- a/flume-ng-sinks/flume-http-sink/src/main/java/org/apache/flume/sink/http/HttpSink.java
+++ b/flume-ng-sinks/flume-http-sink/src/main/java/org/apache/flume/sink/http/HttpSink.java
@@ -218,7 +218,12 @@ public class HttpSink extends AbstractSink implements Configurable {
           int httpStatusCode = connection.getResponseCode();
           LOG.debug("Got status code : " + httpStatusCode);
 
-          connection.getInputStream().close();
+          if (httpStatusCode < HttpURLConnection.HTTP_BAD_REQUEST) {
+            connection.getInputStream().close();
+          } else {
+            LOG.debug("bad request");
+            connection.getErrorStream().close();
+          }
           LOG.debug("Response processed and closed");
 
           if (httpStatusCode >= HTTP_STATUS_CONTINUE) {

--- a/flume-ng-sinks/flume-http-sink/src/test/java/org/apache/flume/sink/http/TestHttpSink.java
+++ b/flume-ng-sinks/flume-http-sink/src/test/java/org/apache/flume/sink/http/TestHttpSink.java
@@ -216,6 +216,22 @@ public class TestHttpSink {
   }
 
   @Test
+  public void ensureSingleErrorStatusConfigurationCorrectlyUsed() throws Exception {
+    when(channel.take()).thenReturn(event);
+    when(event.getBody()).thenReturn("something".getBytes());
+
+    Context context = new Context();
+    context.put("defaultRollback", "true");
+    context.put("defaultBackoff", "true");
+    context.put("defaultIncrementMetrics", "false");
+    context.put("rollback.401", "false");
+    context.put("backoff.401", "false");
+    context.put("incrementMetrics.401", "false");
+
+    executeWithMocks(true, Status.READY, false, true, context, HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
   public void ensureGroupConfigurationCorrectlyUsed() throws Exception {
     when(channel.take()).thenReturn(event);
     when(event.getBody()).thenReturn("something".getBytes());
@@ -278,6 +294,7 @@ public class TestHttpSink {
     when(channel.getTransaction()).thenReturn(transaction);
     when(httpURLConnection.getOutputStream()).thenReturn(outputStream);
     when(httpURLConnection.getInputStream()).thenReturn(inputStream);
+    when(httpURLConnection.getErrorStream()).thenReturn(inputStream);
     when(httpURLConnection.getResponseCode()).thenReturn(httpStatus);
 
     Status actualStatus = httpSink.process();

--- a/flume-ng-sinks/flume-http-sink/src/test/java/org/apache/flume/sink/http/TestHttpSinkIT.java
+++ b/flume-ng-sinks/flume-http-sink/src/test/java/org/apache/flume/sink/http/TestHttpSinkIT.java
@@ -71,6 +71,8 @@ public class TestHttpSinkIT {
       httpSinkContext.put("contentTypeHeader", "application/json");
       httpSinkContext.put("backoff.200", "false");
       httpSinkContext.put("rollback.200", "false");
+      httpSinkContext.put("backoff.401", "false");
+      httpSinkContext.put("rollback.401", "false");
       httpSinkContext.put("incrementMetrics.200", "true");
 
       Context memoryChannelContext = new Context();
@@ -129,6 +131,31 @@ public class TestHttpSinkIT {
 
     service.verify(2, postRequestedFor(urlEqualTo("/endpoint"))
         .withRequestBody(equalToJson(event("TRANSIENT_ERROR"))));
+  }
+
+  @Test
+  public void ensureEventsNotResentOn401Failure() throws Exception {
+
+    service.stubFor(post(urlEqualTo("/endpoint"))
+            .inScenario(errorScenario)
+            .whenScenarioStateIs(STARTED)
+            .willReturn(aResponse().withStatus(401)
+                    .withHeader("Content-Type", "text/plain")
+                    .withBody("Not allowed!"))
+            .willSetStateTo("Error Sent"));
+
+    service.stubFor(post(urlEqualTo("/endpoint"))
+            .inScenario(errorScenario)
+            .withRequestBody(equalToJson(event("NEXT EVENT")))
+            .willReturn(aResponse().withStatus(200))
+
+    addEventToChannel(event("NEXT EVENT"), Status.READY);
+
+    service.verify(1, postRequestedFor(urlEqualTo("/endpoint"))
+
+    service.verify(1, postRequestedFor(urlEqualTo("/endpoint"))
+            .withRequestBody(equalToJson(event("NEXT EVENT"))));
+
   }
 
   @Test

--- a/flume-ng-sinks/flume-http-sink/src/test/java/org/apache/flume/sink/http/TestHttpSinkIT.java
+++ b/flume-ng-sinks/flume-http-sink/src/test/java/org/apache/flume/sink/http/TestHttpSinkIT.java
@@ -142,16 +142,15 @@ public class TestHttpSinkIT {
             .whenScenarioStateIs(STARTED)
             .withRequestBody(equalToJson(event("UNAUTHORIZED REQUEST")))
             .willReturn(aResponse().withStatus(401)
-                    .withHeader("Content-Type", "text/plain")
-                    .withBody("Not allowed!"))
+            .withHeader("Content-Type", "text/plain")
+            .withBody("Not allowed!"))
             .willSetStateTo("Error Sent"));
 
     service.stubFor(post(urlEqualTo("/endpoint"))
             .inScenario(errorScenario)
             .whenScenarioStateIs("Error Sent")
             .withRequestBody(equalToJson(event("NEXT EVENT")))
-            .willReturn(aResponse().withStatus(200))
-            );
+            .willReturn(aResponse().withStatus(200)));
 
     addEventToChannel(event("UNAUTHORIZED REQUEST"), Status.READY);
     addEventToChannel(event("NEXT EVENT"), Status.READY);


### PR DESCRIPTION
After a bad response, connection.getInputStream () returns null. I'm adding a check for this. If the answer is bad - try to close ErrorStream.