### PR TITLE
FLUME-3144. Improve Log4jAppender's performance by allowing logging collection of messages

### DIFF
--- a/flume-ng-clients/flume-ng-log4jappender/pom.xml
+++ b/flume-ng-clients/flume-ng-log4jappender/pom.xml
@@ -87,6 +87,12 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 

--- a/flume-ng-clients/flume-ng-log4jappender/src/test/java/org/apache/flume/clients/log4jappender/TestLog4jAppender.java
+++ b/flume-ng-clients/flume-ng-log4jappender/src/test/java/org/apache/flume/clients/log4jappender/TestLog4jAppender.java
@@ -21,11 +21,13 @@ package org.apache.flume.clients.log4jappender;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import junit.framework.Assert;
 
@@ -41,6 +43,7 @@ import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.source.AvroSource;
+import org.apache.flume.source.avro.AvroFlumeEvent;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -48,6 +51,7 @@ import org.apache.log4j.PropertyConfigurator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class TestLog4jAppender {
   private AvroSource source;
@@ -57,7 +61,7 @@ public class TestLog4jAppender {
   @Before
   public void initiate() throws Exception {
     int port = 25430;
-    source = new AvroSource();
+    source = Mockito.spy(new AvroSource());
     ch = new MemoryChannel();
     Configurables.configure(ch, new Context());
 
@@ -76,16 +80,12 @@ public class TestLog4jAppender {
   }
 
   private void configureSource() {
-    List<Channel> channels = new ArrayList<Channel>();
-    channels.add(ch);
-
     ChannelSelector rcs = new ReplicatingChannelSelector();
-    rcs.setChannels(channels);
-
+    rcs.setChannels(Collections.singletonList(ch));
     source.setChannelProcessor(new ChannelProcessor(rcs));
-
     source.start();
   }
+
   @Test
   public void testLog4jAppender() throws IOException {
     configureSource();
@@ -125,7 +125,64 @@ public class TestLog4jAppender {
       transaction.commit();
       transaction.close();
     }
+  }
 
+  private void testBatchedSending(int numEvents) {
+    configureSource();
+    PropertyConfigurator.configure(props);
+
+    Logger logger = LogManager.getLogger(getClass());
+    List<String> events = IntStream.range(0, numEvents).mapToObj(String::valueOf)
+        .collect(Collectors.toList());
+    logger.info(events);
+
+    Transaction tx = ch.getTransaction();
+    tx.begin();
+    for (String s : events) {
+      Event e = ch.take();
+      Assert.assertNotNull(e);
+      Assert.assertEquals(s, new String(e.getBody()));
+    }
+    Assert.assertNull("There should be no more events in the channel", ch.take());
+  }
+
+  @Test
+  public void testLogBatch() {
+    testBatchedSending(5);
+    Mockito.verify(source, Mockito.times(1)).appendBatch(Mockito.anyList());
+    Mockito.verify(source, Mockito.times(0)).append(Mockito.any(AvroFlumeEvent.class));
+  }
+
+  @Test
+  public void testLogSingleMessage() {
+    configureSource();
+    PropertyConfigurator.configure(props);
+
+    Logger logger = LogManager.getLogger(getClass());
+    logger.info("test");
+
+    Transaction tx = ch.getTransaction();
+    tx.begin();
+    Event e = ch.take();
+    Assert.assertNotNull(e);
+    Assert.assertEquals("test", new String(e.getBody()));
+
+    Mockito.verify(source, Mockito.times(0)).appendBatch(Mockito.anyList());
+    Mockito.verify(source, Mockito.times(1)).append(Mockito.any(AvroFlumeEvent.class));
+  }
+
+  @Test
+  public void testLogSingleMessageInCollection() {
+    testBatchedSending(1);
+    Mockito.verify(source, Mockito.times(0)).appendBatch(Mockito.anyList());
+    Mockito.verify(source, Mockito.times(1)).append(Mockito.any(AvroFlumeEvent.class));
+  }
+
+  @Test
+  public void testLogEmptyBatch() {
+    testBatchedSending(0);
+    Mockito.verify(source, Mockito.times(0)).appendBatch(Mockito.anyList());
+    Mockito.verify(source, Mockito.times(0)).append(Mockito.any(AvroFlumeEvent.class));
   }
 
   @Test
@@ -136,7 +193,6 @@ public class TestLog4jAppender {
     Logger logger = LogManager.getLogger(TestLog4jAppender.class);
     source.stop();
     sendAndAssertFail(logger);
-
   }
 
   @Test(expected = EventDeliveryException.class)


### PR DESCRIPTION
`Log4jAppender` treats `Collection` messages as a special case making it possible to log collection of events in one Log4j log call. The appender sends these events to the receiving Flume instance as one batch with the `rpcClient.appendBatch()` method.

New tests added:
- logging of a collection of multiple strings, expect one `appendBatch()` call.
- logging one string, expect one `append()` call.
- logging of a singleton collection of a string, expect one `append()` call.
- logging of an empty collection, expect that neither `append()` nor `appendBatch()` was called.
- logging of a `String` and an arbitrary object in one collection with `AvroReflectionEnabled` set to `true`
- logging of a `String` and an arbitrary object in one collection with `AvroReflectionEnabled` set to `false`