### PR TITLE
FLUME-3175. Turn off doclint for javadoc generation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,6 +519,9 @@ limitations under the License.
                 </goals>
               </execution>
             </executions>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
           </plugin>
 
           <plugin>


### PR DESCRIPTION
With Java 8's new doclint feature the javadoc generation breaks due to the
strict checking so adding -Xdoclint:none to the maven-javadoc-plugin's
configuration to turn off the check.