### PR TITLE
FLUME-2957. Remove Guava from our public API

### DIFF
--- a/flume-ng-configuration/src/main/java/org/apache/flume/Context.java
+++ b/flume-ng-configuration/src/main/java/org/apache/flume/Context.java
@@ -48,8 +48,9 @@ public class Context {
    * Gets a copy of the backing map structure.
    * @return immutable copy of backing map structure
    */
-  public ImmutableMap<String, String> getParameters() {
+  public Map<String, String> getParameters() {
     synchronized (parameters) {
+
       return ImmutableMap.copyOf(parameters);
     }
   }
@@ -82,7 +83,7 @@ public class Context {
    * @throws IllegalArguemntException if the given prefix does not end with
    *   a period character.
    */
-  public ImmutableMap<String, String> getSubProperties(String prefix) {
+  public Map<String, String> getSubProperties(String prefix) {
     Preconditions.checkArgument(prefix.endsWith("."),
         "The given prefix does not end with a period (" + prefix + ")");
     Map<String, String> result = Maps.newHashMap();

--- a/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
@@ -20,7 +20,6 @@ package org.apache.flume.source;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -113,7 +112,7 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
     // clear any previous charset configuration and reconfigure it
     portCharsets.clear();
     {
-      ImmutableMap<String, String> portCharsetCfg = context.getSubProperties(
+      Map<String, String> portCharsetCfg = context.getSubProperties(
           SyslogSourceConfigurationConstants.CONFIG_PORT_CHARSET_PREFIX);
       for (Map.Entry<String, String> entry : portCharsetCfg.entrySet()) {
         String portStr = entry.getKey();

--- a/flume-ng-embedded-agent/src/test/java/org/apache/flume/agent/embedded/TestEmbeddedAgentEmbeddedSource.java
+++ b/flume-ng-embedded-agent/src/test/java/org/apache/flume/agent/embedded/TestEmbeddedAgentEmbeddedSource.java
@@ -75,21 +75,21 @@ public class TestEmbeddedAgentEmbeddedSource {
 
     config = new MaterializedConfiguration() {
       @Override
-      public ImmutableMap<String, SourceRunner> getSourceRunners() {
+      public Map<String, SourceRunner> getSourceRunners() {
         Map<String, SourceRunner> result = Maps.newHashMap();
         result.put("source", sourceRunner);
         return ImmutableMap.copyOf(result);
       }
 
       @Override
-      public ImmutableMap<String, SinkRunner> getSinkRunners() {
+      public Map<String, SinkRunner> getSinkRunners() {
         Map<String, SinkRunner> result = Maps.newHashMap();
         result.put("sink", sinkRunner);
         return ImmutableMap.copyOf(result);
       }
 
       @Override
-      public ImmutableMap<String, Channel> getChannels() {
+      public Map<String, Channel> getChannels() {
         Map<String, Channel> result = Maps.newHashMap();
         result.put("channel", channel);
         return ImmutableMap.copyOf(result);

--- a/flume-ng-node/src/main/java/org/apache/flume/node/MaterializedConfiguration.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/MaterializedConfiguration.java
@@ -23,7 +23,7 @@ import org.apache.flume.Channel;
 import org.apache.flume.SinkRunner;
 import org.apache.flume.SourceRunner;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 
 /**
  * MaterializedConfiguration represents the materialization of a Flume
@@ -38,10 +38,10 @@ public interface MaterializedConfiguration {
 
   public void addChannel(String name, Channel channel);
 
-  public ImmutableMap<String, SourceRunner> getSourceRunners();
+  public Map<String, SourceRunner> getSourceRunners();
 
-  public ImmutableMap<String, SinkRunner> getSinkRunners();
+  public Map<String, SinkRunner> getSinkRunners();
 
-  public ImmutableMap<String, Channel> getChannels();
+  public Map<String, Channel> getChannels();
 
 }

--- a/flume-ng-node/src/main/java/org/apache/flume/node/SimpleMaterializedConfiguration.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/SimpleMaterializedConfiguration.java
@@ -61,17 +61,17 @@ public class SimpleMaterializedConfiguration implements MaterializedConfiguratio
   }
 
   @Override
-  public ImmutableMap<String, Channel> getChannels() {
+  public Map<String, Channel> getChannels() {
     return ImmutableMap.copyOf(channels);
   }
 
   @Override
-  public ImmutableMap<String, SourceRunner> getSourceRunners() {
+  public Map<String, SourceRunner> getSourceRunners() {
     return ImmutableMap.copyOf(sourceRunners);
   }
 
   @Override
-  public ImmutableMap<String, SinkRunner> getSinkRunners() {
+  public Map<String, SinkRunner> getSinkRunners() {
     return ImmutableMap.copyOf(sinkRunners);
   }
 

--- a/flume-ng-sinks/flume-http-sink/src/main/java/org/apache/flume/sink/http/HttpSink.java
+++ b/flume-ng-sinks/flume-http-sink/src/main/java/org/apache/flume/sink/http/HttpSink.java
@@ -18,7 +18,6 @@
  */
 package org.apache.flume.sink.http;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
@@ -323,7 +322,7 @@ public class HttpSink extends AbstractSink implements Configurable {
                                     final Context context,
                                     final Map<String, Boolean> override) {
 
-    ImmutableMap<String, String> config = context.getSubProperties(
+    Map<String, String> config = context.getSubProperties(
         propertyName + ".");
 
     if (config != null) {


### PR DESCRIPTION
The only Guava class used in public API is the `ImmutableMap` in the `org.apache.flume.Context`, `org.apache.flume.node.MaterializedConfiguration` and `org.apache.flume.node.SimpleMaterializedConfiguration` classes.

This commit replaces these with `java.util.Map`.

Note: this is a breaking change as it modifies the return type of a method on a public interface.