### PR TITLE
FLUME-3057 Update snappy-java version for Power(ppc64le) support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@ limitations under the License.
     <netty.version>3.9.4.Final</netty.version>
     <protobuf.version>2.5.0</protobuf.version>
     <rat.version>0.11</rat.version>
-    <snappy-java.version>1.1.0</snappy-java.version>
+    <snappy-java.version>1.1.4</snappy-java.version>
     <solr-global.version>4.3.0</solr-global.version>
     <slf4j.version>1.6.1</slf4j.version>
     <system-rules.version>1.16.0</system-rules.version>


### PR DESCRIPTION
Flume has a snappy-java dependency with version 1.1.0. Upon building Flume on ppc64le architecture, errors such as "[FAILED_TO_LOAD_NATIVE_LIBRARY] no native library is found for os.name=Linux and os.arch=ppc64le" are seen
Native libraries for ppc64le were added in snappy-java version 1.1.1. Hence Flume needs to have a higher version of snappy-java.