### PR TITLE
FLUME-2956 - hive sink not sending heartbeat correctly

### DIFF
--- a/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
+++ b/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
@@ -254,6 +254,9 @@ public class HiveSink extends AbstractSink implements Configurable {
       transaction.commit();
       success = true;
 
+      // & close idle writers
+      closeIdleWriters();
+      
       // 3 Update Counters
       if (txnEventCount < 1) {
         return Status.BACKOFF;

--- a/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
+++ b/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
@@ -312,13 +312,13 @@ public class HiveSink extends AbstractSink implements Configurable {
 
 
       // 5) Flush all Writers
-      for (HiveWriter writer : activeWriters.values()) {
-        writer.flush(true);
+      for (HiveWriter writer : allWriters.values()) {
+        writer.flush(activeWriters.containsValue(writer));
       }
 
       sinkCounter.addToEventDrainSuccessCount(txnEventCount);
       return txnEventCount;
-    } catch (HiveWriter.Failure e) {
+    } catch (Exception e) {
       // in case of error we close all TxnBatches to start clean next time
       LOG.warn(getName() + " : " + e.getMessage(), e);
       abortAllWriters();
@@ -438,7 +438,13 @@ public class HiveSink extends AbstractSink implements Configurable {
   private void closeAllWriters() throws InterruptedException {
     //1) Retire writers
     for (Entry<HiveEndPoint,HiveWriter> entry : allWriters.entrySet()) {
-      entry.getValue().close();
+      try {
+        entry.getValue().close();
+      } catch (InterruptedException err) {
+        throw err;
+      } catch (Throwable t) {
+        LOG.warn(getName() + ": threw at closing writer", t);
+      }
     }
 
     //2) Clear cache
@@ -451,7 +457,13 @@ public class HiveSink extends AbstractSink implements Configurable {
    */
   private void abortAllWriters() throws InterruptedException {
     for (Entry<HiveEndPoint,HiveWriter> entry : allWriters.entrySet()) {
-      entry.getValue().abort();
+      try {
+        entry.getValue().abort();
+      } catch (InterruptedException err) {
+        throw err;
+      } catch (Throwable t) {
+        LOG.warn(getName() + ": threw at aborting writer", t);
+      }
     }
   }
 

--- a/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
+++ b/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
@@ -58,7 +58,7 @@ public class HiveSink extends AbstractSink implements Configurable {
   private static final int DEFAULT_TXNSPERBATCH = 100;
   private static final int DEFAULT_BATCHSIZE = 15000;
   private static final int DEFAULT_CALLTIMEOUT = 10000;
-  private static final int DEFAULT_IDLETIMEOUT = 0;
+  private static final int DEFAULT_IDLETIMEOUT = 10000;
   private static final int DEFAULT_HEARTBEATINTERVAL = 240; // seconds
 
   private Map<HiveEndPoint, HiveWriter> allWriters;

--- a/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveWriter.java
+++ b/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveWriter.java
@@ -200,11 +200,10 @@ class HiveWriter {
     
     try {
       //1 commit txn & close batch if needed
-      commitTxn();
-      if (txnBatch.remainingTransactions() == 0) {
-        closeTxnBatch();
-        txnBatch = null;
-        if (rollToNext) {
+      if (rollToNext) {
+        commitTxn();
+        if (txnBatch.remainingTransactions() == 0) {
+          closeTxnBatch();
           txnBatch = nextTxnBatch(recordWriter);
         }
       }

--- a/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveWriter.java
+++ b/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveWriter.java
@@ -192,8 +192,12 @@ class HiveWriter {
       hearbeatNeeded = false;
       heartBeat();
     }
-    lastUsed = System.currentTimeMillis();
 
+    // update lastUsed only if something written
+    if (rollToNext) {
+      lastUsed = System.currentTimeMillis();
+    }
+    
     try {
       //1 commit txn & close batch if needed
       commitTxn();

--- a/flume-ng-sinks/flume-hive-sink/src/test/java/org/apache/flume/sink/hive/TestHiveWriter.java
+++ b/flume-ng-sinks/flume-hive-sink/src/test/java/org/apache/flume/sink/hive/TestHiveWriter.java
@@ -134,7 +134,7 @@ public class TestHiveWriter {
                                        serializer, sinkCounter);
 
     writeEvents(writer,3);
-    writer.flush(false);
+    writer.flush(true);
     writer.close();
     checkRecordCountInTable(3);
   }
@@ -240,7 +240,7 @@ public class TestHiveWriter {
     writer.write(event);
     event.setBody("3,Hello world 3".getBytes());
     writer.write(event);
-    writer.flush(false);
+    writer.flush(true);
     writer.close();
   }
 
@@ -302,9 +302,9 @@ public class TestHiveWriter {
     HiveWriter writer2 = new HiveWriter(endPoint2, 10, true, timeout, callTimeoutPool, "flumetest",
                                         serializer, sinkCounter2);
     writeEvents(writer2, 3);
-    writer2.flush(false); // commit
+    writer2.flush(true); // commit
 
-    writer1.flush(false); // commit
+    writer1.flush(true); // commit
     writer1.close();
 
     writer2.close();
@@ -327,13 +327,13 @@ public class TestHiveWriter {
 
     writeEvents(writer1, 3);
 
-    writer1.flush(false); // commit
+    writer1.flush(true); // commit
 
 
     HiveWriter writer2 = new HiveWriter(endPoint2, 10, true, timeout, callTimeoutPool, "flumetest",
                                         serializer, sinkCounter2);
     writeEvents(writer2, 3);
-    writer2.flush(false); // commit
+    writer2.flush(true); // commit
 
 
     writer1.close();


### PR DESCRIPTION
1. flush all writers to make sure heartbeats are sent on inactive ones
2. catch any throwable  in abortAllWriters and closeAllWriters to guarantee nothing left in allWriters map