### PR TITLE
[FLUME-3133] Add a 'ipHeader' config in both tcp and udp syslog source

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogSourceConfigurationConstants.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogSourceConfigurationConstants.java
@@ -74,6 +74,9 @@ public final class SyslogSourceConfigurationConstants {
   public static final String CONFIG_KEEP_FIELDS_TIMESTAMP = "timestamp";
   public static final String CONFIG_KEEP_FIELDS_HOSTNAME = "hostname";
 
+  public static final String CONFIG_IP_HEADER = "ipHeader";
+  public static final String DEFAULT_IP_HEADER = "ip";
+
   private SyslogSourceConfigurationConstants() {
     // Disable explicit creation of objects.
   }

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestMultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestMultiportSyslogTCPSource.java
@@ -411,7 +411,7 @@ public class TestMultiportSyslogTCPSource {
     Context context = new Context();
     StringBuilder ports = new StringBuilder();
     context.put(SyslogSourceConfigurationConstants.CONFIG_PORTS,
-            String.valueOf(BASE_TEST_SYSLOG_PORT));
+            String.valueOf(getFreePort()));
     context.put(SyslogSourceConfigurationConstants.CONFIG_IP_HEADER,
             TEST_IP_HEADER);
 
@@ -421,7 +421,7 @@ public class TestMultiportSyslogTCPSource {
     //create a socket to send a test event
     Socket syslogSocket;
     syslogSocket = new Socket(
-            InetAddress.getLocalHost(), BASE_TEST_SYSLOG_PORT);
+            InetAddress.getLocalHost(), getFreePort());
     syslogSocket.getOutputStream().write(getEvent(0));
 
     //take event frome channel

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -1566,6 +1566,7 @@ keepFields       none         Setting this to 'all' will preserve the Priority,
                               fields can be included: priority, version,
                               timestamp, hostname. The values 'true' and 'false'
                               have been deprecated in favor of 'all' and 'none'.
+ipHeader         --           If specified, the IP will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming port.
 selector.type                 replicating or multiplexing
 selector.*       replicating  Depends on the selector.type value
 interceptors     --           Space-separated list of interceptors
@@ -1609,6 +1610,7 @@ keepFields            none              Setting this to 'all' will preserve the
                                         fields can be included: priority, version,
                                         timestamp, hostname. The values 'true' and 'false'
                                         have been deprecated in favor of 'all' and 'none'.
+ipHeader              --                If specified, the IP will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming port.
 portHeader            --                If specified, the port number will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming port.
 charset.default       UTF-8             Default character set used while parsing syslog events into strings.
 charset.port.<port>   --                Character set is configurable on a per-port basis.
@@ -1645,6 +1647,7 @@ Property Name   Default      Description
 **port**        --           Port # to bind to
 keepFields      false        Setting this to true will preserve the Priority,
                              Timestamp and Hostname in the body of the event.
+ipHeader        --           If specified, the IP will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming port.
 selector.type                replicating or multiplexing
 selector.*      replicating  Depends on the selector.type value
 interceptors    --           Space-separated list of interceptors

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -1566,7 +1566,7 @@ keepFields       none         Setting this to 'all' will preserve the Priority,
                               fields can be included: priority, version,
                               timestamp, hostname. The values 'true' and 'false'
                               have been deprecated in favor of 'all' and 'none'.
-ipHeader         --           If specified, the IP will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming port.
+ipHeader         --           If specified, the IP will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming host.
 selector.type                 replicating or multiplexing
 selector.*       replicating  Depends on the selector.type value
 interceptors     --           Space-separated list of interceptors
@@ -1610,7 +1610,7 @@ keepFields            none              Setting this to 'all' will preserve the
                                         fields can be included: priority, version,
                                         timestamp, hostname. The values 'true' and 'false'
                                         have been deprecated in favor of 'all' and 'none'.
-ipHeader              --                If specified, the IP will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming port.
+ipHeader              --                If specified, the IP will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming host.
 portHeader            --                If specified, the port number will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming port.
 charset.default       UTF-8             Default character set used while parsing syslog events into strings.
 charset.port.<port>   --                Character set is configurable on a per-port basis.
@@ -1647,7 +1647,7 @@ Property Name   Default      Description
 **port**        --           Port # to bind to
 keepFields      false        Setting this to true will preserve the Priority,
                              Timestamp and Hostname in the body of the event.
-ipHeader        --           If specified, the IP will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming port.
+ipHeader        --           If specified, the IP will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming host.
 selector.type                replicating or multiplexing
 selector.*      replicating  Depends on the selector.type value
 interceptors    --           Space-separated list of interceptors


### PR DESCRIPTION
When I use the syslog source, I use the "host" header to tell where the event come from.However, when change the format of syslog service, the "host" header willl be missing.

So I add a new config named "ipHeader" which looks like the "portHeader" in Multiport Syslog TCP Source.
When this config is specified, a header will be added.

For more detail: 
https://issues.apache.org/jira/browse/FLUME-3133