### PR TITLE
FLUME-3246 Validate flume configuration to prevent larger source batc…

### DIFF
--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
@@ -40,6 +40,7 @@ import org.apache.flume.channel.file.encryption.EncryptionConfiguration;
 import org.apache.flume.channel.file.encryption.KeyProvider;
 import org.apache.flume.channel.file.encryption.KeyProviderFactory;
 import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
+import org.apache.flume.conf.TransactionCapacitySupported;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,7 +74,7 @@ import java.util.concurrent.TimeUnit;
 @InterfaceAudience.Private
 @InterfaceStability.Stable
 @Disposable
-public class FileChannel extends BasicChannelSemantics {
+public class FileChannel extends BasicChannelSemantics implements TransactionCapacitySupported {
 
   private static final Logger LOG = LoggerFactory.getLogger(FileChannel.class);
 
@@ -442,6 +443,11 @@ public class FileChannel extends BasicChannelSemantics {
   @VisibleForTesting
   FileChannelCounter getChannelCounter() {
     return channelCounter;
+  }
+
+  @Override
+  public long getTransactionCapacity() {
+    return transactionCapacity;
   }
 
   /**

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
@@ -27,6 +27,7 @@ import org.apache.flume.Event;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.annotations.Recyclable;
+import org.apache.flume.conf.TransactionCapacitySupported;
 import org.apache.flume.instrumentation.ChannelCounter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +51,7 @@ import java.util.concurrent.TimeUnit;
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 @Recyclable
-public class MemoryChannel extends BasicChannelSemantics {
+public class MemoryChannel extends BasicChannelSemantics implements TransactionCapacitySupported {
   private static Logger LOGGER = LoggerFactory.getLogger(MemoryChannel.class);
   private static final Integer defaultCapacity = 100;
   private static final Integer defaultTransCapacity = 100;
@@ -378,5 +379,9 @@ public class MemoryChannel extends BasicChannelSemantics {
   @VisibleForTesting
   int getBytesRemainingValue() {
     return bytesRemaining.availablePermits();
+  }
+
+  public long getTransactionCapacity() {
+    return transCapacity;
   }
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/conf/BatchSizeSupported.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/conf/BatchSizeSupported.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flume.conf;
+
+/**
+ * This interface indicates that a component does batching and the batch size
+ * is publicly available.
+ *
+ */
+public interface BatchSizeSupported {
+
+  /**
+   * Returns the batch size
+   */
+  long getBatchSize();
+
+}

--- a/flume-ng-core/src/main/java/org/apache/flume/conf/TransactionCapacitySupported.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/conf/TransactionCapacitySupported.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flume.conf;
+
+/**
+ * This interface indicates that a component has a transaction capacity
+ * and it is publicly available.
+ *
+ */
+public interface TransactionCapacitySupported {
+
+  /**
+   * Returns the transaction capacity
+   */
+  long getTransactionCapacity();
+
+}

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/AbstractRpcSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/AbstractRpcSink.java
@@ -158,6 +158,9 @@ public abstract class AbstractRpcSink extends AbstractSink implements Configurab
   private final ScheduledExecutorService cxnResetExecutor =
       Executors.newSingleThreadScheduledExecutor(
           new ThreadFactoryBuilder().setNameFormat("Rpc Sink Reset Thread").build());
+
+  // batchSize is used in the clients, here it is only used for config validation
+  // before the client is configured
   private int batchSize;
 
 

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/NullSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/NullSink.java
@@ -25,6 +25,7 @@ import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Sink;
 import org.apache.flume.Transaction;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * TODO
  * </p>
  */
-public class NullSink extends AbstractSink implements Configurable {
+public class NullSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
   private static final Logger logger = LoggerFactory.getLogger(NullSink.class);
 
@@ -135,6 +136,11 @@ public class NullSink extends AbstractSink implements Configurable {
   @Override
   public String toString() {
     return "NullSink " + getName() + " { batchSize: " + batchSize + " }";
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
@@ -31,6 +31,7 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Transaction;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.formatter.output.PathManager;
 import org.apache.flume.formatter.output.PathManagerFactory;
@@ -43,7 +44,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.flume.serialization.EventSerializer;
 import org.apache.flume.serialization.EventSerializerFactory;
 
-public class RollingFileSink extends AbstractSink implements Configurable {
+public class RollingFileSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
   private static final Logger logger = LoggerFactory
       .getLogger(RollingFileSink.class);
@@ -283,4 +284,8 @@ public class RollingFileSink extends AbstractSink implements Configurable {
     this.rollInterval = rollInterval;
   }
 
+  @Override
+  public long getBatchSize() {
+    return batchSize;
+  }
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/ExecSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/ExecSource.java
@@ -38,6 +38,7 @@ import org.apache.flume.EventDrivenSource;
 import org.apache.flume.Source;
 import org.apache.flume.SystemClock;
 import org.apache.flume.channel.ChannelProcessor;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.instrumentation.SourceCounter;
@@ -146,7 +147,8 @@ import java.nio.charset.Charset;
  * TODO
  * </p>
  */
-public class ExecSource extends AbstractSource implements EventDrivenSource, Configurable {
+public class ExecSource extends AbstractSource implements EventDrivenSource, Configurable,
+        BatchSizeSupported {
 
   private static final Logger logger = LoggerFactory.getLogger(ExecSource.class);
 
@@ -246,6 +248,11 @@ public class ExecSource extends AbstractSource implements EventDrivenSource, Con
     if (sourceCounter == null) {
       sourceCounter = new SourceCounter(getName());
     }
+  }
+
+  @Override
+  public long getBatchSize() {
+    return bufferCount;
   }
 
   private static class ExecRunnable implements Runnable {

--- a/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
@@ -34,6 +34,7 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDrivenSource;
 import org.apache.flume.channel.ChannelProcessor;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.conf.LogPrivacyUtil;
 import org.apache.flume.event.EventBuilder;
@@ -50,7 +51,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class MultiportSyslogTCPSource extends AbstractSource implements
-        EventDrivenSource, Configurable {
+        EventDrivenSource, Configurable, BatchSizeSupported {
 
   public static final Logger logger = LoggerFactory.getLogger(
           MultiportSyslogTCPSource.class);
@@ -206,6 +207,11 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
   @Override
   public String toString() {
     return "Multiport Syslog TCP source " + getName();
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 
   static class MultiportSyslogHandler extends IoHandlerAdapter {

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SequenceGeneratorSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SequenceGeneratorSource.java
@@ -25,6 +25,7 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.FlumeException;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.instrumentation.SourceCounter;
@@ -35,7 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SequenceGeneratorSource extends AbstractPollableSource implements
-        Configurable {
+        Configurable, BatchSizeSupported {
 
   private static final Logger logger = LoggerFactory
       .getLogger(SequenceGeneratorSource.class);
@@ -114,4 +115,8 @@ public class SequenceGeneratorSource extends AbstractPollableSource implements
     logger.info("Sequence generator source do stopped. Metrics:{}",getName(), sourceCounter);
   }
 
+  @Override
+  public long getBatchSize() {
+    return batchSize;
+  }
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
@@ -27,6 +27,7 @@ import org.apache.flume.Event;
 import org.apache.flume.EventDrivenSource;
 import org.apache.flume.FlumeException;
 import org.apache.flume.client.avro.ReliableSpoolingFileEventReader;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.serialization.DecodeErrorPolicy;
@@ -45,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.flume.source.SpoolDirectorySourceConfigurationConstants.*;
 
 public class SpoolDirectorySource extends AbstractSource
-    implements Configurable, EventDrivenSource {
+    implements Configurable, EventDrivenSource, BatchSizeSupported {
 
   private static final Logger logger = LoggerFactory.getLogger(SpoolDirectorySource.class);
 
@@ -230,6 +231,11 @@ public class SpoolDirectorySource extends AbstractSource
   @VisibleForTesting
   protected boolean getRecursiveDirectorySearch() {
     return recursiveDirectorySearch;
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 
   private class SpoolDirectoryRunnable implements Runnable {

--- a/flume-ng-core/src/main/java/org/apache/flume/source/StressSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/StressSource.java
@@ -29,6 +29,7 @@ import org.apache.flume.CounterGroup;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.FlumeException;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.event.EventBuilder;
 import org.slf4j.Logger;
@@ -53,7 +54,8 @@ import org.slf4j.LoggerFactory;
  *
  * See {@link StressSource#configure(Context)} for configuration options.
  */
-public class StressSource extends AbstractPollableSource implements Configurable {
+public class StressSource extends AbstractPollableSource
+        implements Configurable, BatchSizeSupported {
 
   private static final Logger logger = LoggerFactory.getLogger(StressSource.class);
 
@@ -152,5 +154,10 @@ public class StressSource extends AbstractPollableSource implements Configurable
   @Override
   protected void doStop() throws FlumeException {
     logger.info("Stress source do stop. Metrics:{}", counterGroup);
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 }

--- a/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
@@ -23,6 +23,7 @@ import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
+import org.apache.flume.Transaction;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.channel.PseudoTxnMemoryChannel;
 import org.apache.flume.conf.Configurables;
@@ -280,6 +281,48 @@ public class TestRollingFileSink {
     File[] files = dir.listFiles();
     for (File file : files) {
       file.delete();
+    }
+  }
+
+  /**
+   * This test is to reproduce batch size and
+   * transaction capacity related configuration
+   * problems
+   */
+  @Test(expected = EventDeliveryException.class)
+  public void testTrans() throws EventDeliveryException {
+
+    Context context = new Context();
+
+    context.put("sink.directory", tmpDir.getPath());
+    context.put("sink.rollInterval", "0");
+    context.put("sink.batchSize", "1000");
+
+    Configurables.configure(sink, context);
+
+    context.put("capacity", "50");
+    context.put("transactionCapacity", "5");
+    Channel channel = new MemoryChannel();
+    Configurables.configure(channel, context);
+
+    sink.setChannel(channel);
+    sink.start();
+
+    try {
+      for (int j = 0; j < 10; j++) {
+        Transaction tx = channel.getTransaction();
+        tx.begin();
+        for (int i = 0; i < 5; i++) {
+          Event event = new SimpleEvent();
+          event.setBody(("Test event " + i).getBytes());
+          channel.put(event);
+        }
+        tx.commit();
+        tx.close();
+      }
+      sink.process();
+    } finally {
+      sink.stop();
     }
   }
 }

--- a/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
@@ -290,7 +290,7 @@ public class TestRollingFileSink {
    * problems
    */
   @Test(expected = EventDeliveryException.class)
-  public void testTrans() throws EventDeliveryException {
+  public void testTransCapBatchSizeCompatibility() throws EventDeliveryException {
 
     Context context = new Context();
 

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -2432,7 +2432,7 @@ sink.pathManager.extension  --       The file extension if the default PathManag
 sink.pathManager.prefix     --       A character string to add to the beginning of the file name if the default PathManager is used
 sink.rollInterval           30       Roll the file every 30 seconds. Specifying 0 will disable rolling and cause all events to be written to a single file.
 sink.serializer             TEXT     Other possible options include ``avro_event`` or the FQCN of an implementation of EventSerializer.Builder interface.
-batchSize                   100
+sink.batchSize              100
 ==========================  =======  ======================================================================================================================
 
 Example for agent named a1:

--- a/flume-ng-node/src/main/java/org/apache/flume/node/AbstractConfigurationProvider.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/AbstractConfigurationProvider.java
@@ -359,17 +359,13 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
   }
 
   private List<Channel> getSourceChannels(Map<String, ChannelComponent> channelComponentMap,
-                                          Source source, Collection<String> channelNames) {
+                  Source source, Collection<String> channelNames) throws InstantiationException {
     List<Channel> sourceChannels = new ArrayList<Channel>();
     for (String chName : channelNames) {
       ChannelComponent channelComponent = channelComponentMap.get(chName);
       if (channelComponent != null) {
-        try {
-          checkSourceChannelCompatibility(source, channelComponent.channel);
-          sourceChannels.add(channelComponent.channel);
-        } catch (InstantiationException e) {
-          LOGGER.error("Source - channel compatibility problem", e);
-        }
+        checkSourceChannelCompatibility(source, channelComponent.channel);
+        sourceChannels.add(channelComponent.channel);
       }
     }
     return sourceChannels;

--- a/flume-ng-node/src/test/java/org/apache/flume/node/TestAbstractConfigurationProvider.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/node/TestAbstractConfigurationProvider.java
@@ -185,6 +185,36 @@ public class TestAbstractConfigurationProvider {
     Assert.assertTrue(config.getSinkRunners().size() == 0);
   }
 
+  @Test
+  public void testSinkSourceMismatchDuringConfiguration() throws Exception {
+    String agentName = "agent1";
+    String sourceType = "seq";
+    String channelType = "memory";
+    String sinkType = "avro";
+    Map<String, String> properties = getProperties(agentName, sourceType,
+        channelType, sinkType);
+    properties.put(agentName + ".sources.source1.batchSize", "100");
+    properties.put(agentName + ".sinks.sink1.batch-size", "100");
+    properties.put(agentName + ".sinks.sink1.hostname", "10.10.10.10");
+    properties.put(agentName + ".sinks.sink1.port", "1010");
+
+    MemoryConfigurationProvider provider =
+        new MemoryConfigurationProvider(agentName, properties);
+    MaterializedConfiguration config = provider.getConfiguration();
+    Assert.assertTrue(config.getSourceRunners().size() == 1);
+    Assert.assertTrue(config.getChannels().size() == 1);
+    Assert.assertTrue(config.getSinkRunners().size() == 1);
+
+    properties.put(agentName + ".sources.source1.batchSize", "1001");
+    properties.put(agentName + ".sinks.sink1.batch-size", "1001");
+
+    provider = new MemoryConfigurationProvider(agentName, properties);
+    config = provider.getConfiguration();
+    Assert.assertTrue(config.getSourceRunners().size() == 0);
+    Assert.assertTrue(config.getChannels().size() == 0);
+    Assert.assertTrue(config.getSinkRunners().size() == 0);
+  }
+
   private Map<String, String> getProperties(String agentName,
                                             String sourceType, String channelType,
                                             String sinkType) {

--- a/flume-ng-node/src/test/java/org/apache/flume/node/TestAbstractConfigurationProvider.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/node/TestAbstractConfigurationProvider.java
@@ -193,8 +193,10 @@ public class TestAbstractConfigurationProvider {
     String sinkType = "avro";
     Map<String, String> properties = getProperties(agentName, sourceType,
         channelType, sinkType);
-    properties.put(agentName + ".sources.source1.batchSize", "100");
-    properties.put(agentName + ".sinks.sink1.batch-size", "100");
+    properties.put(agentName + ".channels.channel1.capacity", "1000");
+    properties.put(agentName + ".channels.channel1.transactionCapacity", "1000");
+    properties.put(agentName + ".sources.source1.batchSize", "1000");
+    properties.put(agentName + ".sinks.sink1.batch-size", "1000");
     properties.put(agentName + ".sinks.sink1.hostname", "10.10.10.10");
     properties.put(agentName + ".sinks.sink1.port", "1010");
 
@@ -204,6 +206,24 @@ public class TestAbstractConfigurationProvider {
     Assert.assertTrue(config.getSourceRunners().size() == 1);
     Assert.assertTrue(config.getChannels().size() == 1);
     Assert.assertTrue(config.getSinkRunners().size() == 1);
+
+    properties.put(agentName + ".sources.source1.batchSize", "1001");
+    properties.put(agentName + ".sinks.sink1.batch-size", "1000");
+
+    provider = new MemoryConfigurationProvider(agentName, properties);
+    config = provider.getConfiguration();
+    Assert.assertTrue(config.getSourceRunners().size() == 0);
+    Assert.assertTrue(config.getChannels().size() == 1);
+    Assert.assertTrue(config.getSinkRunners().size() == 1);
+
+    properties.put(agentName + ".sources.source1.batchSize", "1000");
+    properties.put(agentName + ".sinks.sink1.batch-size", "1001");
+
+    provider = new MemoryConfigurationProvider(agentName, properties);
+    config = provider.getConfiguration();
+    Assert.assertTrue(config.getSourceRunners().size() == 1);
+    Assert.assertTrue(config.getChannels().size() == 1);
+    Assert.assertTrue(config.getSinkRunners().size() == 0);
 
     properties.put(agentName + ".sources.source1.batchSize", "1001");
     properties.put(agentName + ".sinks.sink1.batch-size", "1001");

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/AbstractRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/AbstractRpcClient.java
@@ -24,8 +24,11 @@ import java.util.Properties;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.FlumeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractRpcClient implements RpcClient {
+  private static Logger logger = LoggerFactory.getLogger(AbstractRpcClient.class);
 
   protected int batchSize =
       RpcClientConfigurationConstants.DEFAULT_BATCH_SIZE;
@@ -60,5 +63,27 @@ public abstract class AbstractRpcClient implements RpcClient {
    */
   protected abstract void configure(Properties properties)
       throws FlumeException;
+
+  public static int parseBatchSize(Properties properties) {
+    String strBatchSize = properties.getProperty(
+        RpcClientConfigurationConstants.CONFIG_BATCH_SIZE);
+    logger.debug("Batch size string = " + strBatchSize);
+    int _batchSize = RpcClientConfigurationConstants.DEFAULT_BATCH_SIZE;
+    if (strBatchSize != null && !strBatchSize.isEmpty()) {
+      try {
+        int parsedBatch = Integer.parseInt(strBatchSize);
+        if (parsedBatch < 1) {
+          logger.warn("Invalid value for batchSize: {}; Using default value.", parsedBatch);
+        } else {
+          _batchSize = parsedBatch;
+        }
+      } catch (NumberFormatException e) {
+        logger.warn("Batchsize is not valid for RpcClient: " + strBatchSize +
+            ". Default value assigned.", e);
+      }
+    }
+
+    return _batchSize;
+  }
 
 }

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/AbstractRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/AbstractRpcClient.java
@@ -64,18 +64,23 @@ public abstract class AbstractRpcClient implements RpcClient {
   protected abstract void configure(Properties properties)
       throws FlumeException;
 
+  /**
+   * This is to parse the batch size config for rpc clients
+   * @param properties config
+   * @return batch size
+   */
   public static int parseBatchSize(Properties properties) {
     String strBatchSize = properties.getProperty(
         RpcClientConfigurationConstants.CONFIG_BATCH_SIZE);
     logger.debug("Batch size string = " + strBatchSize);
-    int _batchSize = RpcClientConfigurationConstants.DEFAULT_BATCH_SIZE;
+    int batchSize = RpcClientConfigurationConstants.DEFAULT_BATCH_SIZE;
     if (strBatchSize != null && !strBatchSize.isEmpty()) {
       try {
         int parsedBatch = Integer.parseInt(strBatchSize);
         if (parsedBatch < 1) {
           logger.warn("Invalid value for batchSize: {}; Using default value.", parsedBatch);
         } else {
-          _batchSize = parsedBatch;
+          batchSize = parsedBatch;
         }
       } catch (NumberFormatException e) {
         logger.warn("Batchsize is not valid for RpcClient: " + strBatchSize +
@@ -83,7 +88,7 @@ public abstract class AbstractRpcClient implements RpcClient {
       }
     }
 
-    return _batchSize;
+    return batchSize;
   }
 
 }

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/FailoverRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/FailoverRpcClient.java
@@ -89,23 +89,8 @@ public class FailoverRpcClient extends AbstractRpcClient implements RpcClient {
       }
     }
 
-    String strBatchSize = properties.getProperty(
-        RpcClientConfigurationConstants.CONFIG_BATCH_SIZE);
+    batchSize = parseBatchSize(properties);
 
-    if (strBatchSize != null && strBatchSize.trim().length() > 0) {
-      try {
-        batchSize = Integer.parseInt(strBatchSize);
-        if (batchSize < 1) {
-          logger.warn("A batch-size less than 1 was specified: " + batchSize
-              + ". Using default instead.");
-          batchSize = RpcClientConfigurationConstants.DEFAULT_BATCH_SIZE;
-        }
-      } catch (NumberFormatException ex) {
-        logger.warn("Invalid batch size specified: " + strBatchSize
-            + ". Using default instead.");
-      }
-
-    }
     isActive = true;
   }
 

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/LoadBalancingRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/LoadBalancingRpcClient.java
@@ -185,6 +185,7 @@ public class LoadBalancingRpcClient extends AbstractRpcClient {
     }
 
     selector.setHosts(hosts);
+    batchSize = parseBatchSize(properties);
     isOpen = true;
   }
 

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/NettyAvroRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/NettyAvroRpcClient.java
@@ -492,24 +492,7 @@ public class NettyAvroRpcClient extends AbstractRpcClient implements RpcClient {
       stateLock.unlock();
     }
 
-    // batch size
-    String strBatchSize = properties.getProperty(
-        RpcClientConfigurationConstants.CONFIG_BATCH_SIZE);
-    logger.debug("Batch size string = " + strBatchSize);
-    batchSize = RpcClientConfigurationConstants.DEFAULT_BATCH_SIZE;
-    if (strBatchSize != null && !strBatchSize.isEmpty()) {
-      try {
-        int parsedBatch = Integer.parseInt(strBatchSize);
-        if (parsedBatch < 1) {
-          logger.warn("Invalid value for batchSize: {}; Using default value.", parsedBatch);
-        } else {
-          batchSize = parsedBatch;
-        }
-      } catch (NumberFormatException e) {
-        logger.warn("Batchsize is not valid for RpcClient: " + strBatchSize +
-            ". Default value assigned.", e);
-      }
-    }
+    batchSize = parseBatchSize(properties);
 
     // host and port
     String hostNames = properties.getProperty(

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/ThriftRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/ThriftRpcClient.java
@@ -72,7 +72,6 @@ public class ThriftRpcClient extends AbstractRpcClient {
   public static final String BINARY_PROTOCOL = "binary";
   public static final String COMPACT_PROTOCOL = "compact";
 
-  private int batchSize;
   private long requestTimeout;
   private final Lock stateLock;
   private State connState;

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/ThriftRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/ThriftRpcClient.java
@@ -107,12 +107,6 @@ public class ThriftRpcClient extends AbstractRpcClient {
     });
   }
 
-
-  @Override
-  public int getBatchSize() {
-    return batchSize;
-  }
-
   @Override
   public void append(Event event) throws EventDeliveryException {
     // Thrift IPC client is not thread safe, so don't allow state changes or
@@ -299,9 +293,7 @@ public class ThriftRpcClient extends AbstractRpcClient {
             + "choose from. Defaulting to 'compact'.");
         protocol = COMPACT_PROTOCOL;
       }
-      batchSize = Integer.parseInt(properties.getProperty(
-          RpcClientConfigurationConstants.CONFIG_BATCH_SIZE,
-          RpcClientConfigurationConstants.DEFAULT_BATCH_SIZE.toString()));
+      batchSize = parseBatchSize(properties);
       requestTimeout = Long.parseLong(properties.getProperty(
           RpcClientConfigurationConstants.CONFIG_REQUEST_TIMEOUT,
           String.valueOf(

--- a/flume-ng-sinks/flume-dataset-sink/src/main/java/org/apache/flume/sink/kite/DatasetSink.java
+++ b/flume-ng-sinks/flume-dataset-sink/src/main/java/org/apache/flume/sink/kite/DatasetSink.java
@@ -19,6 +19,7 @@ package org.apache.flume.sink.kite;
 
 import org.apache.flume.auth.FlumeAuthenticationUtil;
 import org.apache.flume.auth.PrivilegedExecutor;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.sink.kite.parser.EntityParserFactory;
 import org.apache.flume.sink.kite.parser.EntityParser;
 import org.apache.flume.sink.kite.policy.FailurePolicy;
@@ -69,7 +70,7 @@ import org.kitesdk.data.Formats;
  * and loading a Dataset by name, {@code kite.dataset.name}, and namespace,
  * {@code kite.dataset.namespace}.
  */
-public class DatasetSink extends AbstractSink implements Configurable {
+public class DatasetSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
   private static final Logger LOG = LoggerFactory.getLogger(DatasetSink.class);
 
@@ -578,5 +579,10 @@ public class DatasetSink extends AbstractSink implements Configurable {
   private static String uriToName(URI uri) {
     return Registration.lookupDatasetUri(URI.create(
         uri.getRawSchemeSpecificPart())).second().get("dataset");
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 }

--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
@@ -43,6 +43,7 @@ import org.apache.flume.SystemClock;
 import org.apache.flume.Transaction;
 import org.apache.flume.auth.FlumeAuthenticationUtil;
 import org.apache.flume.auth.PrivilegedExecutor;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.formatter.output.BucketPath;
 import org.apache.flume.instrumentation.SinkCounter;
@@ -58,7 +59,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-public class HDFSEventSink extends AbstractSink implements Configurable {
+public class HDFSEventSink extends AbstractSink implements Configurable, BatchSizeSupported {
   public interface WriterCallback {
     public void run(String filePath);
   }
@@ -557,4 +558,10 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
   int getTryCount() {
     return tryCount;
   }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
+  }
+
 }

--- a/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
+++ b/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
@@ -28,6 +28,7 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Transaction;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.formatter.output.BucketPath;
 import org.apache.flume.instrumentation.SinkCounter;
@@ -50,7 +51,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class HiveSink extends AbstractSink implements Configurable {
+public class HiveSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveSink.class);
 
@@ -512,6 +513,10 @@ public class HiveSink extends AbstractSink implements Configurable {
     }
   }
 
+  @Override
+  public long getBatchSize() {
+    return batchSize;
+  }
 
   @Override
   public String toString() {

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
@@ -38,6 +38,7 @@ import org.apache.flume.CounterGroup;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Transaction;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.formatter.output.BucketPath;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.instrumentation.SinkCounter;
@@ -83,7 +84,7 @@ import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.IND
  *      ://www.elasticsearch.org/guide/reference/api/admin-indices-templates.
  *      html
  */
-public class ElasticSearchSink extends AbstractSink implements Configurable {
+public class ElasticSearchSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
   private static final Logger logger = LoggerFactory
       .getLogger(ElasticSearchSink.class);
@@ -169,6 +170,11 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
   @VisibleForTesting
   IndexNameBuilder getIndexNameBuilder() {
     return indexNameBuilder;
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 
   @Override

--- a/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/AsyncHBaseSink.java
+++ b/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/AsyncHBaseSink.java
@@ -33,6 +33,7 @@ import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.FlumeException;
 import org.apache.flume.Transaction;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.instrumentation.SinkCounter;
@@ -101,7 +102,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * multiple increments are returned by the serializer, then HBase failure
  * will cause them to be re-written, when HBase comes back up.
  */
-public class AsyncHBaseSink extends AbstractSink implements Configurable {
+public class AsyncHBaseSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
   private String tableName;
   private byte[] columnFamily;
@@ -449,6 +450,11 @@ public class AsyncHBaseSink extends AbstractSink implements Configurable {
   @VisibleForTesting
   boolean isConfNull() {
     return conf == null;
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 
   @Override

--- a/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/HBaseSink.java
+++ b/flume-ng-sinks/flume-ng-hbase-sink/src/main/java/org/apache/flume/sink/hbase/HBaseSink.java
@@ -33,6 +33,7 @@ import org.apache.flume.Transaction;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.auth.FlumeAuthenticationUtil;
 import org.apache.flume.auth.PrivilegedExecutor;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.instrumentation.SinkCounter;
@@ -90,7 +91,7 @@ import java.util.NavigableMap;
  * multiple increments are returned by the serializer, then HBase failure
  * will cause them to be re-written, when HBase comes back up.
  */
-public class HBaseSink extends AbstractSink implements Configurable {
+public class HBaseSink extends AbstractSink implements Configurable, BatchSizeSupported {
   private String tableName;
   private byte[] columnFamily;
   private HTable table;
@@ -553,6 +554,11 @@ public class HBaseSink extends AbstractSink implements Configurable {
   @InterfaceAudience.Private
   HbaseEventSerializer getSerializer() {
     return serializer;
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 
   @VisibleForTesting

--- a/flume-ng-sinks/flume-ng-hbase2-sink/src/main/java/org/apache/flume/sink/hbase2/HBase2Sink.java
+++ b/flume-ng-sinks/flume-ng-hbase2-sink/src/main/java/org/apache/flume/sink/hbase2/HBase2Sink.java
@@ -33,6 +33,7 @@ import org.apache.flume.Transaction;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.auth.FlumeAuthenticationUtil;
 import org.apache.flume.auth.PrivilegedExecutor;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.instrumentation.SinkCounter;
@@ -96,7 +97,7 @@ import java.util.NavigableMap;
  * multiple increments are returned by the serializer, then HBase failure
  * will cause them to be re-written, when HBase comes back up.
  */
-public class HBase2Sink extends AbstractSink implements Configurable {
+public class HBase2Sink extends AbstractSink implements Configurable, BatchSizeSupported {
   private String tableName;
   private byte[] columnFamily;
   private Connection conn;
@@ -538,6 +539,11 @@ public class HBase2Sink extends AbstractSink implements Configurable {
   @InterfaceAudience.Private
   HBase2EventSerializer getSerializer() {
     return serializer;
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 
   @VisibleForTesting

--- a/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
@@ -29,6 +29,7 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Transaction;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.conf.LogPrivacyUtil;
@@ -102,7 +103,7 @@ import static org.apache.flume.sink.kafka.KafkaSinkConstants.MESSAGE_SERIALIZER_
  * topic
  * key
  */
-public class KafkaSink extends AbstractSink implements Configurable {
+public class KafkaSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
   private static final Logger logger = LoggerFactory.getLogger(KafkaSink.class);
 
@@ -136,7 +137,7 @@ public class KafkaSink extends AbstractSink implements Configurable {
     return topic;
   }
 
-  public int getBatchSize() {
+  public long getBatchSize() {
     return batchSize;
   }
 

--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/src/main/java/org/apache/flume/sink/solr/morphline/MorphlineSink.java
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/src/main/java/org/apache/flume/sink/solr/morphline/MorphlineSink.java
@@ -22,6 +22,7 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Transaction;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.conf.LogPrivacyUtil;
@@ -36,7 +37,7 @@ import org.kitesdk.morphline.api.Command;
  * Flume sink that extracts search documents from Flume events and processes them using a morphline
  * {@link Command} chain.
  */
-public class MorphlineSink extends AbstractSink implements Configurable {
+public class MorphlineSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
   private int maxBatchSize = 1000;
   private long maxBatchDurationMillis = 1000;
@@ -193,7 +194,12 @@ public class MorphlineSink extends AbstractSink implements Configurable {
       txn.close();
     }
   }
-  
+
+  @Override
+  public long getBatchSize() {
+    return getMaxBatchSize();
+  }
+
   @Override
   public String toString() {
     int i = getClass().getName().lastIndexOf('.') + 1;

--- a/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
+++ b/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
@@ -36,6 +36,7 @@ import org.apache.flume.EventDeliveryException;
 import org.apache.flume.FlumeException;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.AbstractPollableSource;
@@ -50,7 +51,7 @@ import com.google.common.io.Files;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
-public class JMSSource extends AbstractPollableSource {
+public class JMSSource extends AbstractPollableSource implements BatchSizeSupported {
   private static final Logger logger = LoggerFactory.getLogger(JMSSource.class);
 
   // setup by constructor
@@ -354,5 +355,10 @@ public class JMSSource extends AbstractPollableSource {
         createDurableSubscription, durableSubscriptionName);
     jmsExceptionCounter = 0;
     return consumer;
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 }

--- a/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
+++ b/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
@@ -41,6 +41,7 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.FlumeException;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.conf.LogPrivacyUtil;
@@ -94,7 +95,7 @@ import static scala.collection.JavaConverters.asJavaListConverter;
  * <p>
  */
 public class KafkaSource extends AbstractPollableSource
-        implements Configurable {
+        implements Configurable, BatchSizeSupported {
   private static final Logger log = LoggerFactory.getLogger(KafkaSource.class);
 
   // Constants used only for offset migration zookeeper connections
@@ -129,6 +130,11 @@ public class KafkaSource extends AbstractPollableSource
   private boolean migrateZookeeperOffsets = DEFAULT_MIGRATE_ZOOKEEPER_OFFSETS;
   private String topicHeader = null;
   private boolean setTopicHeader;
+
+  @Override
+  public long getBatchSize() {
+    return batchUpperLimit;
+  }
 
   /**
    * This class is a helper to subscribe for topics by using

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
@@ -39,6 +39,7 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.FlumeException;
 import org.apache.flume.PollableSource;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.AbstractSource;
@@ -57,7 +58,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.Gson;
 
 public class TaildirSource extends AbstractSource implements
-    PollableSource, Configurable {
+    PollableSource, Configurable, BatchSizeSupported {
 
   private static final Logger logger = LoggerFactory.getLogger(TaildirSource.class);
 
@@ -188,6 +189,11 @@ public class TaildirSource extends AbstractSource implements
     if (sourceCounter == null) {
       sourceCounter = new SourceCounter(getName());
     }
+  }
+
+  @Override
+  public long getBatchSize() {
+    return batchSize;
   }
 
   private Map<String, String> selectByKeys(Map<String, String> map, String[] keys) {

--- a/flume-ng-sources/flume-twitter-source/src/main/java/org/apache/flume/source/twitter/TwitterSource.java
+++ b/flume-ng-sources/flume-twitter-source/src/main/java/org/apache/flume/source/twitter/TwitterSource.java
@@ -39,6 +39,7 @@ import org.apache.flume.Event;
 import org.apache.flume.EventDrivenSource;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
+import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.source.AbstractSource;
@@ -68,7 +69,7 @@ import twitter4j.auth.AccessToken;
 @InterfaceStability.Unstable
 public class TwitterSource
     extends AbstractSource
-    implements EventDrivenSource, Configurable, StatusListener {
+    implements EventDrivenSource, Configurable, StatusListener, BatchSizeSupported {
 
   private TwitterStream twitterStream;
   private Schema avroSchema;
@@ -324,5 +325,10 @@ public class TwitterSource
 
   public void onException(Exception e) {
     LOGGER.error("Exception while streaming tweets", e);
+  }
+
+  @Override
+  public long getBatchSize() {
+    return maxBatchSize;
   }
 }

--- a/flume-ng-tests/src/test/java/org/apache/flume/test/agent/TestConfig.java
+++ b/flume-ng-tests/src/test/java/org/apache/flume/test/agent/TestConfig.java
@@ -66,7 +66,7 @@ public class TestConfig {
     LOGGER.debug("Using agent stage dir: {}", agentDir);
 
     File testDir = new File(agentDir, TestConfig.class.getName());
-    if (testDir.exists()){
+    if (testDir.exists()) {
       FileUtils.deleteDirectory(testDir);
     }
     assertTrue(testDir.mkdirs());


### PR DESCRIPTION
…h size than the channel transaction capacity

The loadSources() method seemed like an appropriate place to check this.
Added 2 new interfaces for getting the transaction capacity and the batch size fields. The check is only done for channels that implement the TransactioCapacitySupported interface and sources that implement the BatchSizeSupported  interface.
There is a new unit test case that I used for testing.

TODOs:
Add the BatchSizeSupported interface to all the sources that handle batch size.
Check how this works when reloading configuration.