### PR TITLE
FLUME-3155: Use batch mode in mvn to fix Travis CI error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_install:
 install:
   - # Skip mvn install. See https://docs.travis-ci.com/user/languages/java/
 script:
-  - MAVEN_OPTS="-Xms512m -Xmx1024m" mvn clean install -DskipTests
+  - MAVEN_OPTS="-Xms512m -Xmx1024m" mvn clean install -DskipTests -B


### PR DESCRIPTION
Reduce log verbosity with mvn batch mode to avoid this error:
The log length has exceeded the limit of 4 MB (this usually means that the test suite is raising the same exception over and over).
The job has been terminated