### PR TITLE
FLUME-3158: Upgrade surefire version and config

### DIFF
--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
@@ -103,13 +103,9 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.version}</version>
         <configuration>
           <argLine>-Dtests.locale=en_us</argLine>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
-          <systemPropertyVariables>
-            <!--<solr.expected.version>${solr.expected.version}</solr.expected.version>-->
-          </systemPropertyVariables>
         </configuration>
       </plugin>
 

--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
@@ -32,7 +32,7 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <solr.version>${solr-global.version}</solr.version>
     <solr.expected.version>${solr-global.version}</solr.expected.version> <!-- sanity check to verify we actually run against the expected version rather than some outdated version -->
-    <surefire.version>${mvn-surefire-plugin-old-morphline.version}</surefire.version>
+    <surefire.version>${mvn-surefire-plugin.version}</surefire.version>
   </properties>
 
   <dependencies>

--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
@@ -32,7 +32,6 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <solr.version>${solr-global.version}</solr.version>
     <solr.expected.version>${solr-global.version}</solr.expected.version> <!-- sanity check to verify we actually run against the expected version rather than some outdated version -->
-    <surefire.version>${mvn-surefire-plugin.version}</surefire.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -96,9 +96,7 @@ limitations under the License.
     <mvn-project-info-reports-plugin.version>2.4</mvn-project-info-reports-plugin.version>
     <mvn-site-plugin.version>3.3</mvn-site-plugin.version>
     <mvn-sphinx-plugin>1.0.2</mvn-sphinx-plugin>
-    <mvn-surefire-plugin.version>2.14.1</mvn-surefire-plugin.version>
-    <mvn-surefire-plugin-old.version>2.12.3</mvn-surefire-plugin-old.version>
-    <mvn-surefire-plugin-old-morphline.version>2.12.4</mvn-surefire-plugin-old-morphline.version>
+    <mvn-surefire-plugin.version>2.20.1</mvn-surefire-plugin.version>
     <netty.version>3.9.4.Final</netty.version>
     <protobuf.version>2.5.0</protobuf.version>
     <rat.version>0.11</rat.version>
@@ -817,9 +815,11 @@ limitations under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${mvn-surefire-plugin-old.version}</version>
+          <version>${mvn-surefire-plugin.version}</version>
           <configuration>
-            <forkMode>always</forkMode>
+            <reuseForks>false</reuseForks>
+            <forkCount>1</forkCount>
+            <rerunFailingTestsCount>10</rerunFailingTestsCount>
             <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <includes>


### PR DESCRIPTION
Set surefire version to the latest and configure it to rerun failed tests. This way the flaky tests will not break the build as often.

Tests I did: building Flume locally, and running unit tests on server environments.
