### PR TITLE
Fix source assembly

### DIFF
--- a/flume-ng-dist/src/main/assembly/src.xml
+++ b/flume-ng-dist/src/main/assembly/src.xml
@@ -43,6 +43,7 @@
         <exclude>**/*.iml</exclude>
         <exclude>**/.settings/**</exclude>
         <exclude>lib/**</exclude>
+        <exclude>**/.DS_Store</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/flume-ng-dist/src/main/assembly/src.xml
+++ b/flume-ng-dist/src/main/assembly/src.xml
@@ -31,91 +31,19 @@
 
   <baseDirectory>apache-flume-${project.version}-src</baseDirectory>
 
-  <moduleSets>
-
-    <moduleSet>
-      <useAllReactorProjects>true</useAllReactorProjects>
-
-      <includes>
-        <include>org.apache.flume:flume-ng-configuration</include>
-        <include>org.apache.flume:flume-ng-sdk</include>
-        <include>org.apache.flume:flume-ng-core</include>
-        <include>org.apache.flume:flume-ng-node</include>
-        <include>org.apache.flume:flume-ng-dist</include>
-        <include>org.apache.flume:flume-ng-channels</include>
-        <include>org.apache.flume:flume-ng-sinks</include>
-        <include>org.apache.flume:flume-ng-sources</include>
-        <include>org.apache.flume:flume-ng-legacy-sources</include>
-        <include>org.apache.flume:flume-ng-clients</include>
-        <include>org.apache.flume:flume-ng-embedded-agent</include>
-        <include>org.apache.flume:flume-tools</include>
-        <include>org.apache.flume:flume-ng-auth</include>
-        <include>org.apache.flume:flume-shared</include>
-      </includes>
-
-      <sources>
-        <includeModuleDirectory>true</includeModuleDirectory>
-        <excludeSubModuleDirectories>false</excludeSubModuleDirectories>
-
-        <fileSets>
-          <fileSet>
-            <excludes>
-              <exclude>target/**</exclude>
-              <exclude>*/target/**</exclude>
-              <exclude>.classpath</exclude>
-              <exclude>*/.classpath</exclude>
-              <exclude>.project</exclude>
-              <exclude>*/.project</exclude>
-              <exclude>.settings/**</exclude>
-              <exclude>*/.settings/**</exclude>
-            </excludes>
-          </fileSet>
-        </fileSets>
-      </sources>
-
-    </moduleSet>
-
-  </moduleSets>
-
    <fileSets>
     <fileSet>
       <directory>../</directory>
 
       <excludes>
-        <exclude>flume-ng-configuration/**</exclude>
-        <exclude>flume-ng-sdk/**</exclude>
-        <exclude>flume-ng-core/**</exclude>
-        <exclude>flume-ng-node/**</exclude>
-        <exclude>flume-ng-dist/**</exclude>
-        <exclude>flume-ng-channels/**</exclude>
-        <exclude>flume-ng-sinks/**</exclude>
-        <exclude>flume-ng-sources/**</exclude>
-        <exclude>flume-ng-legacy-sources/**</exclude>
-        <exclude>flume-ng-clients/**</exclude>
-        <exclude>flume-ng-embedded-agent/**</exclude>
-        <exclude>flume-tools/**</exclude>
         <exclude>**/target/**</exclude>
         <exclude>**/.classpath</exclude>
         <exclude>**/.project</exclude>
+        <exclude>**/.idea/**</exclude>
+        <exclude>**/*.iml</exclude>
         <exclude>**/.settings/**</exclude>
         <exclude>lib/**</exclude>
       </excludes>
-
-      <includes>
-        <include>.gitignore</include>
-        <include>DEVNOTES</include>
-        <include>README</include>
-        <include>LICENSE</include>
-        <include>NOTICE</include>
-        <include>CHANGELOG</include>
-        <include>RELEASE-NOTES</include>
-        <include>bin/**</include>
-        <include>conf/**</include>
-        <include>pom.xml</include>
-        <include>flume-ng-doc/**</include>
-        <include>flume-ng-tests/**</include>
-        <include>dev-support/**</include>
-      </includes>
     </fileSet>
   </fileSets>
 


### PR DESCRIPTION
flume-checkstyle breaks the assembly because its parent is not the flume-parent
Removing the moduleSets definition from the src assembly solved the issue.
Files are added based on fileSets, the resulting tarball's content equals
to the result of the dev-support/generate-source-release.sh in a clean
working directory.