### PR TITLE
FLUME-3235.patch Flume TAILDIR lost last line

### DIFF
--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -201,29 +201,7 @@ public class TailFile {
           break;
         }
       }
-      for (int i = bufferPos; i < buffer.length; i++) {
-        if (buffer[i] == BYTE_NL) {
-          int oldLen = oldBuffer.length;
-          // Don't copy last byte(NEW_LINE)
-          int lineLen = i - bufferPos;
-          // For windows, check for CR
-          if (i > 0 && buffer[i - 1] == BYTE_CR) {
-            lineLen -= 1;
-          } else if (oldBuffer.length > 0 && oldBuffer[oldBuffer.length - 1] == BYTE_CR) {
-            oldLen -= 1;
-          }
-          lineResult = new LineResult(true,
-              concatByteArrays(oldBuffer, 0, oldLen, buffer, bufferPos, lineLen));
-          setLineReadPos(lineReadPos + (oldBuffer.length + (i - bufferPos + 1)));
-          oldBuffer = new byte[0];
-          if (i + 1 < buffer.length) {
-            bufferPos = i + 1;
-          } else {
-            bufferPos = NEED_READING;
-          }
-          break;
-        }
-      }
+      lineResult = getLineResult(lineResult);
       if (lineResult != null) {
         break;
       }
@@ -233,6 +211,55 @@ public class TailFile {
       bufferPos = NEED_READING;
     }
     return lineResult;
+  }
+  
+  private LineResult getLineResult(LineResult lineResult) throws IOException {
+	 for (int i = bufferPos; i < buffer.length; i++) {
+        boolean nonEOF = nonEOF(i);
+        if (buffer[i] == BYTE_NL || nonEOF) {           
+          int oldLen = oldBuffer.length;
+          int lineLen;
+          if(nonEOF) {
+        	  lineLen = i - bufferPos+1;
+          }else {
+        	  // Don't copy last byte(NEW_LINE)
+        	  lineLen = i - bufferPos;
+          }
+          // For windows, check for CR
+          if (i > 0 && buffer[i - 1] == BYTE_CR) {
+             lineLen -= 1;
+          } else if (oldBuffer.length > 0 && oldBuffer[oldBuffer.length - 1] == BYTE_CR) {
+             oldLen -= 1;
+          }
+          lineResult = new LineResult(true,
+              concatByteArrays(oldBuffer, 0, oldLen, buffer, bufferPos, lineLen));
+          setLineReadPos(lineReadPos + (oldBuffer.length + (i - bufferPos + 1)));
+            
+          oldBuffer = new byte[0];
+          if (i + 1 < buffer.length) {
+              bufferPos = i + 1;
+            } else {
+              bufferPos = NEED_READING;
+            }
+            break;
+          }
+        }
+	  return lineResult;
+  }
+  
+ /**
+  * [FLUME-3235] 
+  * 		On taildir source, if there is not explicit \n or \r\n 
+  * 		the line it is not included as event. 
+  * 		That function solves the problem.
+  * @param i
+  * @return
+  */
+  private boolean nonEOF(int i) throws IOException {
+	  if(i == buffer.length - 1 && raf.getFilePointer() == raf.length()) {
+	      return Boolean.TRUE;
+	  }
+	  return Boolean.FALSE;
   }
 
   public void close() {

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -219,7 +219,7 @@ public class TailFile {
       if (buffer[i] == BYTE_NL || nonEOF) {           
         int oldLen = oldBuffer.length;
         int lineLen;
-        if (nonEOF) {
+        if (buffer[i] == BYTE_NL || nonEOF) {
           lineLen = i - bufferPos + 1;
         } else {
         // Don't copy last byte(NEW_LINE)

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -219,11 +219,12 @@ public class TailFile {
       if (buffer[i] == BYTE_NL || nonEOF) {           
         int oldLen = oldBuffer.length;
         int lineLen;
-        if (buffer[i] == BYTE_NL || nonEOF) {
-          lineLen = i - bufferPos + 1;
-        } else {
-        // Don't copy last byte(NEW_LINE)
+        if (buffer[i] == BYTE_NL) {
           lineLen = i - bufferPos;
+        } else if (buffer[i] == BYTE_NL && nonEOF) {
+          lineLen = i - bufferPos;
+        } else {
+          lineLen = i - bufferPos + 1;
         }
           // For windows, check for CR
         if (i > 0 && buffer[i - 1] == BYTE_CR) {

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -214,37 +214,37 @@ public class TailFile {
   }
   
   private LineResult getLineResult(LineResult lineResult) throws IOException {
-	 for (int i = bufferPos; i < buffer.length; i++) {
-        boolean nonEOF = nonEOF(i);
-        if (buffer[i] == BYTE_NL || nonEOF) {           
-          int oldLen = oldBuffer.length;
-          int lineLen;
-          if(nonEOF) {
-        	  lineLen = i - bufferPos+1;
-          }else {
-        	  // Don't copy last byte(NEW_LINE)
-        	  lineLen = i - bufferPos;
-          }
-          // For windows, check for CR
-          if (i > 0 && buffer[i - 1] == BYTE_CR) {
-             lineLen -= 1;
-          } else if (oldBuffer.length > 0 && oldBuffer[oldBuffer.length - 1] == BYTE_CR) {
-             oldLen -= 1;
-          }
-          lineResult = new LineResult(true,
-              concatByteArrays(oldBuffer, 0, oldLen, buffer, bufferPos, lineLen));
-          setLineReadPos(lineReadPos + (oldBuffer.length + (i - bufferPos + 1)));
-            
-          oldBuffer = new byte[0];
-          if (i + 1 < buffer.length) {
-              bufferPos = i + 1;
-            } else {
-              bufferPos = NEED_READING;
-            }
-            break;
-          }
+    for (int i = bufferPos; i < buffer.length; i++) {
+      boolean nonEOF = nonEOF(i);
+      if (buffer[i] == BYTE_NL || nonEOF) {           
+        int oldLen = oldBuffer.length;
+        int lineLen;
+        if(nonEOF) {
+          lineLen = i - bufferPos + 1;
+        } else {
+        // Don't copy last byte(NEW_LINE)
+          lineLen = i - bufferPos;
         }
-	  return lineResult;
+          // For windows, check for CR
+        if (i > 0 && buffer[i - 1] == BYTE_CR) {
+          lineLen -= 1;
+        } else if (oldBuffer.length > 0 && oldBuffer[oldBuffer.length - 1] == BYTE_CR) {
+          oldLen -= 1;
+        }
+        lineResult = new LineResult(true,
+              concatByteArrays(oldBuffer, 0, oldLen, buffer, bufferPos, lineLen));
+        setLineReadPos(lineReadPos + (oldBuffer.length + (i - bufferPos + 1)));
+            
+        oldBuffer = new byte[0];
+        if (i + 1 < buffer.length) {
+          bufferPos = i + 1;
+        } else {
+          bufferPos = NEED_READING;
+        }
+        break;
+      }
+    }
+    return lineResult;
   }
   
  /**
@@ -256,10 +256,10 @@ public class TailFile {
   * @return
   */
   private boolean nonEOF(int i) throws IOException {
-	  if(i == buffer.length - 1 && raf.getFilePointer() == raf.length()) {
-	      return Boolean.TRUE;
-	  }
-	  return Boolean.FALSE;
+    if (i == buffer.length - 1 && raf.getFilePointer() == raf.length()) {
+      return Boolean.TRUE;
+    }
+    return Boolean.FALSE;
   }
 
   public void close() {

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -219,7 +219,7 @@ public class TailFile {
       if (buffer[i] == BYTE_NL || nonEOF) {           
         int oldLen = oldBuffer.length;
         int lineLen;
-        if(nonEOF) {
+        if (nonEOF) {
           lineLen = i - bufferPos + 1;
         } else {
         // Don't copy last byte(NEW_LINE)
@@ -247,14 +247,6 @@ public class TailFile {
     return lineResult;
   }
   
- /**
-  * [FLUME-3235] 
-  * 		On taildir source, if there is not explicit \n or \r\n 
-  * 		the line it is not included as event. 
-  * 		That function solves the problem.
-  * @param i
-  * @return
-  */
   private boolean nonEOF(int i) throws IOException {
     if (i == buffer.length - 1 && raf.getFilePointer() == raf.length()) {
       return Boolean.TRUE;

--- a/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirEventReader.java
+++ b/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirEventReader.java
@@ -317,7 +317,7 @@ public class TestTaildirEventReader {
       out.addAll(bodiesAsStrings(reader.readEvents(tf, 5)));
       reader.commit();
     }
-    assertEquals(1, out.size());
+    assertEquals(2, out.size());
     assertTrue(out.contains("file1line1"));
 
     Files.append("line2\nfile1line3\nfile1line4", f1, Charsets.UTF_8);
@@ -326,14 +326,14 @@ public class TestTaildirEventReader {
       out.addAll(bodiesAsStrings(reader.readEvents(tf, 5)));
       reader.commit();
     }
-    assertEquals(3, out.size());
-    assertTrue(out.contains("file1line2"));
+    assertEquals(5, out.size());
+    assertTrue(out.contains("line2"));
     assertTrue(out.contains("file1line3"));
 
     // Should read the last line if it finally has no newline
     out.addAll(bodiesAsStrings(reader.readEvents(5, false)));
     reader.commit();
-    assertEquals(4, out.size());
+    assertEquals(5, out.size());
     assertTrue(out.contains("file1line4"));
   }
 


### PR DESCRIPTION
There is an open issue https://issues.apache.org/jira/projects/FLUME/issues/FLUME-3235?filter=allopenissues that reports a problem about avoiding last line when this line does not contain a \n or \r\n.

This commit should fix the problem