### PR TITLE
FLUME-3149 reduce cpu cost for taildir file source while still maintaining reliability by using posFile in memory channel

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
@@ -20,10 +20,17 @@ package org.apache.flume.channel;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import java.util.HashMap;
 import org.apache.flume.ChannelException;
 import org.apache.flume.ChannelFullException;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
+import org.apache.flume.FlumeException;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.annotations.Recyclable;
@@ -32,6 +39,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.GuardedBy;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +78,8 @@ public class MemoryChannel extends BasicChannelSemantics {
   private static final Integer defaultByteCapacityBufferPercentage = 20;
 
   private static final Integer defaultKeepAlive = 3;
+  private static final String defaultPositionFile = "/.flume/taildir_position.json";
+  private static final boolean defaultWritePos = false;
 
   private class MemoryTransaction extends BasicTransactionSemantics {
     private LinkedBlockingDeque<Event> takeList;
@@ -132,6 +153,30 @@ public class MemoryChannel extends BasicChannelSemantics {
       int puts = putList.size();
       int takes = takeList.size();
       synchronized (queueLock) {
+        if (writePos && takes > 0) {
+          for (Event event : takeList) {
+            if (event.getHeaders().containsKey("inode")) {
+              inodePositionMap.put(event.getHeaders().get("inode"), event.getHeaders().get("pos"));
+              inodePathMap.put(event.getHeaders().get("inode"), event.getHeaders().get("path"));
+            }
+            if (event.getHeaders().containsKey("existingInodes")) {
+              HashMap<String, String> existingInodes = Maps.newHashMap();
+              String[] inodes = event.getHeaders().get("existingInodes").split(",");
+              for (String inode : inodes) {
+                existingInodes.put(inode, "");
+              }
+              Iterator<Map.Entry<String,String>> iter = inodePositionMap.entrySet().iterator();
+              while (iter.hasNext()) {
+                String inode = iter.next().getKey();
+                if (!existingInodes.containsKey(inode)) {
+                  iter.remove();
+                  inodePathMap.remove(inode);
+                }
+              }
+            }
+          }
+          writePosition();
+        }
         if (puts > 0) {
           while (!putList.isEmpty()) {
             if (!queue.offer(putList.removeFirst())) {
@@ -208,6 +253,11 @@ public class MemoryChannel extends BasicChannelSemantics {
   private Semaphore bytesRemaining;
   private ChannelCounter channelCounter;
 
+  private String positionFilePath;
+  private boolean writePos;
+  private ConcurrentHashMap<String, String> inodePositionMap = new ConcurrentHashMap<>();
+  private ConcurrentHashMap<String, String> inodePathMap = new ConcurrentHashMap<>();
+
   public MemoryChannel() {
     super();
   }
@@ -222,6 +272,9 @@ public class MemoryChannel extends BasicChannelSemantics {
    */
   @Override
   public void configure(Context context) {
+    String homePath = System.getProperty("user.home").replace('\\', '/');
+    positionFilePath = context.getString("positionFile", homePath + defaultPositionFile);
+    writePos = context.getBoolean("writePos", defaultWritePos);
     Integer capacity = null;
     try {
       capacity = context.getInteger("capacity", defaultCapacity);
@@ -347,6 +400,15 @@ public class MemoryChannel extends BasicChannelSemantics {
 
   @Override
   public synchronized void start() {
+    if (writePos) {
+      try {
+        Files.createDirectories(Paths.get(positionFilePath).getParent());
+      } catch (IOException e) {
+        throw new FlumeException("Error creating positionFile parent directories", e);
+      }
+      loadPositionFile(positionFilePath);
+    }
+
     channelCounter.start();
     channelCounter.setChannelSize(queue.size());
     channelCounter.setChannelCapacity(Long.valueOf(
@@ -364,6 +426,92 @@ public class MemoryChannel extends BasicChannelSemantics {
   @Override
   protected BasicTransactionSemantics createTransaction() {
     return new MemoryTransaction(transCapacity, channelCounter);
+  }
+
+  private void writePosition() {
+    File file = new File(positionFilePath);
+    FileWriter writer = null;
+    try {
+      writer = new FileWriter(file);
+      if (!inodePositionMap.isEmpty()) {
+        String json = toPosInfoJson();
+        writer.write(json);
+      }
+    } catch (Throwable t) {
+      LOGGER.error("Failed writing positionFile", t);
+      throw new ChannelFullException(t);
+    } finally {
+      try {
+        if (writer != null) writer.close();
+      } catch (IOException e) {
+        LOGGER.error("Error: " + e.getMessage(), e);
+      }
+    }
+  }
+
+  private String toPosInfoJson() {
+    @SuppressWarnings("rawtypes")
+    List<Map> posInfos = Lists.newArrayList();
+    for (String inode : inodePositionMap.keySet()) {
+      posInfos.add(ImmutableMap.of("inode", inode, "pos", inodePositionMap.get(inode),
+          "file", inodePathMap.get(inode)));
+    }
+    return new Gson().toJson(posInfos);
+  }
+
+  /**
+   * Load a position file which has the last read position of each file.
+   * If the position file exists, update tailFiles mapping.
+   */
+  public void loadPositionFile(String filePath) {
+    Long inode, pos;
+    String path;
+    FileReader fr = null;
+    JsonReader jr = null;
+    try {
+      fr = new FileReader(filePath);
+      jr = new JsonReader(fr);
+      jr.beginArray();
+      while (jr.hasNext()) {
+        inode = null;
+        pos = null;
+        path = null;
+        jr.beginObject();
+        while (jr.hasNext()) {
+          switch (jr.nextName()) {
+            case "inode":
+              inode = jr.nextLong();
+              break;
+            case "pos":
+              pos = jr.nextLong();
+              break;
+            case "file":
+              path = jr.nextString();
+              break;
+          }
+        }
+        jr.endObject();
+
+        for (Object v : Arrays.asList(inode, pos, path)) {
+          Preconditions.checkNotNull(v, "Detected missing value in position file. "
+              + "inode: " + inode + ", pos: " + pos + ", path: " + path);
+        }
+        inodePositionMap.put(inode + "", pos + "");
+        inodePathMap.put(inode + "", path);
+      }
+      jr.endArray();
+    } catch (FileNotFoundException e) {
+      LOGGER.info("File not found: " + filePath + ", not updating position");
+    } catch (IOException e) {
+      LOGGER.error("Failed loading positionFile: " + filePath, e);
+    } finally {
+      try {
+        if (fr != null) fr.close();
+        if (jr != null) jr.close();
+      } catch (IOException e) {
+        LOGGER.error("Error: " + e.getMessage(), e);
+      }
+    }
   }
 
   private long estimateEventSize(Event event) {

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
@@ -488,6 +488,8 @@ public class MemoryChannel extends BasicChannelSemantics {
             case "file":
               path = jr.nextString();
               break;
+            default:
+              break;
           }
         }
         jr.endObject();

--- a/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
@@ -79,41 +79,6 @@ public class TestMemoryChannel {
   }
 
   @Test
-  public void testPutTakeWithWritePos() throws IOException, InterruptedException,
-      EventDeliveryException {
-    Event event = EventBuilder.withBody("test event".getBytes());
-    event.getHeaders().put("inode", "1");
-    event.getHeaders().put("pos", "100");
-    event.getHeaders().put("path", "test");
-    Context context = new Context();
-    Map<String, String> parms = new HashMap<String, String>();
-    File tmpDir = Files.createTempDir();
-
-    parms.put("writePos", "true");
-    parms.put("positionFile", tmpDir.getAbsolutePath() + "pos");
-    context.putAll(parms);
-    Configurables.configure(channel, context);
-
-    Transaction transaction = channel.getTransaction();
-    Assert.assertNotNull(transaction);
-
-    transaction.begin();
-    channel.put(event);
-    transaction.commit();
-    transaction.close();
-
-    transaction = channel.getTransaction();
-    Assert.assertNotNull(transaction);
-
-    transaction.begin();
-    Event event2 = channel.take();
-    Assert.assertEquals(event, event2);
-    transaction.commit();
-    Assert.assertEquals(IOUtils.toString(new FileReader(tmpDir.getAbsolutePath() + "pos")),
-        "[{\"inode\":\"1\",\"pos\":\"100\",\"file\":\"test\"}]");
-  }
-
-  @Test
   public void testPutAcceptsNullValueInHeader() {
     Configurables.configure(channel, new Context());
 

--- a/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
@@ -79,7 +79,8 @@ public class TestMemoryChannel {
   }
 
   @Test
-  public void testPutTakeWithWritePos() throws IOException, InterruptedException, EventDeliveryException {
+  public void testPutTakeWithWritePos() throws IOException, InterruptedException,
+      EventDeliveryException {
     Event event = EventBuilder.withBody("test event".getBytes());
     event.getHeaders().put("inode", "1");
     event.getHeaders().put("pos", "100");

--- a/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
@@ -21,8 +21,6 @@ package org.apache.flume.channel;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Files;
-import org.apache.commons.io.IOUtils;
 import org.apache.flume.ChannelException;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
@@ -35,9 +33,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -1182,7 +1182,6 @@ headers.<filegroupName>.<headerKey> --                             Header value 
 byteOffsetHeader                    false                          Whether to add the byte offset of a tailed line to a header called 'byteoffset'.
 skipToEnd                           false                          Whether to skip the position to EOF in the case of files not written on the position file.
 idleTimeout                         120000                         Time (ms) to close inactive files. If the closed file is appended new lines to, this source will automatically re-open it.
-writePosInterval                    3000                           Interval time (ms) to write the last position of each file on the position file.
 batchSize                           100                            Max number of lines to read and send to the channel at a time. Using the default is usually fine.
 backoffSleepIncrement               1000                           The increment for time delay before reattempting to poll for new data, when the last attempt did not find any new data.
 maxBackoffSleep                     5000                           The max time delay between each reattempt to poll for new data, when the last attempt did not find any new data.

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -1161,7 +1161,7 @@ If the new lines are being written, this source will retry reading them in wait 
 This source is reliable and will not miss data even when the tailing files rotate.
 By default it periodically writes the last read position of each files on the given position file in JSON format.
 It can also be configured by setting writePosOnCommit to true and use MemoryChannel to write the last consumed position of each file when commits.
-This way, we save CPU costs in FileChannel and maintains reliability as well.
+This way, we reach reliability and avoid heavy system calls in FileChannel thus reducing CPU cost.
 If Flume is stopped or down for some reason, it can restart tailing from the position written on the existing position file.
 
 In other use case, this source can also start tailing from the arbitrary position for each files using the given position file.

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -1159,7 +1159,9 @@ Watch the specified files, and tail them in nearly real-time once detected new l
 If the new lines are being written, this source will retry reading them in wait for the completion of the write.
 
 This source is reliable and will not miss data even when the tailing files rotate.
-It periodically writes the last read position of each files on the given position file in JSON format.
+By default it periodically writes the last read position of each files on the given position file in JSON format.
+It can also be configured by setting writePosOnCommit to true and use MemoryChannel to write the last consumed position of each file when commits.
+This way, we save CPU costs in FileChannel and maintains reliability as well.
 If Flume is stopped or down for some reason, it can restart tailing from the position written on the existing position file.
 
 In other use case, this source can also start tailing from the arbitrary position for each files using the given position file.
@@ -1182,6 +1184,8 @@ headers.<filegroupName>.<headerKey> --                             Header value 
 byteOffsetHeader                    false                          Whether to add the byte offset of a tailed line to a header called 'byteoffset'.
 skipToEnd                           false                          Whether to skip the position to EOF in the case of files not written on the position file.
 idleTimeout                         120000                         Time (ms) to close inactive files. If the closed file is appended new lines to, this source will automatically re-open it.
+writePosInterval                    3000                           Interval time (ms) to write the last position of each file on the position file.
+writePosOnCommit                    false                          Whether to writ position of each file when transaction commits in MemoryChannel.
 batchSize                           100                            Max number of lines to read and send to the channel at a time. Using the default is usually fine.
 backoffSleepIncrement               1000                           The increment for time delay before reattempting to poll for new data, when the last attempt did not find any new data.
 maxBackoffSleep                     5000                           The max time delay between each reattempt to poll for new data, when the last attempt did not find any new data.

--- a/flume-ng-sdk/src/main/java/org/apache/flume/event/SimpleEvent.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/event/SimpleEvent.java
@@ -64,4 +64,7 @@ public class SimpleEvent implements Event {
     return "[Event headers = " + headers + ", body.length = " + bodyLen + " ]";
   }
 
+  public void notifySource() {}
+
+  public void commit() {}
 }

--- a/flume-ng-sdk/src/main/java/org/apache/flume/event/SimpleEvent.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/event/SimpleEvent.java
@@ -64,7 +64,17 @@ public class SimpleEvent implements Event {
     return "[Event headers = " + headers + ", body.length = " + bodyLen + " ]";
   }
 
+  /**
+   * Notify the source side to update event transfer information if necessary.
+   * For now, it's designed for updating position info in TaildirSource.
+   */
   public void notifySource() {}
 
+  /**
+   * Notify the source side to commit if necessary.
+   * For now, it's designed for writing position info to file in TaildirSource
+   * when events are consumed properly from the sink side. In this way, we can
+   * ensure TaildirSource maintains reliability using MemoryChannel.
+   */
   public void commit() {}
 }

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
@@ -195,7 +195,8 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
       long lastPos = currentFile.getPos();
       currentFile.updateFilePos(lastPos);
     }
-    List<Event> events = currentFile.readEvents(numEvents, backoffWithoutNL, addByteOffset, writePosOnCommit);
+    List<Event> events = currentFile.readEvents(numEvents, backoffWithoutNL,
+        addByteOffset, writePosOnCommit);
     if (events.isEmpty()) {
       return events;
     }

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
@@ -57,6 +57,7 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
   private boolean addByteOffset;
   private boolean cachePatternMatching;
   private boolean committed = true;
+  private final boolean writePos;
   private final boolean annotateFileName;
   private final String fileNameHeader;
 
@@ -66,7 +67,7 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
   private ReliableTaildirEventReader(Map<String, String> filePaths,
       Table<String, String, String> headerTable, String positionFilePath,
       boolean skipToEnd, boolean addByteOffset, boolean cachePatternMatching,
-      boolean annotateFileName, String fileNameHeader) throws IOException {
+      boolean writePos, boolean annotateFileName, String fileNameHeader) throws IOException {
     // Sanity checks
     Preconditions.checkNotNull(filePaths);
     Preconditions.checkNotNull(positionFilePath);
@@ -87,6 +88,7 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
     this.headerTable = headerTable;
     this.addByteOffset = addByteOffset;
     this.cachePatternMatching = cachePatternMatching;
+    this.writePos = writePos;
     this.annotateFileName = annotateFileName;
     this.fileNameHeader = fileNameHeader;
     updateTailFiles(skipToEnd);
@@ -198,13 +200,18 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
     }
 
     Map<String, String> headers = currentFile.getHeaders();
-    if (annotateFileName || (headers != null && !headers.isEmpty())) {
+    if (annotateFileName || !writePos || (headers != null && !headers.isEmpty())) {
       for (Event event : events) {
         if (headers != null && !headers.isEmpty()) {
           event.getHeaders().putAll(headers);
         }
         if (annotateFileName) {
           event.getHeaders().put(fileNameHeader, currentFile.getPath());
+        }
+        if (!writePos) {
+          event.getHeaders().put("inode", Long.toString(currentFile.getInode()));
+          event.getHeaders().put("pos", Long.toString(currentFile.getLineReadPos()));
+          event.getHeaders().put("path", currentFile.getPath());
         }
       }
     }
@@ -297,6 +304,8 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
     private boolean skipToEnd;
     private boolean addByteOffset;
     private boolean cachePatternMatching;
+    private Boolean writePos =
+            TaildirSourceConfigurationConstants.DEFAULT_WRITE_POS;
     private Boolean annotateFileName =
             TaildirSourceConfigurationConstants.DEFAULT_FILE_HEADER;
     private String fileNameHeader =
@@ -332,6 +341,11 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
       return this;
     }
 
+    public Builder writePos(boolean writePos) {
+      this.writePos = writePos;
+      return this;
+    }
+
     public Builder annotateFileName(boolean annotateFileName) {
       this.annotateFileName = annotateFileName;
       return this;
@@ -344,7 +358,7 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
 
     public ReliableTaildirEventReader build() throws IOException {
       return new ReliableTaildirEventReader(filePaths, headerTable, positionFilePath, skipToEnd,
-                                            addByteOffset, cachePatternMatching,
+                                            addByteOffset, cachePatternMatching, writePos,
                                             annotateFileName, fileNameHeader);
     }
   }

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
@@ -284,7 +284,7 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
   private TailFile openFile(File file, Map<String, String> headers, long inode, long pos) {
     try {
       logger.info("Opening file: " + file + ", inode: " + inode + ", pos: " + pos);
-      return new TailFile(file, headers, inode, pos, writePosOnCommit);
+      return new TailFile(file, headers, inode, pos);
     } catch (IOException e) {
       throw new FlumeException("Failed opening file: " + file, e);
     }

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -162,6 +162,9 @@ public class TailFile {
       return null;
     }
     Event event = EventBuilder.withBody(line.line);
+    event.getHeaders().put("inode", Long.toString(this.getInode()));
+    event.getHeaders().put("pos", Long.toString(this.getLineReadPos()));
+    event.getHeaders().put("path", this.getPath());
     if (addByteOffset == true) {
       event.getHeaders().put(BYTE_OFFSET_HEADER_KEY, posTmp.toString());
     }

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -46,7 +46,6 @@ public class TailFile {
   private final String path;
   private final long inode;
   private long pos;
-  private boolean writePosOnCommit;
   private long lastUpdated;
   private boolean needTail;
   private final Map<String, String> headers;
@@ -55,7 +54,7 @@ public class TailFile {
   private int bufferPos;
   private long lineReadPos;
 
-  public TailFile(File file, Map<String, String> headers, long inode, long pos, boolean writePosOnCommit)
+  public TailFile(File file, Map<String, String> headers, long inode, long pos)
       throws IOException {
     this.raf = new RandomAccessFile(file, "r");
     if (pos > 0) {
@@ -65,7 +64,6 @@ public class TailFile {
     this.path = file.getAbsolutePath();
     this.inode = inode;
     this.pos = pos;
-    this.writePosOnCommit = writePosOnCommit;
     this.lastUpdated = 0L;
     this.needTail = true;
     this.headers = headers;

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
@@ -114,15 +114,17 @@ public class TaildirSource extends AbstractSource implements
     }
     if (writePosOnCommit) {
       for (Entry<Long, TailFile> entry : reader.getTailFiles().entrySet()) {
-        inodePositionMap.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue().getPos()));
-        inodePathMap.put(String.valueOf(entry.getKey()), String.valueOf(entry.getValue().getPath()));
+        inodePositionMap.put(String.valueOf(entry.getKey()),
+            String.valueOf(entry.getValue().getPos()));
+        inodePathMap.put(String.valueOf(entry.getKey()),
+            String.valueOf(entry.getValue().getPath()));
       }
     }
     idleFileChecker = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder().setNameFormat("idleFileChecker").build());
     idleFileChecker.scheduleWithFixedDelay(new idleFileCheckerRunnable(),
         idleTimeout, checkIdleInterval, TimeUnit.MILLISECONDS);
-    
+
     if (!writePosOnCommit) {
       positionWriter = Executors.newSingleThreadScheduledExecutor(
           new ThreadFactoryBuilder().setNameFormat("positionWriter").build());
@@ -165,7 +167,8 @@ public class TaildirSource extends AbstractSource implements
   public String toString() {
     return String.format("Taildir source: { positionFile: %s, skipToEnd: %s, "
         + "byteOffsetHeader: %s, idleTimeout: %s, writePosInterval: %s }",
-        positionFilePath, skipToEnd, byteOffsetHeader, idleTimeout, writePosInterval);  }
+        positionFilePath, skipToEnd, byteOffsetHeader, idleTimeout, writePosInterval);
+  }
 
   @Override
   public synchronized void configure(Context context) {

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
@@ -41,14 +41,6 @@ public class TaildirSourceConfigurationConstants {
   public static final String IDLE_TIMEOUT = "idleTimeout";
   public static final int DEFAULT_IDLE_TIMEOUT = 120000;
 
-  /** Whether to write position file in source. */
-  public static final String WRITE_POS = "writePos";
-  public static final boolean DEFAULT_WRITE_POS = true;
-
-  /** Interval time (ms) to write the last position of each file on the position file. */
-  public static final String WRITE_POS_INTERVAL = "writePosInterval";
-  public static final int DEFAULT_WRITE_POS_INTERVAL = 3000;
-
   /** Whether to add the byte offset of a tailed line to the header */
   public static final String BYTE_OFFSET_HEADER = "byteOffsetHeader";
   public static final String BYTE_OFFSET_HEADER_KEY = "byteoffset";

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
@@ -41,6 +41,14 @@ public class TaildirSourceConfigurationConstants {
   public static final String IDLE_TIMEOUT = "idleTimeout";
   public static final int DEFAULT_IDLE_TIMEOUT = 120000;
 
+  /** Interval time (ms) to write the last position of each file on the position file. */
+  public static final String WRITE_POS_INTERVAL = "writePosInterval";
+  public static final int DEFAULT_WRITE_POS_INTERVAL = 3000;
+
+  /** Whether to writ position of each file when commit in MemoryChannel. */
+  public static final String WRITE_POS_ON_COMMIT = "writePosOnCommit";
+  public static final boolean DEFAULT_WRITE_POS_ON_COMMIT = false;
+
   /** Whether to add the byte offset of a tailed line to the header */
   public static final String BYTE_OFFSET_HEADER = "byteOffsetHeader";
   public static final String BYTE_OFFSET_HEADER_KEY = "byteoffset";

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
@@ -41,6 +41,10 @@ public class TaildirSourceConfigurationConstants {
   public static final String IDLE_TIMEOUT = "idleTimeout";
   public static final int DEFAULT_IDLE_TIMEOUT = 120000;
 
+  /** Whether to write position file in source. */
+  public static final String WRITE_POS = "writePos";
+  public static final boolean DEFAULT_WRITE_POS = true;
+
   /** Interval time (ms) to write the last position of each file on the position file. */
   public static final String WRITE_POS_INTERVAL = "writePosInterval";
   public static final int DEFAULT_WRITE_POS_INTERVAL = 3000;

--- a/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
@@ -342,6 +342,7 @@ public class TestTaildirSource {
 
     assertEquals(e.getHeaders().get("pos"), "3");
     assertEquals(source.getInodePositionMap().get(e.getHeaders().get("inode")), "3");
-    assertEquals(source.getInodePathMap().get(e.getHeaders().get("inode")), e.getHeaders().get("path"));
+    assertEquals(source.getInodePathMap().get(e.getHeaders().get("inode")),
+        e.getHeaders().get("path"));
   }
 }

--- a/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
@@ -20,7 +20,6 @@ package org.apache.flume.source.taildir;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
-import java.util.logging.Logger;
 import org.apache.flume.Channel;
 import org.apache.flume.ChannelSelector;
 import org.apache.flume.Context;
@@ -53,14 +52,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import org.slf4j.LoggerFactory;
 
 public class TestTaildirSource {
   static TaildirSource source;
   static MemoryChannel channel;
   private File tmpDir;
   private String posFilePath;
-  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(TestTaildirSource.class);
 
   @Before
   public void setUp() {


### PR DESCRIPTION
File channel tracks transferred events and use transnational mechanism to make transfer recoverable. However, it increases CPU cost due to frequent system calls like write, read, etc. The Cpu cost could be very high if the transfer rate is high. 
In contrast, Memory channel has no such issue which requires only about 10% of CPU cost in the same environment but it's not recovered if the system is down accidentally.
For sources like taildir, I propose we could write position file in memory channel to achieve reliability and reduce CPU cost.
After testing on my own production environment, CPU usage dropped from 13% to 3% and still maintain reliability.  （Transfer rate: 1Mb/s ,  kafka sink, file channel -> memory channel with pos file)