### PR TITLE
FLUME-2752 Fix AvroSource startup resource leaks

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/AvroSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/AvroSource.java
@@ -20,7 +20,6 @@
 package org.apache.flume.source;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.avro.ipc.NettyServer;
 import org.apache.avro.ipc.NettyTransceiver;
@@ -156,6 +155,7 @@ public class AvroSource extends AbstractSource implements EventDrivenSource,
   private boolean enableIpFilter;
   private String patternRuleConfigDefinition;
 
+  private NioServerSocketChannelFactory socketChannelFactory;
   private Server server;
   private SourceCounter sourceCounter;
 
@@ -233,14 +233,20 @@ public class AvroSource extends AbstractSource implements EventDrivenSource,
   public void start() {
     logger.info("Starting {}...", this);
 
-    Responder responder = new SpecificResponder(AvroSourceProtocol.class, this);
+    try {
+      Responder responder = new SpecificResponder(AvroSourceProtocol.class, this);
 
-    NioServerSocketChannelFactory socketChannelFactory = initSocketChannelFactory();
+      socketChannelFactory = initSocketChannelFactory();
 
-    ChannelPipelineFactory pipelineFactory = initChannelPipelineFactory();
+      ChannelPipelineFactory pipelineFactory = initChannelPipelineFactory();
 
-    server = new NettyServer(responder, new InetSocketAddress(bindAddress, port),
-          socketChannelFactory, pipelineFactory, null);
+      server = new NettyServer(responder, new InetSocketAddress(bindAddress, port),
+              socketChannelFactory, pipelineFactory, null);
+    } catch (org.jboss.netty.channel.ChannelException nce) {
+      logger.error("Avro source {} startup failed. Cannot initialize Netty server", getName(), nce);
+      stop();
+      throw new FlumeException(nce);
+    }
 
     connectionCountUpdater = Executors.newSingleThreadScheduledExecutor();
     server.start();
@@ -300,28 +306,30 @@ public class AvroSource extends AbstractSource implements EventDrivenSource,
   public void stop() {
     logger.info("Avro source {} stopping: {}", getName(), this);
 
-    server.close();
-
-    try {
-      server.join();
-    } catch (InterruptedException e) {
-      logger.info("Avro source " + getName() + ": Interrupted while waiting " +
-          "for Avro server to stop. Exiting. Exception follows.", e);
-    }
-    sourceCounter.stop();
-    connectionCountUpdater.shutdown();
-    while (!connectionCountUpdater.isTerminated()) {
+    if (server != null) {
+      server.close();
       try {
-        Thread.sleep(100);
-      } catch (InterruptedException ex) {
-        logger.error("Interrupted while waiting for connection count executor "
-                + "to terminate", ex);
-        Throwables.propagate(ex);
+        server.join();
+        server = null;
+      } catch (InterruptedException e) {
+        logger.info("Avro source " + getName() + ": Interrupted while waiting " +
+                "for Avro server to stop. Exiting. Exception follows.", e);
       }
     }
+
+    if (socketChannelFactory != null) {
+      socketChannelFactory.releaseExternalResources();
+      socketChannelFactory = null;
+    }
+
+    sourceCounter.stop();
+    if (connectionCountUpdater != null) {
+      connectionCountUpdater.shutdownNow();
+      connectionCountUpdater = null;
+    }
+
     super.stop();
-    logger.info("Avro source {} stopped. Metrics: {}", getName(),
-        sourceCounter);
+    logger.info("Avro source {} stopped. Metrics: {}", getName(), sourceCounter);
   }
 
   @Override

--- a/flume-ng-core/src/main/java/org/apache/flume/source/AvroSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/AvroSource.java
@@ -245,7 +245,7 @@ public class AvroSource extends AbstractSource implements EventDrivenSource,
     } catch (org.jboss.netty.channel.ChannelException nce) {
       logger.error("Avro source {} startup failed. Cannot initialize Netty server", getName(), nce);
       stop();
-      throw new FlumeException(nce);
+      throw new FlumeException("Failed to set up server socket", nce);
     }
 
     connectionCountUpdater = Executors.newSingleThreadScheduledExecutor();
@@ -314,6 +314,7 @@ public class AvroSource extends AbstractSource implements EventDrivenSource,
       } catch (InterruptedException e) {
         logger.info("Avro source " + getName() + ": Interrupted while waiting " +
                 "for Avro server to stop. Exiting. Exception follows.", e);
+        Thread.currentThread().interrupt();
       }
     }
 

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
@@ -96,13 +96,13 @@ public class TestAvroSource {
     boolean bound = false;
 
     for (int i = 0; i < 100 && !bound; i++) {
-        Context context = new Context();
 
-        context.put("port", String.valueOf(selectedPort = 41414 + i));
-        context.put("bind", "0.0.0.0");
+      Context context = new Context();
 
-        Configurables.configure(source, context);
-
+      context.put("port", String.valueOf(selectedPort = 41414 + i));
+      context.put("bind", "0.0.0.0");
+      // Invalid configuration may throw a FlumeException which has to be expected in the callers
+      Configurables.configure(source, context);
       try {
         source.start();
         bound = true;
@@ -235,18 +235,17 @@ public class TestAvroSource {
     boolean bound = false;
 
     for (int i = 0; i < 100 && !bound; i++) {
-        Context context = new Context();
-        context.put("port", String.valueOf(selectedPort = 41414 + i));
-        context.put("bind", "0.0.0.0");
-        context.put("threads", "50");
-        if (serverEnableCompression) {
-          context.put("compression-type", "deflate");
-        } else {
-          context.put("compression-type", "none");
-        }
-
-        Configurables.configure(source, context);
-
+      Context context = new Context();
+      context.put("port", String.valueOf(selectedPort = 41414 + i));
+      context.put("bind", "0.0.0.0");
+      context.put("threads", "50");
+      if (serverEnableCompression) {
+        context.put("compression-type", "deflate");
+      } else {
+        context.put("compression-type", "none");
+      }
+      // Invalid configuration may throw a FlumeException which has to be expected in the callers
+      Configurables.configure(source, context);
       try {
         source.start();
         bound = true;
@@ -337,17 +336,16 @@ public class TestAvroSource {
     boolean bound = false;
 
     for (int i = 0; i < 10 && !bound; i++) {
-        Context context = new Context();
+      Context context = new Context();
 
-        context.put("port", String.valueOf(selectedPort = 41414 + i));
-        context.put("bind", "0.0.0.0");
-        context.put("ssl", "true");
-        context.put("keystore", "src/test/resources/server.p12");
-        context.put("keystore-password", "password");
-        context.put("keystore-type", "PKCS12");
-
-        Configurables.configure(source, context);
-
+      context.put("port", String.valueOf(selectedPort = 41414 + i));
+      context.put("bind", "0.0.0.0");
+      context.put("ssl", "true");
+      context.put("keystore", "src/test/resources/server.p12");
+      context.put("keystore-password", "password");
+      context.put("keystore-type", "PKCS12");
+      // Invalid configuration may throw a FlumeException which has to be expected in the callers
+      Configurables.configure(source, context);
       try {
         source.start();
         bound = true;
@@ -520,22 +518,23 @@ public class TestAvroSource {
     boolean bound = false;
 
     for (int i = 0; i < 100 && !bound; i++) {
-        Context context = new Context();
-        context.put("port", String.valueOf(selectedPort = 41414 + i));
-        context.put("bind", "0.0.0.0");
-        context.put("ipFilter", "true");
-        if (ruleDefinition != null) {
-          context.put("ipFilterRules", ruleDefinition);
-        }
-        if (testWithSSL) {
-          logger.info("Client testWithSSL" + testWithSSL);
-          context.put("ssl", "true");
-          context.put("keystore", "src/test/resources/server.p12");
-          context.put("keystore-password", "password");
-          context.put("keystore-type", "PKCS12");
-        }
 
-        Configurables.configure(source, context);
+      Context context = new Context();
+      context.put("port", String.valueOf(selectedPort = 41414 + i));
+      context.put("bind", "0.0.0.0");
+      context.put("ipFilter", "true");
+      if (ruleDefinition != null) {
+        context.put("ipFilterRules", ruleDefinition);
+      }
+      if (testWithSSL) {
+        logger.info("Client testWithSSL" + testWithSSL);
+        context.put("ssl", "true");
+        context.put("keystore", "src/test/resources/server.p12");
+        context.put("keystore-password", "password");
+        context.put("keystore-type", "PKCS12");
+      }
+      // Invalid configuration may throw a FlumeException which has to be expected in the callers
+      Configurables.configure(source, context);
 
       try {
         source.start();

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
@@ -140,15 +140,14 @@ public class TestAvroSource {
       Context context = new Context();
       context.put("port", String.valueOf(port));
       context.put("bind", loopbackIPv4);
-      // Invalid configuration may throw a FlumeException which has to be expected in the callers
       Configurables.configure(source, context);
       try {
         source.start();
         Assert.fail("Expected an exception during startup caused by binding on a used port");
       } catch (FlumeException e) {
         logger.info("Received an expected exception.", e);
-        Assert.assertTrue("Expected a bind related root cause",
-            e.getMessage().contains("Failed to bind to"));
+        Assert.assertTrue("Expected a server socket setup related root cause",
+            e.getMessage().contains("server socket"));
       }
     }
     // As port is already in use, an exception is thrown and the source is stopped
@@ -166,7 +165,6 @@ public class TestAvroSource {
     Context context = new Context();
     context.put("port", String.valueOf(port));
     context.put("bind", invalidHost);
-    // Invalid configuration may throw a FlumeException which has to be expected in the callers
     Configurables.configure(source, context);
 
     try {
@@ -174,8 +172,8 @@ public class TestAvroSource {
       Assert.fail("Expected an exception during startup caused by binding on a invalid host");
     } catch (FlumeException e) {
       logger.info("Received an expected exception.", e);
-      Assert.assertTrue("Expected a bind related root cause",
-          e.getMessage().contains("Failed to bind to"));
+      Assert.assertTrue("Expected a server socket setup related root cause",
+          e.getMessage().contains("server socket"));
     }
 
     // As port is already in use, an exception is thrown and the source is stopped
@@ -244,7 +242,6 @@ public class TestAvroSource {
       } else {
         context.put("compression-type", "none");
       }
-      // Invalid configuration may throw a FlumeException which has to be expected in the callers
       Configurables.configure(source, context);
       try {
         source.start();
@@ -344,7 +341,6 @@ public class TestAvroSource {
       context.put("keystore", "src/test/resources/server.p12");
       context.put("keystore-password", "password");
       context.put("keystore-type", "PKCS12");
-      // Invalid configuration may throw a FlumeException which has to be expected in the callers
       Configurables.configure(source, context);
       try {
         source.start();
@@ -533,7 +529,7 @@ public class TestAvroSource {
         context.put("keystore-password", "password");
         context.put("keystore-type", "PKCS12");
       }
-      // Invalid configuration may throw a FlumeException which has to be expected in the callers
+      // Invalid configuration may result in a FlumeException
       Configurables.configure(source, context);
 
       try {

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
@@ -52,7 +52,6 @@ import org.apache.flume.lifecycle.LifecycleState;
 import org.apache.flume.source.avro.AvroFlumeEvent;
 import org.apache.flume.source.avro.AvroSourceProtocol;
 import org.apache.flume.source.avro.Status;
-import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.socket.SocketChannel;
 import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
@@ -97,7 +96,6 @@ public class TestAvroSource {
     boolean bound = false;
 
     for (int i = 0; i < 100 && !bound; i++) {
-      try {
         Context context = new Context();
 
         context.put("port", String.valueOf(selectedPort = 41414 + i));
@@ -105,12 +103,12 @@ public class TestAvroSource {
 
         Configurables.configure(source, context);
 
+      try {
         source.start();
         bound = true;
-      } catch (ChannelException e) {
+      } catch (FlumeException e) {
         /*
-         * NB: This assume we're using the Netty server under the hood and the
-         * failure is to bind. Yucky.
+         * NB: This assume the failure is to bind.
          */
       }
     }
@@ -237,7 +235,6 @@ public class TestAvroSource {
     boolean bound = false;
 
     for (int i = 0; i < 100 && !bound; i++) {
-      try {
         Context context = new Context();
         context.put("port", String.valueOf(selectedPort = 41414 + i));
         context.put("bind", "0.0.0.0");
@@ -250,12 +247,12 @@ public class TestAvroSource {
 
         Configurables.configure(source, context);
 
+      try {
         source.start();
         bound = true;
-      } catch (ChannelException e) {
+      } catch (FlumeException e) {
         /*
-         * NB: This assume we're using the Netty server under the hood and the
-         * failure is to bind. Yucky.
+         * NB: This assume the failure is to bind.
          */
       }
     }
@@ -340,7 +337,6 @@ public class TestAvroSource {
     boolean bound = false;
 
     for (int i = 0; i < 10 && !bound; i++) {
-      try {
         Context context = new Context();
 
         context.put("port", String.valueOf(selectedPort = 41414 + i));
@@ -352,12 +348,12 @@ public class TestAvroSource {
 
         Configurables.configure(source, context);
 
+      try {
         source.start();
         bound = true;
-      } catch (ChannelException e) {
+      } catch (FlumeException e) {
         /*
-         * NB: This assume we're using the Netty server under the hood and the
-         * failure is to bind. Yucky.
+         * NB: This assume the failure is to bind.
          */
         Thread.sleep(100);
       }
@@ -524,7 +520,6 @@ public class TestAvroSource {
     boolean bound = false;
 
     for (int i = 0; i < 100 && !bound; i++) {
-      try {
         Context context = new Context();
         context.put("port", String.valueOf(selectedPort = 41414 + i));
         context.put("bind", "0.0.0.0");
@@ -542,12 +537,12 @@ public class TestAvroSource {
 
         Configurables.configure(source, context);
 
+      try {
         source.start();
         bound = true;
-      } catch (ChannelException e) {
+      } catch (FlumeException e) {
         /*
-         * NB: This assume we're using the Netty server under the hood and the
-         * failure is to bind. Yucky.
+         * NB: This assume the failure is to bind.
          */
         Thread.sleep(100);
       }


### PR DESCRIPTION
Cleanup after Netty initialisation failes (call this.stop())
Make sure this.stop() releases the resources and end up the component in
a LifecycleAware.STOPPED state
Added junit tests to cover the invalid host and used port scenarios