### PR TITLE
Refactor ConfigurationProviders

### DIFF
--- a/flume-ng-node/src/main/java/org/apache/flume/node/ConfigurationProvider.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/ConfigurationProvider.java
@@ -19,6 +19,15 @@
 
 package org.apache.flume.node;
 
-public interface ConfigurationProvider {
-  MaterializedConfiguration getConfiguration();
+import org.apache.flume.lifecycle.LifecycleAware;
+
+import java.util.function.Consumer;
+
+public interface ConfigurationProvider extends LifecycleAware {
+  /**
+   * Registers a MaterializedConfiguration Consumer that will be notified when
+   * this ConfigurationProvider finds new configuration.
+   */
+  void registerConfigurationConsumer(Consumer<MaterializedConfiguration> configurationConsumer);
+
 }

--- a/flume-ng-node/src/main/java/org/apache/flume/node/PollingPropertiesFileConfigurationProvider.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/PollingPropertiesFileConfigurationProvider.java
@@ -21,40 +21,39 @@ import java.io.File;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import org.apache.flume.CounterGroup;
-import org.apache.flume.lifecycle.LifecycleAware;
-import org.apache.flume.lifecycle.LifecycleState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 public class PollingPropertiesFileConfigurationProvider
-    extends PropertiesFileConfigurationProvider
-    implements LifecycleAware {
+    extends PropertiesFileConfigurationProvider {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PollingPropertiesFileConfigurationProvider.class);
 
-  private final EventBus eventBus;
   private final File file;
   private final int interval;
   private final CounterGroup counterGroup;
-  private LifecycleState lifecycleState;
 
   private ScheduledExecutorService executorService;
 
   public PollingPropertiesFileConfigurationProvider(String agentName,
-      File file, EventBus eventBus, int interval) {
+      File file, int interval) {
     super(agentName, file);
-    this.eventBus = eventBus;
     this.file = file;
     this.interval = interval;
     counterGroup = new CounterGroup();
-    lifecycleState = LifecycleState.IDLE;
+  }
+
+  @Override
+  public void registerConfigurationConsumer(
+          Consumer<MaterializedConfiguration> configurationConsumer) {
+    setConfigurationConsumer(configurationConsumer);
   }
 
   @Override
@@ -74,7 +73,7 @@ public class PollingPropertiesFileConfigurationProvider
     executorService.scheduleWithFixedDelay(fileWatcherRunnable, 0, interval,
         TimeUnit.SECONDS);
 
-    lifecycleState = LifecycleState.START;
+    super.start();
 
     LOGGER.debug("Configuration provider started");
   }
@@ -96,15 +95,9 @@ public class PollingPropertiesFileConfigurationProvider
       LOGGER.debug("Interrupted while waiting for file watcher to terminate");
       Thread.currentThread().interrupt();
     }
-    lifecycleState = LifecycleState.STOP;
+    super.stop();
     LOGGER.debug("Configuration provider stopped");
   }
-
-  @Override
-  public synchronized  LifecycleState getLifecycleState() {
-    return lifecycleState;
-  }
-
 
   @Override
   public String toString() {
@@ -142,7 +135,7 @@ public class PollingPropertiesFileConfigurationProvider
         lastChange = lastModified;
 
         try {
-          eventBus.post(getConfiguration());
+          notifyConfigurationConsumer(getConfiguration());
         } catch (Exception e) {
           LOGGER.error("Failed to load configuration data. Exception follows.",
               e);

--- a/flume-ng-node/src/test/java/org/apache/flume/node/TestAbstractConfigurationProvider.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/node/TestAbstractConfigurationProvider.java
@@ -35,6 +35,11 @@ import org.apache.flume.source.AbstractSource;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class TestAbstractConfigurationProvider {
 
@@ -183,6 +188,22 @@ public class TestAbstractConfigurationProvider {
     Assert.assertTrue(config.getSourceRunners().size() == 0);
     Assert.assertTrue(config.getChannels().size() == 0);
     Assert.assertTrue(config.getSinkRunners().size() == 0);
+  }
+
+  @Test
+  public void testRegisterConfigurationConsumer() {
+    String agentName = "agent1";
+    String sourceType = "seq";
+    String channelType = "memory";
+    String sinkType = "null";
+    Map<String, String> properties = getProperties(agentName, sourceType,
+            channelType, sinkType);
+    MemoryConfigurationProvider provider =
+            new MemoryConfigurationProvider(agentName, properties);
+    @SuppressWarnings("unchecked")
+    Consumer<MaterializedConfiguration> mockConfigurationConsumer = mock(Consumer.class);
+    provider.registerConfigurationConsumer(mockConfigurationConsumer);
+    verify(mockConfigurationConsumer).accept(any(MaterializedConfiguration.class));
   }
 
   private Map<String, String> getProperties(String agentName,

--- a/flume-ng-node/src/test/java/org/apache/flume/node/TestApplication.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/node/TestApplication.java
@@ -109,13 +109,8 @@ public class TestApplication {
     Channel channel = mockLifeCycle(Channel.class);
     materializedConfiguration.addChannel("test", channel);
 
-
-    ConfigurationProvider configurationProvider = mock(ConfigurationProvider.class);
-    when(configurationProvider.getConfiguration()).thenReturn(materializedConfiguration);
-
     Application application = new Application();
-    eventBus.register(application);
-    eventBus.post(materializedConfiguration);
+    application.handleConfigurationEvent(materializedConfiguration);
     application.start();
 
     Thread.sleep(1000L);
@@ -140,14 +135,13 @@ public class TestApplication {
         .getResource("flume-conf.properties").getFile()), configFile);
     Random random = new Random();
     for (int i = 0; i < 3; i++) {
-      EventBus eventBus = new EventBus("test-event-bus");
       PollingPropertiesFileConfigurationProvider configurationProvider =
           new PollingPropertiesFileConfigurationProvider("host1",
-              configFile, eventBus, 1);
+              configFile, 1);
       List<LifecycleAware> components = Lists.newArrayList();
       components.add(configurationProvider);
       Application application = new Application(components);
-      eventBus.register(application);
+      configurationProvider.registerConfigurationConsumer(application::handleConfigurationEvent);
       application.start();
       Thread.sleep(random.nextInt(10000));
       application.stop();

--- a/flume-ng-node/src/test/java/org/apache/flume/node/TestApplication.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/node/TestApplication.java
@@ -169,7 +169,7 @@ public class TestApplication {
     EventBus eventBus = new EventBus(agentName + "-event-bus");
     PollingPropertiesFileConfigurationProvider configurationProvider =
         new PollingPropertiesFileConfigurationProvider(agentName,
-            mockConfigFile, eventBus, interval);
+            mockConfigFile, interval);
     PollingPropertiesFileConfigurationProvider mockConfigurationProvider =
         spy(configurationProvider);
     doAnswer(new Answer<Void>() {
@@ -184,7 +184,7 @@ public class TestApplication {
     List<LifecycleAware> components = Lists.newArrayList();
     components.add(mockConfigurationProvider);
     Application application = new Application(components);
-    eventBus.register(application);
+    mockConfigurationProvider.registerConfigurationConsumer(application::handleConfigurationEvent);
     application.start();
     Thread.sleep(1500L);
     application.stop();


### PR DESCRIPTION
Refactor ConfigurationProviders so

- they can be handled uniformly from Application
- they fit the push model better
- EventBus is unneccessary

Also  make TestPollingZooKeeperConfigurationProvider.EventSync.notified volatile