### PR TITLE
FLUME-3128: Fix TestHDFSEventSinkOnMiniCluster.java due to incompatib…

### DIFF
--- a/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSinkOnMiniCluster.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSinkOnMiniCluster.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.apache.hadoop.hdfs.server.namenode.LeaseManager;
 import org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -570,13 +569,12 @@ public class TestHDFSEventSinkOnMiniCluster {
     Assert.assertEquals(1, statuses.length);
 
     String filePath = statuses[0].getPath().toUri().getPath();
-    LeaseManager lm = NameNodeAdapter.getLeaseManager(cluster.getNamesystem());
 
-    Object lease = lm.getLeaseByPath(filePath);
+    Object lease = NameNodeAdapter.getLeaseForPath(cluster.getNameNode(), filePath);
     // wait until the NameNode recovers the lease
     for (int i = 0; i < 10 && lease != null; i++) {
       TimeUnit.SECONDS.sleep(1);
-      lease = lm.getLeaseByPath(filePath);
+      lease = NameNodeAdapter.getLeaseForPath(cluster.getNameNode(), filePath);
     }
 
     // There should be no lease for the given path even if close failed as the BucketWriter


### PR DESCRIPTION
…le changes in hadoop-hdfs lib.

Our test in flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSinkOnMiniCluster.java
Uses the getLeaseByPath(String src) method of Lease class which is to be replaced by getLeaseForPath(Namenode n, String src) method.

This change is to make Flume compatible after the hadoop change is made effective.

See https://issues.apache.org/jira/browse/HDFS-6757