### PR TITLE
FLUME-3199 Update netty to latest 3.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ limitations under the License.
     <mvn-site-plugin.version>3.3</mvn-site-plugin.version>
     <mvn-sphinx-plugin>1.0.2</mvn-sphinx-plugin>
     <mvn-surefire-plugin.version>2.20.1</mvn-surefire-plugin.version>
-    <netty.version>3.9.4.Final</netty.version>
+    <netty.version>3.10.6.Final</netty.version>
     <protobuf.version>2.5.0</protobuf.version>
     <rat.version>0.11</rat.version>
     <snappy-java.version>1.1.4</snappy-java.version>


### PR DESCRIPTION
With this change I would upgrade netty to latest 3.x version.

The netty-all 4.x upgrade requires the rewriting of NettyAvroRpcClient class which could be next step.
The current version (3.9.4) has known vulnerability:
[CVE-2015-2156](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2156)

Unit tests passed.