### PR TITLE
Change the checkstyle project's parent to flume-parent

### DIFF
--- a/flume-checkstyle/pom.xml
+++ b/flume-checkstyle/pom.xml
@@ -22,14 +22,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache</groupId>
-    <artifactId>apache</artifactId>
-    <version>18</version>
+    <groupId>org.apache.flume</groupId>
+    <artifactId>flume-parent</artifactId>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.flume</groupId>
   <artifactId>flume-checkstyle</artifactId>
-  <version>1.9.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
   <name>Flume checkstyle project</name>
 


### PR DESCRIPTION
- Change the checkstyle project's parent to flume-parent
- Set flume-checkstyle's packaging to "pom"

This fixes among others the packaging issue when the modules were missing
from the source tarball.