### PR TITLE
FLUME-3262: Improve Scribe Source With More Options

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -2292,16 +2292,19 @@ Flume should use ScribeSource based on Thrift with compatible transfering protoc
 For deployment of Scribe please follow the guide from Facebook.
 Required properties are in **bold**.
 
-====================  ===========  ==============================================
-Property Name         Default      Description
-====================  ===========  ==============================================
-**type**              --           The component type name, needs to be ``org.apache.flume.source.scribe.ScribeSource``
-port                  1499         Port that Scribe should be connected
-maxReadBufferBytes    16384000     Thrift Default FrameBuffer Size
-workerThreads         5            Handing threads number in Thrift
+====================    ===========  ==============================================
+Property Name           Default      Description
+====================    ===========  ==============================================
+**type**                --           The component type name, needs to be ``org.apache.flume.source.scribe.ScribeSource``
+port                    1499         Port that Scribe should be connected
+maxReadBufferBytes      16384000     Thrift Default FrameBuffer Size
+maxThriftFrameSizeBytes 16384000     The max allowed frame size of thrift RPC request
+thriftServer            ThshaServer  Could be ThshaServer, TThreadedSelectorServer or TThreadPoolServer
+workerThreads           5            Handing threads number in Thrift, will be max thread allowed while using TThreadPoolServer
+selectorThreads         4            Selector threads number in Thrift while using TThreadedSelectorServer
 selector.type
 selector.*
-====================  ===========  ==============================================
+====================    ===========  ==============================================
 
 Example for agent named a1:
 

--- a/flume-ng-sources/flume-scribe-source/src/main/java/org/apache/flume/source/scribe/ScribeSourceConfiguration.java
+++ b/flume-ng-sources/flume-scribe-source/src/main/java/org/apache/flume/source/scribe/ScribeSourceConfiguration.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flume.source.scribe;
+
+import org.apache.flume.Context;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.server.THsHaServer;
+import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.server.TThreadedSelectorServer;
+import org.apache.thrift.transport.TFramedTransport;
+import org.apache.thrift.transport.TNonblockingServerSocket;
+import org.apache.thrift.transport.TNonblockingServerTransport;
+import org.apache.thrift.transport.TServerSocket;
+import org.apache.thrift.transport.TServerTransport;
+import org.apache.thrift.transport.TTransportException;
+
+public class ScribeSourceConfiguration {
+
+  public enum ThriftServerType {
+    THSHA_SERVER("ThshaServer"),
+    TTHREADED_SELECTOR_SERVER("TThreadedSelectorServer"),
+    TTHREADPOOL_SERVER("TThreadPoolServer");
+
+    private String value;
+
+    ThriftServerType(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public static ThriftServerType getServerType(String value) throws IllegalArgumentException {
+      for(ThriftServerType v : values()) {
+        if (v.getValue().equalsIgnoreCase(value)) {
+          return v;
+        }
+      }
+      throw new IllegalArgumentException("Cannot find Thrift server type:" + value);
+    }
+  }
+
+  public static final int DEFAULT_PORT = 1499;
+  public static final int DEFAULT_WORKERS = 5;
+  public static final ThriftServerType DEFAULT_THRIFT_SERVER_TYPE = ThriftServerType.THSHA_SERVER;
+  public static final int DEFAULT_THREADED_SELECTOR_NUM_THREADS = 4;
+  public static final long DEFAULT_MAX_READ_BUFFER_BYTES = 16384000;
+  public static final int DEFAULT_MAX_THRIFT_FRAME_SIZE_BYTES = 16384000;
+  public static final String SCRIBE_CATEGORY = "category";
+
+
+  public int port;
+  public int workerThreadNum;
+  public int selectorThreadNum;
+  public ThriftServerType thriftServerType;
+  public long maxReadBufferBytes;
+  public int maxThriftFrameSizeBytes;
+
+  public void configure(Context context) {
+    port = context.getInteger("port", DEFAULT_PORT);
+    maxReadBufferBytes = context.getLong("maxReadBufferBytes", DEFAULT_MAX_READ_BUFFER_BYTES);
+    if (maxReadBufferBytes <= 0) {
+      maxReadBufferBytes = DEFAULT_MAX_READ_BUFFER_BYTES;
+    }
+    maxThriftFrameSizeBytes = context.getInteger("maxThriftFrameSizeBytes",
+        DEFAULT_MAX_THRIFT_FRAME_SIZE_BYTES);
+    if (maxThriftFrameSizeBytes <= 0) {
+      maxThriftFrameSizeBytes = DEFAULT_MAX_THRIFT_FRAME_SIZE_BYTES;
+    }
+    workerThreadNum = context.getInteger("workerThreads", DEFAULT_WORKERS);
+    if (workerThreadNum <= 0) {
+      workerThreadNum = DEFAULT_WORKERS;
+    }
+    String thriftServerTypeStr
+        = context.getString("thriftServer", DEFAULT_THRIFT_SERVER_TYPE.getValue());
+    thriftServerType = ThriftServerType.getServerType(thriftServerTypeStr);
+    selectorThreadNum = context.getInteger("selectorThreads", DEFAULT_THREADED_SELECTOR_NUM_THREADS);
+    if (selectorThreadNum <= 0) {
+      selectorThreadNum = DEFAULT_THREADED_SELECTOR_NUM_THREADS;
+    }
+  }
+
+  public THsHaServer.Args createTHsHasServerArg(
+      Scribe.Processor processor, int port) throws TTransportException {
+    TNonblockingServerTransport transport = new TNonblockingServerSocket(port);
+    THsHaServer.Args args = new THsHaServer.Args(transport);
+    args.minWorkerThreads(workerThreadNum);
+    args.maxWorkerThreads(workerThreadNum);
+    args.processor(processor);
+    args.transportFactory(new TFramedTransport.Factory(maxThriftFrameSizeBytes));
+    args.protocolFactory(new TBinaryProtocol.Factory(false, false));
+    args.maxReadBufferBytes = maxReadBufferBytes;
+    return args;
+  }
+
+  public TThreadedSelectorServer.Args createTThreadedSelectorServerArgs(
+      Scribe.Processor processor, int port) throws TTransportException {
+    TNonblockingServerTransport transport = new TNonblockingServerSocket(port);
+    TThreadedSelectorServer.Args args = new TThreadedSelectorServer.Args(transport);
+    args.selectorThreads(selectorThreadNum);
+    args.workerThreads(workerThreadNum);
+    args.processor(processor);
+    args.transportFactory(new TFramedTransport.Factory(maxThriftFrameSizeBytes));
+    args.protocolFactory(new TBinaryProtocol.Factory(false, false));
+    args.maxReadBufferBytes = maxReadBufferBytes;
+    args.validate();
+    return args;
+  }
+
+  public TThreadPoolServer.Args createTThreadPoolServerArgs(
+      Scribe.Processor processor, int port) throws TTransportException {
+    TServerTransport transport = new TServerSocket(port);
+    TThreadPoolServer.Args args = new TThreadPoolServer.Args(transport);
+    if (workerThreadNum < args.minWorkerThreads) {
+      args.minWorkerThreads = workerThreadNum;
+    }
+    args.maxWorkerThreads(workerThreadNum);
+    args.processor(processor);
+    args.transportFactory(new TFramedTransport.Factory(maxThriftFrameSizeBytes));
+    args.protocolFactory(new TBinaryProtocol.Factory(false, false));
+    return args;
+  }
+}

--- a/flume-ng-sources/flume-scribe-source/src/main/java/org/apache/flume/source/scribe/ScribeSourceThriftServerFactory.java
+++ b/flume-ng-sources/flume-scribe-source/src/main/java/org/apache/flume/source/scribe/ScribeSourceThriftServerFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flume.source.scribe;
+
+import org.apache.flume.FlumeException;
+import org.apache.thrift.TException;
+import org.apache.thrift.server.THsHaServer;
+import org.apache.thrift.server.TServer;
+import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.server.TThreadedSelectorServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ScribeSourceThriftServerFactory {
+  private static final Logger logger =
+      LoggerFactory.getLogger(ScribeSourceThriftServerFactory.class);
+
+  public static TServer create(
+      ScribeSourceConfiguration configuration, ScribeSource.Receiver receiver)
+      throws FlumeException {
+    if (configuration.thriftServerType == null) {
+      throw new FlumeException("Initialize thrift server failed, null thriftServerType");
+    }
+    try {
+      Scribe.Processor processor = new Scribe.Processor(receiver);
+      switch (configuration.thriftServerType) {
+        case THSHA_SERVER:
+          return new THsHaServer(
+              configuration.createTHsHasServerArg(processor, configuration.port));
+        case TTHREADED_SELECTOR_SERVER:
+          return new TThreadedSelectorServer(
+              configuration.createTThreadedSelectorServerArgs(processor, configuration.port));
+        case TTHREADPOOL_SERVER:
+          return new TThreadPoolServer(
+              configuration.createTThreadPoolServerArgs(processor, configuration.port));
+        default:
+          logger.error("Unsupported thrift server type, should happen!");
+          throw new FlumeException("Unsupported thrift server type, should happen!");
+      }
+    } catch (FlumeException ex) {
+      throw ex;
+    } catch (TException ex) {
+      throw new FlumeException("Create thrift server failed", ex);
+    }
+  }
+}

--- a/flume-ng-sources/flume-scribe-source/src/test/java/org/apache/flume/source/scribe/TestScribeSourceConfiguration.java
+++ b/flume-ng-sources/flume-scribe-source/src/test/java/org/apache/flume/source/scribe/TestScribeSourceConfiguration.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flume.source.scribe;
+
+import org.apache.flume.Context;
+import org.apache.thrift.server.THsHaServer;
+import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.server.TThreadedSelectorServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestScribeSourceConfiguration {
+  private static final Logger logger =
+      LoggerFactory.getLogger(TestScribeSourceThriftServerFactory.class);
+  Context context;
+  ScribeSourceConfiguration configuration;
+
+
+  @Before
+  public void setUp() {
+    context = new Context();
+    context.put("workerThreads", "8");
+    context.put("maxReadBufferBytes", "10240");
+    context.put("maxThriftFrameSizeBytes", "1204");
+    configuration = new ScribeSourceConfiguration();
+  }
+
+  @After
+  public void tearDown() {
+    context = null;
+    configuration = null;
+  }
+
+  @Test
+  public void testConfiguration() {
+    context.put("port", "1111");
+    context.put("workerThreads", "8");
+    context.put("maxReadBufferBytes", "10240");
+    context.put("maxThriftFrameSizeBytes", "1204");
+    context.put("selectorThreads", "2");
+    context.put("thriftServer",
+        ScribeSourceConfiguration.ThriftServerType.TTHREADPOOL_SERVER.getValue());
+    configuration.configure(context);
+    Assert.assertEquals(configuration.port, 1111);
+    Assert.assertEquals(configuration.workerThreadNum, 8);
+    Assert.assertEquals(configuration.maxReadBufferBytes, 10240);
+    Assert.assertEquals(configuration.selectorThreadNum, 2);
+    Assert.assertTrue(
+        configuration.thriftServerType ==
+            ScribeSourceConfiguration.ThriftServerType.TTHREADPOOL_SERVER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfigurationWithBadThriftServerType() {
+    context.put("port", "1111");
+    context.put("workerThreads", "8");
+    context.put("maxReadBufferBytes", "10240");
+    context.put("maxThriftFrameSizeBytes", "1204");
+    context.put("selectorThreads", "2");
+    context.put("thriftServer", "aaa");
+    configuration.configure(context);
+  }
+
+  @Test
+  public void testCreateTHsHasServerArg() throws Exception{
+    context.put("port", "1111");
+    context.put("workerThreads", "8");
+    context.put("maxReadBufferBytes", "10240");
+    context.put("maxThriftFrameSizeBytes", "1204");
+    context.put("selectorThreads", "2");
+    context.put(
+        "thriftServer",
+        ScribeSourceConfiguration.ThriftServerType.THSHA_SERVER.getValue());
+    configuration.configure(context);
+    THsHaServer.Args args = configuration.createTHsHasServerArg(
+        null, TestUtils.findFreePort());
+    Assert.assertEquals(args.maxReadBufferBytes, 10240);
+    Assert.assertEquals(args.getMaxWorkerThreads(), 8);
+  }
+
+  @Test
+  public void testCreateTThreadedSelectorServerArgs() throws Exception {
+    context.put("port", "1111");
+    context.put("workerThreads", "8");
+    context.put("maxReadBufferBytes", "10240");
+    context.put("maxThriftFrameSizeBytes", "1204");
+    context.put("selectorThreads", "2");
+    context.put(
+        "thriftServer",
+        ScribeSourceConfiguration.ThriftServerType.TTHREADED_SELECTOR_SERVER.getValue());
+    configuration.configure(context);
+    TThreadedSelectorServer.Args args =
+        configuration.createTThreadedSelectorServerArgs(null, TestUtils.findFreePort());
+    Assert.assertEquals(args.maxReadBufferBytes, 10240);
+    Assert.assertEquals(args.selectorThreads, 2);
+    Assert.assertEquals(args.getWorkerThreads(), 8);
+  }
+
+  @Test
+  public void testCreateTThreadPoolServerArgs() throws Exception {
+    context.put("port", "1111");
+    context.put("workerThreads", "8");
+    context.put("maxReadBufferBytes", "10240");
+    context.put("maxThriftFrameSizeBytes", "1204");
+    context.put("selectorThreads", "2");
+    context.put(
+        "thriftServer",
+        ScribeSourceConfiguration.ThriftServerType.TTHREADPOOL_SERVER.getValue());
+    configuration.configure(context);
+    TThreadPoolServer.Args args =
+        configuration.createTThreadPoolServerArgs(null, TestUtils.findFreePort());
+    Assert.assertEquals(args.minWorkerThreads, 5);
+    Assert.assertEquals(args.maxWorkerThreads, 8);
+  }
+}

--- a/flume-ng-sources/flume-scribe-source/src/test/java/org/apache/flume/source/scribe/TestScribeSourceThriftServerFactory.java
+++ b/flume-ng-sources/flume-scribe-source/src/test/java/org/apache/flume/source/scribe/TestScribeSourceThriftServerFactory.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flume.source.scribe;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import org.apache.flume.Context;
+import org.apache.flume.FlumeException;
+import org.apache.thrift.server.THsHaServer;
+import org.apache.thrift.server.TServer;
+import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.server.TThreadedSelectorServer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestScribeSourceThriftServerFactory {
+  private static final Logger logger =
+      LoggerFactory.getLogger(TestScribeSourceThriftServerFactory.class);
+  Context context;
+  ScribeSource.Receiver receiver;
+  ScribeSourceConfiguration configuration;
+
+  @Before
+  public void setUp() {
+    int port = 11111;
+    try {
+      ServerSocket socket = new ServerSocket(0);
+      port = socket.getLocalPort();
+      socket.close();
+    } catch (IOException ex) {
+      logger.error("Got exception while finding port", ex);
+    }
+    context = new Context();
+    context.put("port", Integer.toString(port));
+    context.put("workerThreads", "8");
+    context.put("maxReadBufferBytes", "10240");
+    context.put("maxThriftFrameSizeBytes", "1204");
+    ScribeSource source = new ScribeSource();
+    configuration = new ScribeSourceConfiguration();
+    receiver = source.new Receiver();
+  }
+
+  @After
+  public void tearDown() {
+    context = null;
+    receiver = null;
+    configuration = null;
+  }
+
+  /**
+   * This function has purposes:
+   * 1. Test server's function.
+   * 2. Release server port as TNonblockingServerSocket will
+   * automatically bind port and call server.stop() won't help if server
+   * hadn't be started.
+   * @param server
+   */
+  public void testServer(final TServer server) {
+    Thread serverThread = new Thread(new Runnable() {
+      @Override
+      public void run(){
+        server.serve();
+      }
+    });
+    serverThread.start();
+    while (!server.isServing()) {
+      try {
+        Thread.sleep(500);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    server.stop();
+  }
+
+  @Test
+  public void testThshaServer() {
+    context.put(
+        "thriftServer",
+        ScribeSourceConfiguration.ThriftServerType.THSHA_SERVER.getValue());
+    configuration.configure(context);
+    TServer server = ScribeSourceThriftServerFactory.create(configuration, receiver);
+    Assert.assertTrue(server instanceof THsHaServer);
+    testServer(server);
+  }
+
+  @Test
+  public void testTThreadedSelectorServer() {
+    context.put(
+        "thriftServer",
+        ScribeSourceConfiguration.
+            ThriftServerType.TTHREADED_SELECTOR_SERVER.getValue());
+    configuration.configure(context);
+    TServer server = ScribeSourceThriftServerFactory.create(configuration, receiver);
+    Assert.assertTrue(server instanceof TThreadedSelectorServer);
+    testServer(server);
+  }
+
+  @Test
+  public void testTThreadPoolServer() {
+    context.put(
+        "thriftServer",
+        ScribeSourceConfiguration.
+            ThriftServerType.TTHREADPOOL_SERVER.getValue());
+    configuration.configure(context);
+    TServer server = ScribeSourceThriftServerFactory.create(configuration, receiver);
+    Assert.assertTrue(server instanceof TThreadPoolServer);
+    testServer(server);
+  }
+
+  @Test(expected = FlumeException.class)
+  public void testIllegalThriftServer() {
+    configuration.configure(context);
+    configuration.thriftServerType = null;
+    ScribeSourceThriftServerFactory.create(configuration, receiver);
+  }
+}

--- a/flume-ng-sources/flume-scribe-source/src/test/java/org/apache/flume/source/scribe/TestUtils.java
+++ b/flume-ng-sources/flume-scribe-source/src/test/java/org/apache/flume/source/scribe/TestUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flume.source.scribe;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public final class TestUtils {
+  public static int findFreePort() throws IOException {
+    ServerSocket socket = new ServerSocket(0);
+    int port = socket.getLocalPort();
+    socket.close();
+    return port;
+  }
+}


### PR DESCRIPTION
We added following options:
  1. ThriftServerType, user choose one of {THshaServer, TThreadedSelectorServer, TThreadPoolServer} baed on their own traffic pattern. More details on thrift server could be found on Apache Thrift project.
  2. MaxThriftFrameSizeBytes: thrift frame size limit.
  3. MaxReadBufferSize. The buffer size thrift used to handle requests, increase the buffer will benefit throughput under heavy load.