### PR TITLE
FLUME-3239 Do not rename files in SpoolDirectorySource

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
@@ -298,7 +298,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
       return completedFiles;
     }
 
-    Path trackerDirPath = Paths.get(trackerDirectory.getPath());
+    Path trackerDirPath = trackerDirectory.toPath();
     Files.walkFileTree(trackerDirPath, new SimpleFileVisitor<Path>() {
 
       @Override
@@ -542,7 +542,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
   }
 
   private void rollCurrentFileInTrackerDir(File fileToRoll) throws IOException {
-    Path path = Paths.get(fileToRoll.getPath());
+    Path path = fileToRoll.toPath();
     Path relToRoll = getRelPathToSpoolDir(path);
 
     File dest = new File(trackerDirectory.getPath(), relToRoll + completedSuffix);

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
@@ -77,6 +77,7 @@ public class SpoolDirectorySource extends AbstractSource
   private ConsumeOrder consumeOrder;
   private int pollDelay;
   private boolean recursiveDirectorySearch;
+  private String trackingPolicy;
 
   @Override
   public synchronized void start() {
@@ -104,6 +105,7 @@ public class SpoolDirectorySource extends AbstractSource
           .decodeErrorPolicy(decodeErrorPolicy)
           .consumeOrder(consumeOrder)
           .recursiveDirectorySearch(recursiveDirectorySearch)
+          .trackingPolicy(trackingPolicy)
           .build();
     } catch (IOException ioe) {
       throw new FlumeException("Error instantiating spooling event parser",
@@ -193,6 +195,7 @@ public class SpoolDirectorySource extends AbstractSource
     if (sourceCounter == null) {
       sourceCounter = new SourceCounter(getName());
     }
+    trackingPolicy = context.getString(TRACKING_POLICY, DEFAULT_TRACKING_POLICY);
   }
 
   @VisibleForTesting

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySourceConfigurationConstants.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySourceConfigurationConstants.java
@@ -17,8 +17,6 @@
 
 package org.apache.flume.source;
 
-import org.apache.flume.client.avro.ReliableSpoolingFileEventReader;
-import org.apache.flume.client.avro.ReliableSpoolingFileEventReader.TrackingPolicy;
 import org.apache.flume.serialization.DecodeErrorPolicy;
 
 public class SpoolDirectorySourceConfigurationConstants {
@@ -81,7 +79,7 @@ public class SpoolDirectorySourceConfigurationConstants {
   public static final String DEFAULT_DELETE_POLICY = "never";
 
   public static final String TRACKING_POLICY = "trackingPolicy";
-  public static final String DEFAULT_TRACKING_POLICY = TrackingPolicy.RENAME.name();
+  public static final String DEFAULT_TRACKING_POLICY = "rename";
 
   /** Character set used when reading the input. */
   public static final String INPUT_CHARSET = "inputCharset";

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySourceConfigurationConstants.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySourceConfigurationConstants.java
@@ -17,6 +17,8 @@
 
 package org.apache.flume.source;
 
+import org.apache.flume.client.avro.ReliableSpoolingFileEventReader;
+import org.apache.flume.client.avro.ReliableSpoolingFileEventReader.TrackingPolicy;
 import org.apache.flume.serialization.DecodeErrorPolicy;
 
 public class SpoolDirectorySourceConfigurationConstants {
@@ -77,6 +79,9 @@ public class SpoolDirectorySourceConfigurationConstants {
 
   public static final String DELETE_POLICY = "deletePolicy";
   public static final String DEFAULT_DELETE_POLICY = "never";
+
+  public static final String TRACKING_POLICY = "trackingPolicy";
+  public static final String DEFAULT_TRACKING_POLICY = TrackingPolicy.RENAME.name();
 
   /** Character set used when reading the input. */
   public static final String INPUT_CHARSET = "inputCharset";

--- a/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
@@ -491,13 +491,8 @@ public class TestReliableSpoolingFileEventReader {
   }
 
   @Test public void testLargeNumberOfFilesYOUNGEST() throws IOException {
-    templateTestForRecursiveDirs(ConsumeOrder.YOUNGEST, new Comparator<Long>() {
-
-      @Override
-      public int compare(Long o1, Long o2) {
-        return o2.compareTo(o1);
-      }
-    }, 3, 3, 37, TrackingPolicy.RENAME);
+    templateTestForRecursiveDirs(ConsumeOrder.YOUNGEST, Comparator.reverseOrder(),
+        3, 3, 37, TrackingPolicy.RENAME);
   }
 
   @Test public void testLargeNumberOfFilesRANDOM() throws IOException {
@@ -509,12 +504,8 @@ public class TestReliableSpoolingFileEventReader {
   }
 
   @Test public void testLargeNumberOfFilesYOUNGESTTrackerDir() throws IOException {
-    templateTestForRecursiveDirs(ConsumeOrder.YOUNGEST, new Comparator<Long>() {
-      @Override
-      public int compare(Long o1, Long o2) {
-        return o2.compareTo(o1);
-      }
-    }, 3, 3, 10, TrackingPolicy.TRACKER_DIR);
+    templateTestForRecursiveDirs(ConsumeOrder.YOUNGEST, Comparator.reverseOrder(),
+        3, 3, 10, TrackingPolicy.TRACKER_DIR);
   }
 
   @Test public void testLargeNumberOfFilesRANDOMTrackerDir() throws IOException {
@@ -619,8 +610,8 @@ public class TestReliableSpoolingFileEventReader {
     }
   }
 
-  private void createFiles(File dir, int N, Map<Long, List<String>> expected, MutableLong id) throws IOException {
-    for (int i = 0; i < N; i++) {
+  private void createFiles(File dir, int fileNum, Map<Long, List<String>> expected, MutableLong id) throws IOException {
+    for (int i = 0; i < fileNum; i++) {
       File f = new File(dir, "file-" + id);
       String data = f.getPath();
       Files.write(data, f, Charsets.UTF_8);

--- a/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
@@ -583,10 +583,12 @@ public class TestReliableSpoolingFileEventReader {
       }
 
       int expNum = expectedColl.size();
+      int actualNum = 0;
       for (int i = 0; i < expNum; i++) {
         List<Event> events;
         events = reader.readEvents(10);
         for (Event e : events) {
+          actualNum++;
           if (order == ConsumeOrder.RANDOM) {
             Assert.assertTrue(expectedColl.remove(new String(e.getBody())));
           } else {
@@ -598,6 +600,7 @@ public class TestReliableSpoolingFileEventReader {
         }
         reader.commit();
       }
+      Assert.assertEquals(expNum, actualNum);
     } finally {
       deleteDir(dir);
     }

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -1005,7 +1005,8 @@ This source will watch the specified directory for new files, and will parse
 events out of new files as they appear.
 The event parsing logic is pluggable.
 After a given file has been fully read
-into the channel, it is renamed to indicate completion (or optionally deleted).
+into the channel, completion by default is indicated by renaming the file or it can be deleted or the trackerDir is used
+to keep track of processed files.
 
 Unlike the Exec source, this source is reliable and will not miss data, even if
 Flume is restarted or killed. In exchange for this reliability, only immutable,
@@ -1047,6 +1048,11 @@ ignorePattern             ^$              Regular expression specifying which fi
                                           the file is ignored.
 trackerDir                .flumespool     Directory to store metadata related to processing of files.
                                           If this path is not an absolute path, then it is interpreted as relative to the spoolDir.
+trackingPolicy            rename          The tracking policy defines how file processign is tracked. It can be "rename" or
+                                          "tracker_dir". This parameter is only effective if the deletePolicy is "never".
+                                          "rename" - After processing files they get renamed according to the fileSuffix parameter.
+                                          "tracker_dir" - Files are not renemad but a new empty file is created in the trackerDir.
+                                          The new tracker file name is derived from the ingested one plus the fileSuffix.
 consumeOrder              oldest          In which order files in the spooling directory will be consumed ``oldest``,
                                           ``youngest`` and ``random``. In case of ``oldest`` and ``youngest``, the last modified
                                           time of the files will be used to compare the files. In case of a tie, the file

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -1048,10 +1048,10 @@ ignorePattern             ^$              Regular expression specifying which fi
                                           the file is ignored.
 trackerDir                .flumespool     Directory to store metadata related to processing of files.
                                           If this path is not an absolute path, then it is interpreted as relative to the spoolDir.
-trackingPolicy            rename          The tracking policy defines how file processign is tracked. It can be "rename" or
+trackingPolicy            rename          The tracking policy defines how file processing is tracked. It can be "rename" or
                                           "tracker_dir". This parameter is only effective if the deletePolicy is "never".
                                           "rename" - After processing files they get renamed according to the fileSuffix parameter.
-                                          "tracker_dir" - Files are not renemad but a new empty file is created in the trackerDir.
+                                          "tracker_dir" - Files are not renamed but a new empty file is created in the trackerDir.
                                           The new tracker file name is derived from the ingested one plus the fileSuffix.
 consumeOrder              oldest          In which order files in the spooling directory will be consumed ``oldest``,
                                           ``youngest`` and ``random``. In case of ``oldest`` and ``youngest``, the last modified


### PR DESCRIPTION
Added functionality to track files in the meta directory rather than renaming them.
Improved tests for checking multilevel directories.