### PR TITLE
【乱码问题】characters are not displayed properly____execSource.java

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/ExecSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/ExecSource.java
@@ -333,7 +333,7 @@ public class ExecSource extends AbstractSource implements EventDrivenSource, Con
           while ((line = reader.readLine()) != null) {
             sourceCounter.incrementEventReceivedCount();
             synchronized (eventList) {
-              eventList.add(EventBuilder.withBody(line.getBytes(charset)));
+              eventList.add(EventBuilder.withBody(line.getBytes("UTF-8")));
               if (eventList.size() >= bufferCount || timeout()) {
                 flushEventBatch(eventList);
               }


### PR DESCRIPTION
I hope to confirm the following questions:
      When I use execSource to get data to elasticsearchSink:
      The source uses the "GBK" encoding, and the data on the es side will be garbled.
I think:
        When the exec source configuration code is "GBK", the data should be encoded as "UTF-8" after reading the data, because the elasticsearchSink side does not have a code configuration. So I made the following changes to execSource.java in my personal use:
        eventList.add(EventBuilder.withBody(line.getBytes("UTF-8")));
--------------------------------------------------------------------------------------------英文表达不清楚的话，以下是汉语原文
我在使用execSource获取数据到elasticsearchSink时：
source使用“GBK”编码，es端的数据会乱码。
我认为：
       exec源端配置编码为“GBK”时，在读取到数据以后应该将数据编码为"UTF-8"，因为elasticsearchSink端并没有编码配置。所以我在个人使用中将execSource.java作出以下修改：
       eventList.add(EventBuilder.withBody(line.getBytes("UTF-8")));