### PR TITLE
FLUME-3186: Make asyncHbaseClient configuration parameters available …

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -2540,6 +2540,10 @@ timeout              60000                                                      
                                                                                    all events in a transaction.
 serializer           org.apache.flume.sink.hbase.SimpleAsyncHbaseEventSerializer
 serializer.*         --                                                            Properties to be passed to the serializer.
+async.*              --                                                            Properties to be passed to asyncHbase library.
+                                                                                   These properties have precedence over the old ``zookeeperQuorum`` and ``znodeParent`` values.
+                                                                                   You can find the list of the available properties at
+                                                                                   `the documentation page of AsyncHBase <http://opentsdb.github.io/asynchbase/docs/build/html/configuration.html#properties>`_.
 ===================  ============================================================  ====================================================================================
 
 Note that this sink takes the Zookeeper Quorum and parent znode information in

--- a/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/AsyncHBaseSink.java
+++ b/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/AsyncHBaseSink.java
@@ -109,7 +109,7 @@ public class AsyncHBaseSink extends AbstractSink implements Configurable {
   private long batchSize;
   private static final Logger logger = LoggerFactory.getLogger(AsyncHBaseSink.class);
   private AsyncHbaseEventSerializer serializer;
-  private Config asyncClientConfig;
+  Config asyncClientConfig;
   private String eventSerializerType;
   private Context serializerContext;
   private HBaseClient client;
@@ -426,7 +426,7 @@ public class AsyncHBaseSink extends AbstractSink implements Configurable {
                            HBaseSinkConfigurationConstants.DEFAULT_MAX_CONSECUTIVE_FAILS);
 
 
-    ImmutableMap<String, String> asyncProperties
+    Map<String, String> asyncProperties
             = context.getSubProperties(HBaseSinkConfigurationConstants.ASYNC_PREFIX);
     asyncClientConfig = new Config();
     asyncClientConfig.overrideConfig(

--- a/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/AsyncHBaseSink.java
+++ b/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/AsyncHBaseSink.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.UnsignedBytes;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -109,6 +108,8 @@ public class AsyncHBaseSink extends AbstractSink implements Configurable {
   private long batchSize;
   private static final Logger logger = LoggerFactory.getLogger(AsyncHBaseSink.class);
   private AsyncHbaseEventSerializer serializer;
+
+  @VisibleForTesting
   Config asyncClientConfig;
   private String eventSerializerType;
   private Context serializerContext;

--- a/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/HBaseSinkConfigurationConstants.java
+++ b/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/HBaseSinkConfigurationConstants.java
@@ -74,4 +74,10 @@ public class HBaseSinkConfigurationConstants {
 
   public static final String CONFIG_MAX_CONSECUTIVE_FAILS = "maxConsecutiveFails";
 
+  public static final String ASYNC_PREFIX = "async.";
+
+  public static final String ASYNC_ZK_QUORUM_KEY = "hbase.zookeeper.quorum";
+
+  public static final String ASYNC_ZK_BASEPATH_KEY = "hbase.zookeeper.znode.parent";
+
 }

--- a/flume-ng-sinks/flume-ng-hbase-sink/src/test/java/org/apache/flume/sink/hbase/TestAsyncHBaseSinkConfiguration.java
+++ b/flume-ng-sinks/flume-ng-hbase-sink/src/test/java/org/apache/flume/sink/hbase/TestAsyncHBaseSinkConfiguration.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flume.sink.hbase;
+
+import org.apache.flume.Context;
+import org.apache.flume.conf.Configurables;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestAsyncHBaseSinkConfiguration {
+
+  private static final String tableName = "TestHbaseSink";
+  private static final String columnFamily = "TestColumnFamily";
+  private static Context ctx = new Context();
+
+
+  @Before
+  public void setUp() throws Exception {
+    Map<String, String> ctxMap = new HashMap<>();
+    ctxMap.put("table", tableName);
+    ctxMap.put("columnFamily", columnFamily);
+    ctx = new Context();
+    ctx.putAll(ctxMap);
+  }
+
+
+  //FLUME-3186 Make asyncHbaseClient configuration parameters available from flume config
+  @Test
+  public void testAsyncConfigBackwardCompatibility() throws Exception {
+    //Old way: zookeeperQuorum
+    String oldZkQuoriumTestValue = "old_zookeeper_quorium_test_value";
+    String oldZkZnodeParentValue = "old_zookeeper_znode_parent_test_value";
+    ctx.put(HBaseSinkConfigurationConstants.ZK_QUORUM, oldZkQuoriumTestValue);
+    ctx.put(HBaseSinkConfigurationConstants.ZK_ZNODE_PARENT,oldZkZnodeParentValue);
+    AsyncHBaseSink sink = new AsyncHBaseSink();
+    Configurables.configure(sink, ctx);
+    Assert.assertEquals(
+            oldZkQuoriumTestValue,
+            sink.asyncClientConfig.getString(HBaseSinkConfigurationConstants.ASYNC_ZK_QUORUM_KEY));
+    Assert.assertEquals(
+            oldZkZnodeParentValue,
+            sink.asyncClientConfig.getString(
+                    HBaseSinkConfigurationConstants.ASYNC_ZK_BASEPATH_KEY));
+  }
+
+  @Test
+  public void testAsyncConfigNewStyleOverwriteOldOne() throws Exception {
+    //Old way: zookeeperQuorum
+    String oldZkQuoriumTestValue = "old_zookeeper_quorium_test_value";
+    String oldZkZnodeParentValue = "old_zookeeper_znode_parent_test_value";
+    ctx.put(HBaseSinkConfigurationConstants.ZK_QUORUM, oldZkQuoriumTestValue);
+    ctx.put(HBaseSinkConfigurationConstants.ZK_ZNODE_PARENT,oldZkZnodeParentValue);
+
+    String newZkQuoriumTestValue = "new_zookeeper_quorium_test_value";
+    String newZkZnodeParentValue = "new_zookeeper_znode_parent_test_value";
+    ctx.put(
+            HBaseSinkConfigurationConstants.ASYNC_PREFIX +
+                    HBaseSinkConfigurationConstants.ASYNC_ZK_QUORUM_KEY,
+            newZkQuoriumTestValue);
+    ctx.put(
+            HBaseSinkConfigurationConstants.ASYNC_PREFIX +
+                    HBaseSinkConfigurationConstants.ASYNC_ZK_BASEPATH_KEY,
+            newZkZnodeParentValue);
+    AsyncHBaseSink sink = new AsyncHBaseSink();
+    Configurables.configure(sink, ctx);
+    Assert.assertEquals(
+            newZkQuoriumTestValue,
+            sink.asyncClientConfig.getString(HBaseSinkConfigurationConstants.ASYNC_ZK_QUORUM_KEY));
+    Assert.assertEquals(
+            newZkZnodeParentValue,
+            sink.asyncClientConfig.getString(
+                    HBaseSinkConfigurationConstants.ASYNC_ZK_BASEPATH_KEY));
+  }
+
+  @Test
+  public void testAsyncConfigAnyKeyCanBePassed() throws Exception {
+    String valueOfANewProp = "vale of the new property";
+    String keyOfANewProp = "some.key.to.be.passed";
+    ctx.put(HBaseSinkConfigurationConstants.ASYNC_PREFIX + keyOfANewProp, valueOfANewProp);
+    AsyncHBaseSink sink = new AsyncHBaseSink();
+    Configurables.configure(sink, ctx);
+    Assert.assertEquals(valueOfANewProp, sink.asyncClientConfig.getString(keyOfANewProp));
+  }
+}
+
+

--- a/flume-ng-sinks/flume-ng-hbase-sink/src/test/java/org/apache/flume/sink/hbase/TestAsyncHBaseSinkConfiguration.java
+++ b/flume-ng-sinks/flume-ng-hbase-sink/src/test/java/org/apache/flume/sink/hbase/TestAsyncHBaseSinkConfiguration.java
@@ -49,14 +49,14 @@ public class TestAsyncHBaseSinkConfiguration {
   @Test
   public void testAsyncConfigBackwardCompatibility() throws Exception {
     //Old way: zookeeperQuorum
-    String oldZkQuoriumTestValue = "old_zookeeper_quorium_test_value";
+    String oldZkQuorumTestValue = "old_zookeeper_quorum_test_value";
     String oldZkZnodeParentValue = "old_zookeeper_znode_parent_test_value";
-    ctx.put(HBaseSinkConfigurationConstants.ZK_QUORUM, oldZkQuoriumTestValue);
+    ctx.put(HBaseSinkConfigurationConstants.ZK_QUORUM, oldZkQuorumTestValue);
     ctx.put(HBaseSinkConfigurationConstants.ZK_ZNODE_PARENT,oldZkZnodeParentValue);
     AsyncHBaseSink sink = new AsyncHBaseSink();
     Configurables.configure(sink, ctx);
     Assert.assertEquals(
-            oldZkQuoriumTestValue,
+            oldZkQuorumTestValue,
             sink.asyncClientConfig.getString(HBaseSinkConfigurationConstants.ASYNC_ZK_QUORUM_KEY));
     Assert.assertEquals(
             oldZkZnodeParentValue,
@@ -67,17 +67,17 @@ public class TestAsyncHBaseSinkConfiguration {
   @Test
   public void testAsyncConfigNewStyleOverwriteOldOne() throws Exception {
     //Old way: zookeeperQuorum
-    String oldZkQuoriumTestValue = "old_zookeeper_quorium_test_value";
+    String oldZkQuorumTestValue = "old_zookeeper_quorum_test_value";
     String oldZkZnodeParentValue = "old_zookeeper_znode_parent_test_value";
-    ctx.put(HBaseSinkConfigurationConstants.ZK_QUORUM, oldZkQuoriumTestValue);
+    ctx.put(HBaseSinkConfigurationConstants.ZK_QUORUM, oldZkQuorumTestValue);
     ctx.put(HBaseSinkConfigurationConstants.ZK_ZNODE_PARENT,oldZkZnodeParentValue);
 
-    String newZkQuoriumTestValue = "new_zookeeper_quorium_test_value";
+    String newZkQuorumTestValue = "new_zookeeper_quorum_test_value";
     String newZkZnodeParentValue = "new_zookeeper_znode_parent_test_value";
     ctx.put(
             HBaseSinkConfigurationConstants.ASYNC_PREFIX +
                     HBaseSinkConfigurationConstants.ASYNC_ZK_QUORUM_KEY,
-            newZkQuoriumTestValue);
+            newZkQuorumTestValue);
     ctx.put(
             HBaseSinkConfigurationConstants.ASYNC_PREFIX +
                     HBaseSinkConfigurationConstants.ASYNC_ZK_BASEPATH_KEY,
@@ -85,7 +85,7 @@ public class TestAsyncHBaseSinkConfiguration {
     AsyncHBaseSink sink = new AsyncHBaseSink();
     Configurables.configure(sink, ctx);
     Assert.assertEquals(
-            newZkQuoriumTestValue,
+            newZkQuorumTestValue,
             sink.asyncClientConfig.getString(HBaseSinkConfigurationConstants.ASYNC_ZK_QUORUM_KEY));
     Assert.assertEquals(
             newZkZnodeParentValue,


### PR DESCRIPTION
In 1.7 version AsyncHbaseClient it is possible to pass all configuration to the constructor.
This makes it possible to pass all the parameters to this library with a specific prefix.