### PR TITLE
FLUME-3050 add counters for error conditions and expose to monitor URL

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/AvroCLIClient.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/AvroCLIClient.java
@@ -43,6 +43,7 @@ import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.api.RpcClient;
 import org.apache.flume.api.RpcClientFactory;
+import org.apache.flume.instrumentation.SourceCounter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -203,7 +204,9 @@ public class AvroCLIClient {
         reader = new SimpleTextLineEventReader(new FileReader(new File(fileName)));
       } else if (dirName != null) {
         reader = new ReliableSpoolingFileEventReader.Builder()
-            .spoolDirectory(new File(dirName)).build();
+            .spoolDirectory(new File(dirName))
+            .sourceCounter(new SourceCounter("avrocli"))
+            .build();
       } else {
         reader = new SimpleTextLineEventReader(new InputStreamReader(System.in));
       }

--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
@@ -359,7 +359,6 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
   public List<Event> readEvents(int numEvents) throws IOException {
     if (!committed) {
       if (!currentFile.isPresent()) {
-        sourceCounter.incrementEventReadFail();
         throw new IllegalStateException("File should not roll when " +
             "commit is outstanding.");
       }
@@ -464,12 +463,10 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
     // Verify that spooling assumptions hold
     if (fileToRoll.lastModified() != currentFile.get().getLastModified()) {
       String message = "File has been modified since being read: " + fileToRoll;
-      sourceCounter.incrementGenericProcessingFail();
       throw new IllegalStateException(message);
     }
     if (fileToRoll.length() != currentFile.get().getLength()) {
       String message = "File has changed size since being read: " + fileToRoll;
-      sourceCounter.incrementGenericProcessingFail();
       throw new IllegalStateException(message);
     }
 
@@ -521,7 +518,6 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
       } else {
         String message = "File name has been re-used with different" +
             " files. Spooling assumptions violated for " + dest;
-        sourceCounter.incrementGenericProcessingFail();
         throw new IllegalStateException(message);
       }
 
@@ -529,7 +525,6 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
     } else if (dest.exists()) {
       String message = "File name has been re-used with different" +
           " files. Spooling assumptions violated for " + dest;
-      sourceCounter.incrementGenericProcessingFail();
       throw new IllegalStateException(message);
 
       // Destination file does not already exist. We are good to go!
@@ -547,7 +542,6 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
         String message = "Unable to move " + fileToRoll + " to " + dest +
             ". This will likely cause duplicate events. Please verify that " +
             "flume has sufficient permissions to perform these operations.";
-        sourceCounter.incrementGenericProcessingFail();
         throw new FlumeException(message);
       }
     }
@@ -584,7 +578,6 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
       return;
     }
     if (!fileToDelete.delete()) {
-      sourceCounter.incrementGenericProcessingFail();
       throw new IOException("Unable to delete spool file: " + fileToDelete);
     }
     // now we no longer need the meta file

--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
@@ -268,6 +268,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
     } catch (IOException e) {
       logger.error("I/O exception occurred while listing directories. " +
                    "Files already matched will be returned. " + directory, e);
+      sourceCounter.incrementGenericProcessingFail();
     }
 
     return candidateFiles;
@@ -456,6 +457,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
         if (!deleted) {
           logger.error("Unable to delete file " + fileToRoll.getAbsolutePath() +
               ". It will likely be ingested another time.");
+          sourceCounter.incrementGenericProcessingFail();
         }
       } else {
         String message = "File name has been re-used with different" +
@@ -615,6 +617,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
       return Optional.absent();
     } catch (IOException e) {
       logger.error("Exception opening file: " + file, e);
+      sourceCounter.incrementGenericProcessingFail();
       return Optional.absent();
     }
   }

--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
@@ -303,7 +303,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
   public List<Event> readEvents(int numEvents) throws IOException {
     if (!committed) {
       if (!currentFile.isPresent()) {
-        sourceCounter.incrementReadFail();
+        sourceCounter.incrementEventReadFail();
         throw new IllegalStateException("File should not roll when " +
             "commit is outstanding.");
       }

--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
@@ -877,6 +877,10 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
     }
 
     public ReliableSpoolingFileEventReader build() throws IOException {
+      if (sourceCounter == null) {
+        sourceCounter = new SourceCounter("noop");
+      }
+
       return new ReliableSpoolingFileEventReader(spoolDirectory, completedSuffix,
           includePattern, ignorePattern, trackerDirPath, annotateFileName, fileNameHeader,
           annotateBaseName, baseNameHeader, deserializerType,

--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/ReliableSpoolingFileEventReader.java
@@ -408,12 +408,12 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
     // Verify that spooling assumptions hold
     if (fileToRoll.lastModified() != currentFile.get().getLastModified()) {
       String message = "File has been modified since being read: " + fileToRoll;
-      sourceCounter.incrementFileHandlingFail();
+      sourceCounter.incrementGenericProcessingFail();
       throw new IllegalStateException(message);
     }
     if (fileToRoll.length() != currentFile.get().getLength()) {
       String message = "File has changed size since being read: " + fileToRoll;
-      sourceCounter.incrementFileHandlingFail();
+      sourceCounter.incrementGenericProcessingFail();
       throw new IllegalStateException(message);
     }
 
@@ -460,7 +460,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
       } else {
         String message = "File name has been re-used with different" +
             " files. Spooling assumptions violated for " + dest;
-        sourceCounter.incrementFileHandlingFail();
+        sourceCounter.incrementGenericProcessingFail();
         throw new IllegalStateException(message);
       }
 
@@ -468,7 +468,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
     } else if (dest.exists()) {
       String message = "File name has been re-used with different" +
           " files. Spooling assumptions violated for " + dest;
-      sourceCounter.incrementFileHandlingFail();
+      sourceCounter.incrementGenericProcessingFail();
       throw new IllegalStateException(message);
 
       // Destination file does not already exist. We are good to go!
@@ -486,7 +486,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
         String message = "Unable to move " + fileToRoll + " to " + dest +
             ". This will likely cause duplicate events. Please verify that " +
             "flume has sufficient permissions to perform these operations.";
-        sourceCounter.incrementFileHandlingFail();
+        sourceCounter.incrementGenericProcessingFail();
         throw new FlumeException(message);
       }
     }
@@ -505,7 +505,7 @@ public class ReliableSpoolingFileEventReader implements ReliableEventReader {
       return;
     }
     if (!fileToDelete.delete()) {
-      sourceCounter.incrementFileHandlingFail();
+      sourceCounter.incrementGenericProcessingFail();
       throw new IOException("Unable to delete spool file: " + fileToDelete);
     }
     // now we no longer need the meta file

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
@@ -50,9 +50,6 @@ public class SinkCounter extends MonitoredCounterGroup implements
   private static final String COUNTER_EVENT_WRITE_FAIL =
       "sink.event.write.fail";
 
-  private static final String COUNTER_FILE_HANDLING_FAIL =
-      "sink.file.handling.fail";
-
   private static final String COUNTER_CHANNEL_READ_FAIL =
       "sink.channel.write.fail";
 
@@ -61,8 +58,7 @@ public class SinkCounter extends MonitoredCounterGroup implements
     COUNTER_CONNECTION_FAILED, COUNTER_BATCH_EMPTY,
     COUNTER_BATCH_UNDERFLOW, COUNTER_BATCH_COMPLETE,
     COUNTER_EVENT_DRAIN_ATTEMPT, COUNTER_EVENT_DRAIN_SUCCESS,
-    COUNTER_EVENT_WRITE_FAIL, COUNTER_FILE_HANDLING_FAIL,
-    COUNTER_CHANNEL_READ_FAIL
+    COUNTER_EVENT_WRITE_FAIL, COUNTER_CHANNEL_READ_FAIL
   };
 
   public SinkCounter(String name) {
@@ -162,11 +158,7 @@ public class SinkCounter extends MonitoredCounterGroup implements
     return increment(COUNTER_CHANNEL_READ_FAIL);
   }
 
-  public long incrementFileHandlingFail() {
-    return increment(COUNTER_FILE_HANDLING_FAIL);
-  }
-
-  public long incrementWriteOrChannelFail(Throwable t) {
+  public long incrementEventWriteOrChannelFail(Throwable t) {
     if (t instanceof ChannelException) {
       return incrementChannelReadFail();
     }
@@ -179,10 +171,6 @@ public class SinkCounter extends MonitoredCounterGroup implements
 
   public long getChannelReadFail() {
     return get(COUNTER_CHANNEL_READ_FAIL);
-  }
-
-  public long getFileHandlingFail() {
-    return get(COUNTER_FILE_HANDLING_FAIL);
   }
 
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
@@ -166,7 +166,7 @@ public class SinkCounter extends MonitoredCounterGroup implements
     return increment(COUNTER_FILE_HANDLING_FAIL);
   }
 
-  public long incrementFail(Throwable t) {
+  public long incrementWriteOrChannelFail(Throwable t) {
     if (t instanceof ChannelException) {
       return incrementChannelReadFail();
     }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
@@ -51,7 +51,7 @@ public class SinkCounter extends MonitoredCounterGroup implements
       "sink.event.write.fail";
 
   private static final String COUNTER_CHANNEL_READ_FAIL =
-      "sink.channel.write.fail";
+      "sink.channel.read.fail";
 
   private static final String[] ATTRIBUTES = {
     COUNTER_CONNECTION_CREATED, COUNTER_CONNECTION_CLOSED,

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
@@ -154,8 +154,18 @@ public class SinkCounter extends MonitoredCounterGroup implements
     return increment(COUNTER_EVENT_WRITE_FAIL);
   }
 
+  @Override
+  public long getEventWriteFail() {
+    return get(COUNTER_EVENT_WRITE_FAIL);
+  }
+
   public long incrementChannelReadFail() {
     return increment(COUNTER_CHANNEL_READ_FAIL);
+  }
+
+  @Override
+  public long getChannelReadFail() {
+    return get(COUNTER_CHANNEL_READ_FAIL);
   }
 
   public long incrementEventWriteOrChannelFail(Throwable t) {
@@ -163,14 +173,6 @@ public class SinkCounter extends MonitoredCounterGroup implements
       return incrementChannelReadFail();
     }
     return incrementEventWriteFail();
-  }
-
-  public long getEventWriteFail() {
-    return get(COUNTER_EVENT_WRITE_FAIL);
-  }
-
-  public long getChannelReadFail() {
-    return get(COUNTER_CHANNEL_READ_FAIL);
   }
 
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounter.java
@@ -18,6 +18,7 @@
 package org.apache.flume.instrumentation;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.flume.ChannelException;
 
 public class SinkCounter extends MonitoredCounterGroup implements
     SinkCounterMBean {
@@ -46,11 +47,22 @@ public class SinkCounter extends MonitoredCounterGroup implements
   private static final String COUNTER_EVENT_DRAIN_SUCCESS =
       "sink.event.drain.sucess";
 
+  private static final String COUNTER_EVENT_WRITE_FAIL =
+      "sink.event.write.fail";
+
+  private static final String COUNTER_FILE_HANDLING_FAIL =
+      "sink.file.handling.fail";
+
+  private static final String COUNTER_CHANNEL_READ_FAIL =
+      "sink.channel.write.fail";
+
   private static final String[] ATTRIBUTES = {
     COUNTER_CONNECTION_CREATED, COUNTER_CONNECTION_CLOSED,
     COUNTER_CONNECTION_FAILED, COUNTER_BATCH_EMPTY,
     COUNTER_BATCH_UNDERFLOW, COUNTER_BATCH_COMPLETE,
-    COUNTER_EVENT_DRAIN_ATTEMPT, COUNTER_EVENT_DRAIN_SUCCESS
+    COUNTER_EVENT_DRAIN_ATTEMPT, COUNTER_EVENT_DRAIN_SUCCESS,
+    COUNTER_EVENT_WRITE_FAIL, COUNTER_FILE_HANDLING_FAIL,
+    COUNTER_CHANNEL_READ_FAIL
   };
 
   public SinkCounter(String name) {
@@ -141,4 +153,36 @@ public class SinkCounter extends MonitoredCounterGroup implements
   public long addToEventDrainSuccessCount(long delta) {
     return addAndGet(COUNTER_EVENT_DRAIN_SUCCESS, delta);
   }
+
+  public long incrementEventWriteFail() {
+    return increment(COUNTER_EVENT_WRITE_FAIL);
+  }
+
+  public long incrementChannelReadFail() {
+    return increment(COUNTER_CHANNEL_READ_FAIL);
+  }
+
+  public long incrementFileHandlingFail() {
+    return increment(COUNTER_FILE_HANDLING_FAIL);
+  }
+
+  public long incrementFail(Throwable t) {
+    if (t instanceof ChannelException) {
+      return incrementChannelReadFail();
+    }
+    return incrementEventWriteFail();
+  }
+
+  public long getEventWriteFail() {
+    return get(COUNTER_EVENT_WRITE_FAIL);
+  }
+
+  public long getChannelReadFail() {
+    return get(COUNTER_CHANNEL_READ_FAIL);
+  }
+
+  public long getFileHandlingFail() {
+    return get(COUNTER_FILE_HANDLING_FAIL);
+  }
+
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounterMBean.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounterMBean.java
@@ -53,6 +53,4 @@ public interface SinkCounterMBean {
 
   long getChannelReadFail();
 
-  long getFileHandlingFail();
-
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounterMBean.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SinkCounterMBean.java
@@ -48,4 +48,11 @@ public interface SinkCounterMBean {
   long getStopTime();
 
   String getType();
+
+  long getEventWriteFail();
+
+  long getChannelReadFail();
+
+  long getFileHandlingFail();
+
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
@@ -56,8 +56,7 @@ public class SourceCounter extends MonitoredCounterGroup implements
     COUNTER_APPEND_RECEIVED, COUNTER_APPEND_ACCEPTED,
     COUNTER_APPEND_BATCH_RECEIVED, COUNTER_APPEND_BATCH_ACCEPTED,
     COUNTER_OPEN_CONNECTION_COUNT, COUNTER_EVENT_READ_FAIL,
-    COUNTER_CHANNEL_WRITE_FAIL,
-      COUNTER_GENERIC_PROCESSING_FAIL
+    COUNTER_CHANNEL_WRITE_FAIL, COUNTER_GENERIC_PROCESSING_FAIL
   };
 
   public SourceCounter(String name) {
@@ -151,7 +150,7 @@ public class SourceCounter extends MonitoredCounterGroup implements
     return increment(COUNTER_GENERIC_PROCESSING_FAIL);
   }
 
-  public long incrementReadOrChannelFail(Throwable t) {
+  public long incrementEventReadOrChannelFail(Throwable t) {
     if (t instanceof ChannelException) {
       return incrementChannelWriteFail();
     }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
@@ -37,15 +37,25 @@ public class SourceCounter extends MonitoredCounterGroup implements
       "src.append-batch.received";
   private static final String COUNTER_APPEND_BATCH_ACCEPTED =
       "src.append-batch.accepted";
-  
+
   private static final String COUNTER_OPEN_CONNECTION_COUNT =
           "src.open-connection.count";
+
+  private static final String COUNTER_READ_FAIL =
+      "src.file.read.fail";
+
+  private static final String COUNTER_FILE_HANDLING_FAIL =
+      "src.file.handling.fail";
+
+  private static final String COUNTER_CHANNEL_WRITE_FAIL =
+      "src.channel.write.fail";
 
   private static final String[] ATTRIBUTES = {
     COUNTER_EVENTS_RECEIVED, COUNTER_EVENTS_ACCEPTED,
     COUNTER_APPEND_RECEIVED, COUNTER_APPEND_ACCEPTED,
     COUNTER_APPEND_BATCH_RECEIVED, COUNTER_APPEND_BATCH_ACCEPTED,
-    COUNTER_OPEN_CONNECTION_COUNT
+    COUNTER_OPEN_CONNECTION_COUNT, COUNTER_READ_FAIL,
+    COUNTER_FILE_HANDLING_FAIL
   };
 
   public SourceCounter(String name) {
@@ -125,5 +135,17 @@ public class SourceCounter extends MonitoredCounterGroup implements
 
   public void setOpenConnectionCount(long openConnectionCount) {
     set(COUNTER_OPEN_CONNECTION_COUNT, openConnectionCount);
+  }
+
+  public long incrementReadFail() {
+    return increment(COUNTER_READ_FAIL);
+  }
+
+  public long incrementChannelWriteFail() {
+    return increment(COUNTER_CHANNEL_WRITE_FAIL);
+  }
+
+  public long incrementFileHandlingFail() {
+    return increment(COUNTER_FILE_HANDLING_FAIL);
   }
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
@@ -142,12 +142,27 @@ public class SourceCounter extends MonitoredCounterGroup implements
     return increment(COUNTER_EVENT_READ_FAIL);
   }
 
+  @Override
+  public long getEventReadFail() {
+    return get(COUNTER_EVENT_READ_FAIL);
+  }
+
   public long incrementChannelWriteFail() {
     return increment(COUNTER_CHANNEL_WRITE_FAIL);
   }
 
+  @Override
+  public long getChannelWriteFail() {
+    return get(COUNTER_CHANNEL_WRITE_FAIL);
+  }
+
   public long incrementGenericProcessingFail() {
     return increment(COUNTER_GENERIC_PROCESSING_FAIL);
+  }
+
+  @Override
+  public long getGenericProcessingFail() {
+    return get(COUNTER_GENERIC_PROCESSING_FAIL);
   }
 
   public long incrementEventReadOrChannelFail(Throwable t) {
@@ -157,18 +172,4 @@ public class SourceCounter extends MonitoredCounterGroup implements
     return incrementEventReadFail();
   }
 
-  @Override
-  public long getEventReadFail() {
-    return get(COUNTER_EVENT_READ_FAIL);
-  }
-
-  @Override
-  public long getChannelWriteFail() {
-    return get(COUNTER_CHANNEL_WRITE_FAIL);
-  }
-
-  @Override
-  public long getGenericProcessingFail() {
-    return get(COUNTER_GENERIC_PROCESSING_FAIL);
-  }
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
@@ -45,8 +45,8 @@ public class SourceCounter extends MonitoredCounterGroup implements
   private static final String COUNTER_EVENT_READ_FAIL =
       "src.event.read.fail";
 
-  private static final String COUNTER_FILE_HANDLING_FAIL =
-      "src.file.handling.fail";
+  private static final String COUNTER_GENERIC_PROCESSING_FAIL =
+      "src.generic.processing.fail";
 
   private static final String COUNTER_CHANNEL_WRITE_FAIL =
       "src.channel.write.fail";
@@ -56,7 +56,8 @@ public class SourceCounter extends MonitoredCounterGroup implements
     COUNTER_APPEND_RECEIVED, COUNTER_APPEND_ACCEPTED,
     COUNTER_APPEND_BATCH_RECEIVED, COUNTER_APPEND_BATCH_ACCEPTED,
     COUNTER_OPEN_CONNECTION_COUNT, COUNTER_EVENT_READ_FAIL,
-    COUNTER_FILE_HANDLING_FAIL, COUNTER_CHANNEL_WRITE_FAIL
+    COUNTER_CHANNEL_WRITE_FAIL,
+      COUNTER_GENERIC_PROCESSING_FAIL
   };
 
   public SourceCounter(String name) {
@@ -146,11 +147,11 @@ public class SourceCounter extends MonitoredCounterGroup implements
     return increment(COUNTER_CHANNEL_WRITE_FAIL);
   }
 
-  public long incrementFileHandlingFail() {
-    return increment(COUNTER_FILE_HANDLING_FAIL);
+  public long incrementGenericProcessingFail() {
+    return increment(COUNTER_GENERIC_PROCESSING_FAIL);
   }
 
-  public long incrementFail(Throwable t) {
+  public long incrementReadOrChannelFail(Throwable t) {
     if (t instanceof ChannelException) {
       return incrementChannelWriteFail();
     }
@@ -168,7 +169,7 @@ public class SourceCounter extends MonitoredCounterGroup implements
   }
 
   @Override
-  public long getFileHandlingFail() {
-    return get(COUNTER_FILE_HANDLING_FAIL);
+  public long getGenericProcessingFail() {
+    return get(COUNTER_GENERIC_PROCESSING_FAIL);
   }
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounter.java
@@ -19,6 +19,7 @@
 package org.apache.flume.instrumentation;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.flume.ChannelException;
 
 public class SourceCounter extends MonitoredCounterGroup implements
     SourceCounterMBean {
@@ -41,8 +42,8 @@ public class SourceCounter extends MonitoredCounterGroup implements
   private static final String COUNTER_OPEN_CONNECTION_COUNT =
           "src.open-connection.count";
 
-  private static final String COUNTER_READ_FAIL =
-      "src.file.read.fail";
+  private static final String COUNTER_EVENT_READ_FAIL =
+      "src.event.read.fail";
 
   private static final String COUNTER_FILE_HANDLING_FAIL =
       "src.file.handling.fail";
@@ -54,8 +55,8 @@ public class SourceCounter extends MonitoredCounterGroup implements
     COUNTER_EVENTS_RECEIVED, COUNTER_EVENTS_ACCEPTED,
     COUNTER_APPEND_RECEIVED, COUNTER_APPEND_ACCEPTED,
     COUNTER_APPEND_BATCH_RECEIVED, COUNTER_APPEND_BATCH_ACCEPTED,
-    COUNTER_OPEN_CONNECTION_COUNT, COUNTER_READ_FAIL,
-    COUNTER_FILE_HANDLING_FAIL
+    COUNTER_OPEN_CONNECTION_COUNT, COUNTER_EVENT_READ_FAIL,
+    COUNTER_FILE_HANDLING_FAIL, COUNTER_CHANNEL_WRITE_FAIL
   };
 
   public SourceCounter(String name) {
@@ -137,8 +138,8 @@ public class SourceCounter extends MonitoredCounterGroup implements
     set(COUNTER_OPEN_CONNECTION_COUNT, openConnectionCount);
   }
 
-  public long incrementReadFail() {
-    return increment(COUNTER_READ_FAIL);
+  public long incrementEventReadFail() {
+    return increment(COUNTER_EVENT_READ_FAIL);
   }
 
   public long incrementChannelWriteFail() {
@@ -147,5 +148,27 @@ public class SourceCounter extends MonitoredCounterGroup implements
 
   public long incrementFileHandlingFail() {
     return increment(COUNTER_FILE_HANDLING_FAIL);
+  }
+
+  public long incrementFail(Throwable t) {
+    if (t instanceof ChannelException) {
+      return incrementChannelWriteFail();
+    }
+    return incrementEventReadFail();
+  }
+
+  @Override
+  public long getEventReadFail() {
+    return get(COUNTER_EVENT_READ_FAIL);
+  }
+
+  @Override
+  public long getChannelWriteFail() {
+    return get(COUNTER_CHANNEL_WRITE_FAIL);
+  }
+
+  @Override
+  public long getFileHandlingFail() {
+    return get(COUNTER_FILE_HANDLING_FAIL);
   }
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounterMBean.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounterMBean.java
@@ -45,4 +45,11 @@ public interface SourceCounterMBean {
   String getType();
 
   long getOpenConnectionCount();
+
+  long getEventReadFail();
+
+  long getChannelWriteFail();
+
+  long getFileHandlingFail();
+
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounterMBean.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/SourceCounterMBean.java
@@ -50,6 +50,6 @@ public interface SourceCounterMBean {
 
   long getChannelWriteFail();
 
-  long getFileHandlingFail();
+  long getGenericProcessingFail();
 
 }

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/AbstractRpcSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/AbstractRpcSink.java
@@ -383,8 +383,10 @@ public abstract class AbstractRpcSink extends AbstractSink implements Configurab
       } else if (t instanceof ChannelException) {
         logger.error("Rpc Sink " + getName() + ": Unable to get event from" +
             " channel " + channel.getName() + ". Exception follows.", t);
+        sinkCounter.incrementChannelReadFail();
         status = Status.BACKOFF;
       } else {
+        sinkCounter.incrementEventWriteFail();
         destroyConnection();
         throw new EventDeliveryException("Failed to send events", t);
       }

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
@@ -220,6 +220,7 @@ public class RollingFileSink extends AbstractSink implements Configurable {
       transaction.commit();
       sinkCounter.addToEventDrainSuccessCount(eventAttemptCounter);
     } catch (Exception ex) {
+      sinkCounter.incrementFail(ex);
       transaction.rollback();
       throw new EventDeliveryException("Failed to process transaction", ex);
     } finally {

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
@@ -220,7 +220,7 @@ public class RollingFileSink extends AbstractSink implements Configurable {
       transaction.commit();
       sinkCounter.addToEventDrainSuccessCount(eventAttemptCounter);
     } catch (Exception ex) {
-      sinkCounter.incrementFail(ex);
+      sinkCounter.incrementWriteOrChannelFail(ex);
       transaction.rollback();
       throw new EventDeliveryException("Failed to process transaction", ex);
     } finally {

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
@@ -220,7 +220,7 @@ public class RollingFileSink extends AbstractSink implements Configurable {
       transaction.commit();
       sinkCounter.addToEventDrainSuccessCount(eventAttemptCounter);
     } catch (Exception ex) {
-      sinkCounter.incrementWriteOrChannelFail(ex);
+      sinkCounter.incrementEventWriteOrChannelFail(ex);
       transaction.rollback();
       throw new EventDeliveryException("Failed to process transaction", ex);
     } finally {

--- a/flume-ng-core/src/main/java/org/apache/flume/source/AvroSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/AvroSource.java
@@ -363,6 +363,7 @@ public class AvroSource extends AbstractSource implements EventDrivenSource,
     } catch (ChannelException ex) {
       logger.warn("Avro source " + getName() + ": Unable to process event. " +
           "Exception follows.", ex);
+      sourceCounter.incrementChannelWriteFail();
       return Status.FAILED;
     }
 
@@ -393,6 +394,7 @@ public class AvroSource extends AbstractSource implements EventDrivenSource,
     } catch (Throwable t) {
       logger.error("Avro source " + getName() + ": Unable to process event " +
           "batch. Exception follows.", t);
+      sourceCounter.incrementChannelWriteFail();
       if (t instanceof Error) {
         throw (Error) t;
       }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
@@ -320,7 +320,7 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
           sourceCounter.addToEventAcceptedCount(numEvents);
         } catch (Throwable t) {
           logger.error("Error writing to channel, event dropped", t);
-          sourceCounter.incrementReadFail();
+          sourceCounter.incrementFail(t);
           if (t instanceof Error) {
             Throwables.propagate(t);
           }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
@@ -320,6 +320,7 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
           sourceCounter.addToEventAcceptedCount(numEvents);
         } catch (Throwable t) {
           logger.error("Error writing to channel, event dropped", t);
+          sourceCounter.incrementReadFail();
           if (t instanceof Error) {
             Throwables.propagate(t);
           }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
@@ -243,6 +243,7 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
     public void exceptionCaught(IoSession session, Throwable cause)
         throws Exception {
       logger.error("Error in syslog message handler", cause);
+      sourceCounter.incrementGenericProcessingFail();
       if (cause instanceof Error) {
         Throwables.propagate(cause);
       }
@@ -320,7 +321,7 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
           sourceCounter.addToEventAcceptedCount(numEvents);
         } catch (Throwable t) {
           logger.error("Error writing to channel, event dropped", t);
-          sourceCounter.incrementFail(t);
+          sourceCounter.incrementReadOrChannelFail(t);
           if (t instanceof Error) {
             Throwables.propagate(t);
           }
@@ -342,6 +343,7 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
       } catch (Throwable t) {
         logger.info("Error decoding line with charset (" + decoder.charset() +
             "). Exception follows.", t);
+        sourceCounter.incrementEventReadFail();
 
         if (t instanceof Error) {
           Throwables.propagate(t);
@@ -378,6 +380,7 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
         event.getHeaders().put(SyslogUtils.EVENT_STATUS,
             SyslogUtils.SyslogStatus.INVALID.getSyslogStatus());
         logger.debug("Error parsing syslog event", ex);
+        sourceCounter.incrementEventReadFail();
       }
 
       return event;

--- a/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/MultiportSyslogTCPSource.java
@@ -321,7 +321,7 @@ public class MultiportSyslogTCPSource extends AbstractSource implements
           sourceCounter.addToEventAcceptedCount(numEvents);
         } catch (Throwable t) {
           logger.error("Error writing to channel, event dropped", t);
-          sourceCounter.incrementReadOrChannelFail(t);
+          sourceCounter.incrementEventReadOrChannelFail(t);
           if (t instanceof Error) {
             Throwables.propagate(t);
           }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SequenceGeneratorSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SequenceGeneratorSource.java
@@ -93,6 +93,7 @@ public class SequenceGeneratorSource extends AbstractPollableSource implements
       eventsSent = eventsSentTX;
     } catch (ChannelException ex) {
       logger.error( getName() + " source could not write to channel.", ex);
+      sourceCounter.incrementChannelWriteFail();
     }
 
     return status;

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SpoolDirectorySource.java
@@ -104,6 +104,7 @@ public class SpoolDirectorySource extends AbstractSource
           .decodeErrorPolicy(decodeErrorPolicy)
           .consumeOrder(consumeOrder)
           .recursiveDirectorySearch(recursiveDirectorySearch)
+          .sourceCounter(sourceCounter)
           .build();
     } catch (IOException ioe) {
       throw new FlumeException("Error instantiating spooling event parser",

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogTcpSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogTcpSource.java
@@ -96,8 +96,10 @@ public class SyslogTcpSource extends AbstractSource
           sourceCounter.incrementEventAcceptedCount();
         } catch (ChannelException ex) {
           logger.error("Error writting to channel, event dropped", ex);
+          sourceCounter.incrementChannelWriteFail();
         } catch (RuntimeException ex) {
           logger.error("Error parsing event from syslog stream, event dropped", ex);
+          sourceCounter.incrementReadFail();
           return;
         }
       }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogTcpSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogTcpSource.java
@@ -96,8 +96,10 @@ public class SyslogTcpSource extends AbstractSource
           sourceCounter.incrementEventAcceptedCount();
         } catch (ChannelException ex) {
           logger.error("Error writting to channel, event dropped", ex);
+          sourceCounter.incrementChannelWriteFail();
         } catch (RuntimeException ex) {
           logger.error("Error parsing event from syslog stream, event dropped", ex);
+          sourceCounter.incrementEventReadFail();
           return;
         }
       }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogTcpSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogTcpSource.java
@@ -96,10 +96,8 @@ public class SyslogTcpSource extends AbstractSource
           sourceCounter.incrementEventAcceptedCount();
         } catch (ChannelException ex) {
           logger.error("Error writting to channel, event dropped", ex);
-          sourceCounter.incrementChannelWriteFail();
         } catch (RuntimeException ex) {
           logger.error("Error parsing event from syslog stream, event dropped", ex);
-          sourceCounter.incrementReadFail();
           return;
         }
       }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUDPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUDPSource.java
@@ -95,7 +95,7 @@ public class SyslogUDPSource extends AbstractSource
         return;
       } catch (RuntimeException ex) {
         logger.error("Error parsing event from syslog stream, event dropped", ex);
-        sourceCounter.incrementReadFail();
+        sourceCounter.incrementEventReadFail();
         return;
       }
     }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUDPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUDPSource.java
@@ -91,9 +91,11 @@ public class SyslogUDPSource extends AbstractSource
         sourceCounter.incrementEventAcceptedCount();
       } catch (ChannelException ex) {
         logger.error("Error writting to channel", ex);
+        sourceCounter.incrementChannelWriteFail();
         return;
       } catch (RuntimeException ex) {
         logger.error("Error parsing event from syslog stream, event dropped", ex);
+        sourceCounter.incrementReadFail();
         return;
       }
     }

--- a/flume-ng-core/src/main/java/org/apache/flume/source/ThriftSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/ThriftSource.java
@@ -430,6 +430,7 @@ public class ThriftSource extends AbstractSource implements Configurable, EventD
       } catch (ChannelException ex) {
         logger.warn("Thrift source " + getName() + " could not append events " +
                     "to the channel.", ex);
+        sourceCounter.incrementChannelWriteFail();
         return Status.FAILED;
       }
       sourceCounter.incrementAppendAcceptedCount();
@@ -451,6 +452,7 @@ public class ThriftSource extends AbstractSource implements Configurable, EventD
         getChannelProcessor().processEventBatch(flumeEvents);
       } catch (ChannelException ex) {
         logger.warn("Thrift source %s could not append events to the channel.", getName());
+        sourceCounter.incrementChannelWriteFail();
         return Status.FAILED;
       }
 

--- a/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
@@ -293,7 +293,7 @@ public class HTTPSource extends AbstractSource implements
         return;
       } catch (Exception ex) {
         LOG.warn("Unexpected error appending event to channel. ", ex);
-        sourceCounter.incrementChannelWriteFail();
+        sourceCounter.incrementGenericProcessingFail();
         response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                 "Unexpected error while appending event to channel. "
                 + ex.getMessage());

--- a/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
@@ -265,14 +265,14 @@ public class HTTPSource extends AbstractSource implements
         events = handler.getEvents(request);
       } catch (HTTPBadRequestException ex) {
         LOG.warn("Received bad request from client. ", ex);
-        sourceCounter.incrementReadFail();
+        sourceCounter.incrementEventReadFail();
         response.sendError(HttpServletResponse.SC_BAD_REQUEST,
                 "Bad request from client. "
                 + ex.getMessage());
         return;
       } catch (Exception ex) {
         LOG.warn("Deserializer threw unexpected exception. ", ex);
-        sourceCounter.incrementReadFail();
+        sourceCounter.incrementEventReadFail();
         response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                 "Deserializer threw unexpected exception. "
                 + ex.getMessage());

--- a/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
@@ -265,12 +265,14 @@ public class HTTPSource extends AbstractSource implements
         events = handler.getEvents(request);
       } catch (HTTPBadRequestException ex) {
         LOG.warn("Received bad request from client. ", ex);
+        sourceCounter.incrementReadFail();
         response.sendError(HttpServletResponse.SC_BAD_REQUEST,
                 "Bad request from client. "
                 + ex.getMessage());
         return;
       } catch (Exception ex) {
         LOG.warn("Deserializer threw unexpected exception. ", ex);
+        sourceCounter.incrementReadFail();
         response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                 "Deserializer threw unexpected exception. "
                 + ex.getMessage());
@@ -284,12 +286,14 @@ public class HTTPSource extends AbstractSource implements
         LOG.warn("Error appending event to channel. "
                 + "Channel might be full. Consider increasing the channel "
                 + "capacity or make sure the sinks perform faster.", ex);
+        sourceCounter.incrementChannelWriteFail();
         response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
                 "Error appending event to channel. Channel might be full."
                 + ex.getMessage());
         return;
       } catch (Exception ex) {
         LOG.warn("Unexpected error appending event to channel. ", ex);
+        sourceCounter.incrementChannelWriteFail();
         response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                 "Unexpected error while appending event to channel. "
                 + ex.getMessage());

--- a/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestReliableSpoolingFileEventReader.java
@@ -41,6 +41,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.flume.Event;
 import org.apache.flume.client.avro.ReliableSpoolingFileEventReader.DeletePolicy;
+import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.SpoolDirectorySourceConfigurationConstants;
 import org.apache.flume.source.SpoolDirectorySourceConfigurationConstants.ConsumeOrder;
 import org.junit.After;
@@ -159,6 +160,7 @@ public class TestReliableSpoolingFileEventReader {
         .spoolDirectory(WORK_DIR)
         .includePattern("^file2$")
         .deletePolicy(DeletePolicy.IMMEDIATE.toString())
+        .sourceCounter(new SourceCounter("test"))
         .build();
     
     String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
@@ -180,6 +182,7 @@ public class TestReliableSpoolingFileEventReader {
             .spoolDirectory(WORK_DIR)
             .ignorePattern("^file2$")
             .deletePolicy(DeletePolicy.IMMEDIATE.toString())
+            .sourceCounter(new SourceCounter("test"))
             .build();
 
     String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
@@ -209,7 +212,8 @@ public class TestReliableSpoolingFileEventReader {
         .ignorePattern("^file[013]$")
         .includePattern("^file2$")
         .deletePolicy(DeletePolicy.IMMEDIATE.toString())
-        .build(); 
+        .sourceCounter(new SourceCounter("test"))
+        .build();
 
     String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
     Assert.assertTrue("Expected " + beforeFiles.length + " files in working dir",
@@ -236,6 +240,7 @@ public class TestReliableSpoolingFileEventReader {
         .ignorePattern("^file2$")
         .includePattern("^file2$")
         .deletePolicy(DeletePolicy.IMMEDIATE.toString())
+        .sourceCounter(new SourceCounter("test"))
         .build();
     
     String[] beforeFiles = { "file0", "file1", "file2", "file3", "emptylineFile" };
@@ -253,6 +258,7 @@ public class TestReliableSpoolingFileEventReader {
   public void testRepeatedCallsWithCommitAlways() throws IOException {
     ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
 
     final int expectedLines = 1 + 1 + 2 + 3 + 1;
@@ -275,6 +281,7 @@ public class TestReliableSpoolingFileEventReader {
     ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                      .trackerDirPath(trackerDirPath)
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
 
     final int expectedLines = 1 + 1 + 2 + 3 + 1;
@@ -302,6 +309,7 @@ public class TestReliableSpoolingFileEventReader {
     ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                      .deletePolicy(DeletePolicy.IMMEDIATE.name())
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
 
     List<File> before = listFiles(WORK_DIR);
@@ -325,6 +333,7 @@ public class TestReliableSpoolingFileEventReader {
   public void testNullConsumeOrder() throws IOException {
     new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                  .consumeOrder(null)
+                                                 .sourceCounter(new SourceCounter("test"))
                                                  .build();
   }
   
@@ -333,6 +342,7 @@ public class TestReliableSpoolingFileEventReader {
     ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                      .consumeOrder(ConsumeOrder.RANDOM)
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
     File fileName = new File(WORK_DIR, "new-file");
     FileUtils.write(fileName, "New file created in the end. Shoud be read randomly.\n");
@@ -354,6 +364,7 @@ public class TestReliableSpoolingFileEventReader {
     final ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                      .consumeOrder(ConsumeOrder.RANDOM)
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
     File fileName = new File(WORK_DIR, "new-file");
     FileUtils.write(fileName, "New file created in the end. Shoud be read randomly.\n");
@@ -390,6 +401,7 @@ public class TestReliableSpoolingFileEventReader {
     ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                      .consumeOrder(ConsumeOrder.OLDEST)
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
     File file1 = new File(WORK_DIR, "new-file1");   
     File file2 = new File(WORK_DIR, "new-file2");    
@@ -417,6 +429,7 @@ public class TestReliableSpoolingFileEventReader {
     ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                      .consumeOrder(ConsumeOrder.YOUNGEST)
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
     File file1 = new File(WORK_DIR, "new-file1");
     File file2 = new File(WORK_DIR, "new-file2");
@@ -448,6 +461,7 @@ public class TestReliableSpoolingFileEventReader {
     ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                      .consumeOrder(ConsumeOrder.OLDEST)
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
     File file1 = new File(WORK_DIR, "new-file1");
     File file2 = new File(WORK_DIR, "new-file2");
@@ -477,6 +491,7 @@ public class TestReliableSpoolingFileEventReader {
     ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                      .consumeOrder(ConsumeOrder.YOUNGEST)
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
     File file1 = new File(WORK_DIR, "new-file1");
     File file2 = new File(WORK_DIR, "new-file2");
@@ -535,6 +550,7 @@ public class TestReliableSpoolingFileEventReader {
     ReliableEventReader reader =
         new ReliableSpoolingFileEventReader.Builder().spoolDirectory(WORK_DIR)
                                                      .trackerDirPath(trackerDirPath)
+                                                     .sourceCounter(new SourceCounter("test"))
                                                      .build();
     final int expectedLines = 1;
     int seenLines = 0;
@@ -557,6 +573,7 @@ public class TestReliableSpoolingFileEventReader {
       ReliableEventReader reader =
           new ReliableSpoolingFileEventReader.Builder().spoolDirectory(dir)
                                                        .consumeOrder(order)
+                                                       .sourceCounter(new SourceCounter("test"))
                                                        .build();
       Map<Long, List<String>> expected;
       if (comparator == null) {

--- a/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestSpoolingFileLineReader.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/client/avro/TestSpoolingFileLineReader.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
+import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.serialization.LineDeserializer;
 import org.apache.flume.source.SpoolDirectorySourceConfigurationConstants;
 import org.junit.After;
@@ -71,6 +72,7 @@ public class TestSpoolingFileLineReader {
           .spoolDirectory(tmpDir)
           .completedSuffix(completedSuffix)
           .deserializerContext(ctx)
+          .sourceCounter(new SourceCounter("dummy"))
           .build();
     } catch (IOException ioe) {
       throw Throwables.propagate(ioe);

--- a/flume-ng-core/src/test/java/org/apache/flume/sink/TestAvroSink.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/sink/TestAvroSink.java
@@ -187,27 +187,7 @@ public class TestAvroSink {
     sink.start();
     Channel channel = Mockito.mock(Channel.class);
     Mockito.when(channel.take()).thenThrow(new ChannelException("dummy"));
-    Transaction transaction = new BasicTransactionSemantics() {
-      @Override
-      protected void doPut(Event event) throws InterruptedException {
-
-      }
-
-      @Override
-      protected Event doTake() throws InterruptedException {
-        return null;
-      }
-
-      @Override
-      protected void doCommit() throws InterruptedException {
-
-      }
-
-      @Override
-      protected void doRollback() throws InterruptedException {
-
-      }
-    };
+    Transaction transaction = Mockito.mock(BasicTransactionSemantics.class);
     Mockito.when(channel.getTransaction()).thenReturn(transaction);
     sink.setChannel(channel);
 

--- a/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
@@ -160,15 +160,15 @@ public class TestRollingFileSink {
 
     try {
       doTest(context, channel);
-    } catch (EventDeliveryException e){
+    } catch (EventDeliveryException e) {
       //
     }
     SinkCounter sinkCounter = (SinkCounter) Whitebox.getInternalState(sink, "sinkCounter");
     Assert.assertEquals(1, sinkCounter.getChannelReadFail());
   }
 
-  private void doTest(Context context) throws EventDeliveryException, InterruptedException
-      , IOException {
+  private void doTest(Context context) throws EventDeliveryException, InterruptedException,
+      IOException {
     doTest(context, null);
   }
 

--- a/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
@@ -20,17 +20,24 @@
 package org.apache.flume.sink;
 
 import org.apache.flume.Channel;
+import org.apache.flume.ChannelException;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
+import org.apache.flume.Transaction;
+import org.apache.flume.channel.BasicTransactionSemantics;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.channel.PseudoTxnMemoryChannel;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.event.SimpleEvent;
+import org.apache.flume.instrumentation.SinkCounter;
 import org.apache.flume.lifecycle.LifecycleException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +72,7 @@ public class TestRollingFileSink {
   }
 
   @Test
-  public void testLifecycle() throws InterruptedException, LifecycleException {
+  public void testLifecycle() {
     Context context = new Context();
 
     context.put("sink.directory", tmpDir.getPath());
@@ -77,7 +84,7 @@ public class TestRollingFileSink {
   }
 
   @Test
-  public void testAppend() throws InterruptedException, LifecycleException,
+  public void testAppend() throws InterruptedException,
       EventDeliveryException, IOException {
 
     Context context = new Context();
@@ -86,46 +93,11 @@ public class TestRollingFileSink {
     context.put("sink.rollInterval", "1");
     context.put("sink.batchSize", "1");
 
-    Configurables.configure(sink, context);
-
-    Channel channel = new PseudoTxnMemoryChannel();
-    Configurables.configure(channel, context);
-
-    sink.setChannel(channel);
-    sink.start();
-
-    for (int i = 0; i < 10; i++) {
-      Event event = new SimpleEvent();
-
-      event.setBody(("Test event " + i).getBytes());
-
-      channel.put(event);
-      sink.process();
-
-      Thread.sleep(500);
-    }
-
-    sink.stop();
-
-    for (String file : sink.getDirectory().list()) {
-      BufferedReader reader =
-          new BufferedReader(new FileReader(new File(sink.getDirectory(), file)));
-
-      String lastLine = null;
-      String currentLine = null;
-
-      while ((currentLine = reader.readLine()) != null) {
-        lastLine = currentLine;
-      }
-
-      logger.debug("Produced file:{} lastLine:{}", file, lastLine);
-
-      reader.close();
-    }
+    doTest(context);
   }
 
   @Test
-  public void testAppend2() throws InterruptedException, LifecycleException,
+  public void testAppend2() throws InterruptedException,
       EventDeliveryException, IOException {
 
     Context context = new Context();
@@ -134,48 +106,12 @@ public class TestRollingFileSink {
     context.put("sink.rollInterval", "0");
     context.put("sink.batchSize", "1");
 
-
-    Configurables.configure(sink, context);
-
-    Channel channel = new PseudoTxnMemoryChannel();
-    Configurables.configure(channel, context);
-
-    sink.setChannel(channel);
-    sink.start();
-
-    for (int i = 0; i < 10; i++) {
-      Event event = new SimpleEvent();
-
-      event.setBody(("Test event " + i).getBytes());
-
-      channel.put(event);
-      sink.process();
-
-      Thread.sleep(500);
-    }
-
-    sink.stop();
-
-    for (String file : sink.getDirectory().list()) {
-      BufferedReader reader =
-          new BufferedReader(new FileReader(new File(sink.getDirectory(), file)));
-
-      String lastLine = null;
-      String currentLine = null;
-
-      while ((currentLine = reader.readLine()) != null) {
-        lastLine = currentLine;
-        logger.debug("Produced file:{} lastLine:{}", file, lastLine);
-      }
-
-
-      reader.close();
-    }
+    doTest(context);
   }
 
   @Test
   public void testAppend3()
-      throws InterruptedException, LifecycleException, EventDeliveryException, IOException {
+      throws InterruptedException, EventDeliveryException, IOException {
     File tmpDir = new File("target/tmpLog");
     tmpDir.mkdirs();
     cleanDirectory(tmpDir);
@@ -187,46 +123,12 @@ public class TestRollingFileSink {
     context.put("sink.pathManager.prefix", "test3-");
     context.put("sink.pathManager.extension", "txt");
 
-    Configurables.configure(sink, context);
-
-    Channel channel = new PseudoTxnMemoryChannel();
-    Configurables.configure(channel, context);
-
-    sink.setChannel(channel);
-    sink.start();
-
-    for (int i = 0; i < 10; i++) {
-      Event event = new SimpleEvent();
-
-      event.setBody(("Test event " + i).getBytes());
-
-      channel.put(event);
-      sink.process();
-
-      Thread.sleep(500);
-    }
-
-    sink.stop();
-
-    for (String file : sink.getDirectory().list()) {
-      BufferedReader reader =
-          new BufferedReader(new FileReader(new File(sink.getDirectory(), file)));
-
-      String lastLine = null;
-      String currentLine = null;
-
-      while ((currentLine = reader.readLine()) != null) {
-        lastLine = currentLine;
-        logger.debug("Produced file:{} lastLine:{}", file, lastLine);
-      }
-
-      reader.close();
-    }
+    doTest(context);
   }
 
   @Test
   public void testRollTime()
-      throws InterruptedException, LifecycleException, EventDeliveryException, IOException {
+      throws InterruptedException, EventDeliveryException, IOException {
     File tmpDir = new File("target/tempLog");
     tmpDir.mkdirs();
     cleanDirectory(tmpDir);
@@ -239,10 +141,45 @@ public class TestRollingFileSink {
     context.put("sink.pathManager.prefix", "test4-");
     context.put("sink.pathManager.extension", "txt");
 
+    doTest(context);
+  }
+
+  @Test
+  public void testChannelException() throws InterruptedException, IOException {
+
+    Context context = new Context();
+
+    context.put("sink.directory", tmpDir.getPath());
+    context.put("sink.rollInterval", "0");
+    context.put("sink.batchSize", "1");
+
+    Channel channel = Mockito.mock(Channel.class);
+    Mockito.when(channel.take()).thenThrow(new ChannelException("dummy"));
+    Transaction transaction = Mockito.mock(BasicTransactionSemantics.class);
+    Mockito.when(channel.getTransaction()).thenReturn(transaction);
+
+    try {
+      doTest(context, channel);
+    } catch (EventDeliveryException e){
+      //
+    }
+    SinkCounter sinkCounter = (SinkCounter) Whitebox.getInternalState(sink, "sinkCounter");
+    Assert.assertEquals(1, sinkCounter.getChannelReadFail());
+  }
+
+  private void doTest(Context context) throws EventDeliveryException, InterruptedException
+      , IOException {
+    doTest(context, null);
+  }
+
+  private void doTest(Context context, Channel channel) throws EventDeliveryException,
+      InterruptedException, IOException {
     Configurables.configure(sink, context);
 
-    Channel channel = new PseudoTxnMemoryChannel();
-    Configurables.configure(channel, context);
+    if (channel == null) {
+      channel = new PseudoTxnMemoryChannel();
+      Configurables.configure(channel, context);
+    }
 
     sink.setChannel(channel);
     sink.start();

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
@@ -75,7 +75,6 @@ import org.slf4j.LoggerFactory;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
 
 public class TestAvroSource {
 

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.security.cert.X509Certificate;
 import java.nio.channels.ServerSocketChannel;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -41,6 +42,7 @@ import javax.net.ssl.X509TrustManager;
 import org.apache.avro.ipc.NettyTransceiver;
 import org.apache.avro.ipc.specific.SpecificRequestor;
 import org.apache.flume.Channel;
+import org.apache.flume.ChannelException;
 import org.apache.flume.ChannelSelector;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
@@ -50,6 +52,7 @@ import org.apache.flume.channel.ChannelProcessor;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
+import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.lifecycle.LifecycleController;
 import org.apache.flume.lifecycle.LifecycleState;
 import org.apache.flume.source.avro.AvroFlumeEvent;
@@ -64,8 +67,15 @@ import org.jboss.netty.handler.ssl.SslHandler;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
 public class TestAvroSource {
 
@@ -578,4 +588,26 @@ public class TestAvroSource {
     Assert.assertEquals("Server is stopped", LifecycleState.STOP,
         source.getLifecycleState());
   }
+
+  @Test
+  public void testErrorCounterChannelWriteFail() throws Exception {
+    Context context = new Context();
+    context.put("port", String.valueOf(selectedPort = getFreePort()));
+    context.put("bind", "0.0.0.0");
+    source.configure(context);
+    ChannelProcessor cp = Mockito.mock(ChannelProcessor.class);
+    doThrow(new ChannelException("dummy")).when(cp).processEvent(any(Event.class));
+    doThrow(new ChannelException("dummy")).when(cp).processEventBatch(anyListOf(Event.class));
+    source.setChannelProcessor(cp);
+    source.start();
+    AvroFlumeEvent avroEvent = new AvroFlumeEvent();
+    avroEvent.setHeaders(new HashMap<CharSequence, CharSequence>());
+    avroEvent.setBody(ByteBuffer.wrap("Hello avro ssl".getBytes()));
+    source.append(avroEvent);
+    source.appendBatch(Arrays.asList(avroEvent));
+    SourceCounter sc = (SourceCounter) Whitebox.getInternalState(source, "sourceCounter");
+    Assert.assertEquals(2, sc.getChannelWriteFail());
+    source.stop();
+  }
+
 }

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestMultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestMultiportSyslogTCPSource.java
@@ -88,50 +88,6 @@ public class TestMultiportSyslogTCPSource {
     return msg1.getBytes();
   }
 
-  /**
-   * Basic test to exercise multiple-port parsing.
-   */
-  @Test
-  public void testMultiplePorts() throws IOException, ParseException {
-    MultiportSyslogTCPSource source = new MultiportSyslogTCPSource();
-    Channel channel = new MemoryChannel();
-    List<Event> channelEvents = new ArrayList<>();
-    int numPorts = 1000;
-
-    List<Integer> portList = testNPorts(source, channel, channelEvents,
-        numPorts, null);
-
-    //Since events can arrive out of order, search for each event in the array
-    for (int i = 0; i < numPorts ; i++) {
-      Iterator<Event> iter = channelEvents.iterator();
-      while (iter.hasNext()) {
-        Event e = iter.next();
-        Map<String, String> headers = e.getHeaders();
-        // rely on port to figure out which event it is
-        Integer port = null;
-        if (headers.containsKey(
-            SyslogSourceConfigurationConstants.DEFAULT_PORT_HEADER)) {
-          port = Integer.parseInt(headers.get(
-                SyslogSourceConfigurationConstants.DEFAULT_PORT_HEADER));
-        }
-        iter.remove();
-
-        Assert.assertEquals("Timestamps must match",
-            String.valueOf(time.getMillis()), headers.get("timestamp"));
-
-        String host2 = headers.get("host");
-        Assert.assertEquals(host1, host2);
-
-        if (port != null) {
-          int num = portList.indexOf(port);
-          Assert.assertEquals(data1 + " " + String.valueOf(num),
-              new String(e.getBody()));
-        }
-      }
-    }
-    source.stop();
-  }
-
   private List<Integer> testNPorts(MultiportSyslogTCPSource source, Channel channel,
                                    List<Event> channelEvents, int numPorts,
                                    ChannelProcessor channelProcessor) throws IOException {
@@ -197,6 +153,50 @@ public class TestMultiportSyslogTCPSource {
 
 
     return portList;
+  }
+
+  /**
+   * Basic test to exercise multiple-port parsing.
+   */
+  @Test
+  public void testMultiplePorts() throws IOException, ParseException {
+    MultiportSyslogTCPSource source = new MultiportSyslogTCPSource();
+    Channel channel = new MemoryChannel();
+    List<Event> channelEvents = new ArrayList<>();
+    int numPorts = 1000;
+
+    List<Integer> portList = testNPorts(source, channel, channelEvents,
+        numPorts, null);
+
+    //Since events can arrive out of order, search for each event in the array
+    for (int i = 0; i < numPorts ; i++) {
+      Iterator<Event> iter = channelEvents.iterator();
+      while (iter.hasNext()) {
+        Event e = iter.next();
+        Map<String, String> headers = e.getHeaders();
+        // rely on port to figure out which event it is
+        Integer port = null;
+        if (headers.containsKey(
+            SyslogSourceConfigurationConstants.DEFAULT_PORT_HEADER)) {
+          port = Integer.parseInt(headers.get(
+                SyslogSourceConfigurationConstants.DEFAULT_PORT_HEADER));
+        }
+        iter.remove();
+
+        Assert.assertEquals("Timestamps must match",
+            String.valueOf(time.getMillis()), headers.get("timestamp"));
+
+        String host2 = headers.get("host");
+        Assert.assertEquals(host1, host2);
+
+        if (port != null) {
+          int num = portList.indexOf(port);
+          Assert.assertEquals(data1 + " " + String.valueOf(num),
+              new String(e.getBody()));
+        }
+      }
+    }
+    source.stop();
   }
 
   /**

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestThriftSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestThriftSource.java
@@ -38,7 +38,6 @@ import org.apache.flume.conf.Configurables;
 import org.apache.flume.event.EventBuilder;
 
 import org.apache.flume.instrumentation.SourceCounter;
-import org.apache.flume.thrift.ThriftFlumeEvent;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,7 +53,6 @@ import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestThriftSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestThriftSource.java
@@ -314,21 +314,20 @@ public class TestThriftSource {
     source.setChannelProcessor(cp);
     source.start();
     Event event = EventBuilder.withBody("hello".getBytes());
-    try{
+    try {
       client.append(event);
-    } catch (EventDeliveryException e){
+    } catch (EventDeliveryException e) {
       //
     }
-    try{
+    try {
       client.appendBatch(Arrays.asList(event));
-    } catch (EventDeliveryException e){
+    } catch (EventDeliveryException e) {
       //
     }
     SourceCounter sc = (SourceCounter) Whitebox.getInternalState(source, "sourceCounter");
     Assert.assertEquals(2, sc.getChannelWriteFail());
     source.stop();
   }
-
 
   private class SubmitHelper implements Runnable {
     private final int i;

--- a/flume-ng-core/src/test/java/org/apache/flume/source/http/TestHTTPSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/http/TestHTTPSource.java
@@ -277,10 +277,12 @@ public class TestHTTPSource {
   public void testCounterGenericFail() throws Exception {
     ChannelProcessor cp = Mockito.mock(ChannelProcessor.class);
     doThrow(new RuntimeException("dummy")).when(cp).processEventBatch(anyListOf(Event.class));
+    ChannelProcessor oldCp = source.getChannelProcessor();
     source.setChannelProcessor(cp);
     testBatchWithVariousEncoding("UTF-8");
     SourceCounter sc = (SourceCounter) Whitebox.getInternalState(source, "sourceCounter");
     Assert.assertEquals(1, sc.getGenericProcessingFail());
+    source.setChannelProcessor(oldCp);
   }
 
   @Test

--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.flume.Channel;
-import org.apache.flume.ChannelException;
 import org.apache.flume.Clock;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
@@ -447,7 +446,7 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
     } catch (Throwable th) {
       transaction.rollback();
       LOG.error("process failed", th);
-      sinkCounter.incrementFail(th);
+      sinkCounter.incrementWriteOrChannelFail(th);
       if (th instanceof Error) {
         throw (Error) th;
       } else {

--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.flume.Channel;
+import org.apache.flume.ChannelException;
 import org.apache.flume.Clock;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
@@ -441,10 +442,12 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
     } catch (IOException eIO) {
       transaction.rollback();
       LOG.warn("HDFS IO error", eIO);
+      sinkCounter.incrementEventWriteFail();
       return Status.BACKOFF;
     } catch (Throwable th) {
       transaction.rollback();
       LOG.error("process failed", th);
+      sinkCounter.incrementFail(th);
       if (th instanceof Error) {
         throw (Error) th;
       } else {

--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
@@ -446,7 +446,7 @@ public class HDFSEventSink extends AbstractSink implements Configurable {
     } catch (Throwable th) {
       transaction.rollback();
       LOG.error("process failed", th);
-      sinkCounter.incrementWriteOrChannelFail(th);
+      sinkCounter.incrementEventWriteOrChannelFail(th);
       if (th instanceof Error) {
         throw (Error) th;
       } else {

--- a/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSink.java
@@ -77,7 +77,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.mockito.invocation.InvocationOnMock;

--- a/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSink.java
@@ -1648,27 +1648,8 @@ public class TestHDFSEventSink {
     Configurables.configure(sink, context);
     Channel channel = Mockito.mock(Channel.class);
     Mockito.when(channel.take()).thenThrow(new ChannelException("dummy"));
-    Mockito.when(channel.getTransaction()).thenReturn(new BasicTransactionSemantics() {
-      @Override
-      protected void doPut(Event event) throws InterruptedException {
-
-      }
-
-      @Override
-      protected Event doTake() throws InterruptedException {
-        return null;
-      }
-
-      @Override
-      protected void doCommit() throws InterruptedException {
-
-      }
-
-      @Override
-      protected void doRollback() throws InterruptedException {
-
-      }
-    });
+    Mockito.when(channel.getTransaction())
+        .thenReturn(Mockito.mock(BasicTransactionSemantics.class));
     sink.setChannel(channel);
     sink.start();
     try {

--- a/flume-ng-sinks/flume-hive-sink/pom.xml
+++ b/flume-ng-sinks/flume-hive-sink/pom.xml
@@ -239,6 +239,12 @@ limitations under the License.
     </dependency>
     <!-- end temporary -->
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
+++ b/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/HiveSink.java
@@ -264,6 +264,7 @@ public class HiveSink extends AbstractSink implements Configurable {
       LOG.warn(getName() + ": Thread was interrupted.", err);
       return Status.BACKOFF;
     } catch (Exception e) {
+      sinkCounter.incrementEventWriteOrChannelFail(e);
       throw new EventDeliveryException(e);
     } finally {
       if (!success) {

--- a/flume-ng-sinks/flume-http-sink/src/main/java/org/apache/flume/sink/http/HttpSink.java
+++ b/flume-ng-sinks/flume-http-sink/src/main/java/org/apache/flume/sink/http/HttpSink.java
@@ -275,6 +275,7 @@ public class HttpSink extends AbstractSink implements Configurable {
           status = Status.BACKOFF;
 
           LOG.error("Error opening connection, or request timed out", e);
+          sinkCounter.incrementEventWriteFail();
         }
 
       } else {
@@ -289,6 +290,7 @@ public class HttpSink extends AbstractSink implements Configurable {
       status = Status.BACKOFF;
 
       LOG.error("Error sending HTTP request, retrying", t);
+      sinkCounter.incrementEventWriteOrChannelFail(t);
 
       // re-throw all Errors
       if (t instanceof Error) {

--- a/flume-ng-sinks/flume-ng-hbase2-sink/src/main/java/org/apache/flume/sink/hbase2/HBase2Sink.java
+++ b/flume-ng-sinks/flume-ng-hbase2-sink/src/main/java/org/apache/flume/sink/hbase2/HBase2Sink.java
@@ -368,7 +368,7 @@ public class HBase2Sink extends AbstractSink implements Configurable {
       }
       logger.error("Failed to commit transaction." +
           "Transaction rolled back.", e);
-      sinkCounter.incrementFail(e);
+      sinkCounter.incrementWriteOrChannelFail(e);
       if (e instanceof Error || e instanceof RuntimeException) {
         logger.error("Failed to commit transaction." +
             "Transaction rolled back.", e);

--- a/flume-ng-sinks/flume-ng-hbase2-sink/src/main/java/org/apache/flume/sink/hbase2/HBase2Sink.java
+++ b/flume-ng-sinks/flume-ng-hbase2-sink/src/main/java/org/apache/flume/sink/hbase2/HBase2Sink.java
@@ -368,6 +368,7 @@ public class HBase2Sink extends AbstractSink implements Configurable {
       }
       logger.error("Failed to commit transaction." +
           "Transaction rolled back.", e);
+      sinkCounter.incrementFail(e);
       if (e instanceof Error || e instanceof RuntimeException) {
         logger.error("Failed to commit transaction." +
             "Transaction rolled back.", e);

--- a/flume-ng-sinks/flume-ng-hbase2-sink/src/main/java/org/apache/flume/sink/hbase2/HBase2Sink.java
+++ b/flume-ng-sinks/flume-ng-hbase2-sink/src/main/java/org/apache/flume/sink/hbase2/HBase2Sink.java
@@ -368,7 +368,7 @@ public class HBase2Sink extends AbstractSink implements Configurable {
       }
       logger.error("Failed to commit transaction." +
           "Transaction rolled back.", e);
-      sinkCounter.incrementWriteOrChannelFail(e);
+      sinkCounter.incrementEventWriteOrChannelFail(e);
       if (e instanceof Error || e instanceof RuntimeException) {
         logger.error("Failed to commit transaction." +
             "Transaction rolled back.", e);

--- a/flume-ng-sinks/flume-ng-hbase2-sink/src/test/java/org/apache/flume/sink/hbase2/TestHBase2Sink.java
+++ b/flume-ng-sinks/flume-ng-hbase2-sink/src/test/java/org/apache/flume/sink/hbase2/TestHBase2Sink.java
@@ -35,6 +35,7 @@ import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.event.EventBuilder;
+import org.apache.flume.instrumentation.SinkCounter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
@@ -56,6 +57,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -472,6 +474,8 @@ public class TestHBase2Sink {
       Assert.fail("take() method should throw exception");
     } catch (ChannelException ex) {
       Assert.assertEquals("Mock Exception", ex.getMessage());
+      SinkCounter sinkCounter = (SinkCounter) Whitebox.getInternalState(sink, "sinkCounter");
+      Assert.assertEquals(1, sinkCounter.getChannelReadFail());
     }
     doReturn(e).when(channel).take();
     sink.process();
@@ -514,6 +518,8 @@ public class TestHBase2Sink {
       Assert.fail("FlumeException expected from serializer");
     } catch (FlumeException ex) {
       Assert.assertEquals("Exception for testing", ex.getMessage());
+      SinkCounter sinkCounter = (SinkCounter) Whitebox.getInternalState(sink, "sinkCounter");
+      Assert.assertEquals(1, sinkCounter.getEventWriteFail());
     }
     MockSimpleHBase2EventSerializer.throwException = false;
     sink.process();

--- a/flume-ng-sinks/flume-ng-kafka-sink/pom.xml
+++ b/flume-ng-sinks/flume-ng-kafka-sink/pom.xml
@@ -110,6 +110,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
@@ -250,6 +250,7 @@ public class KafkaSink extends AbstractSink implements Configurable {
     } catch (Exception ex) {
       String errorMsg = "Failed to publish events";
       logger.error("Failed to publish events", ex);
+      counter.incrementEventWriteOrChannelFail(ex);
       result = Status.BACKOFF;
       if (transaction != null) {
         try {

--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
@@ -117,6 +117,11 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/src/main/java/org/apache/flume/sink/solr/morphline/MorphlineSink.java
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/src/main/java/org/apache/flume/sink/solr/morphline/MorphlineSink.java
@@ -166,6 +166,7 @@ public class MorphlineSink extends AbstractSink implements Configurable {
       // Ooops - need to rollback and back off
       LOGGER.error("Morphline Sink " + getName() + ": Unable to process event from channel " +
           myChannel.getName() + ". Exception follows.", t);
+      sinkCounter.incrementEventWriteOrChannelFail(t);
       try {
         if (!isMorphlineTransactionCommitted) {
           handler.rollbackTransaction();

--- a/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
+++ b/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
@@ -358,9 +358,4 @@ public class JMSSource extends AbstractPollableSource {
     jmsExceptionCounter = 0;
     return consumer;
   }
-
-  @VisibleForTesting
-  SourceCounter getSourceCounter() {
-    return sourceCounter;
-  }
 }

--- a/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
+++ b/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
@@ -301,7 +301,7 @@ public class JMSSource extends AbstractPollableSource {
       if (++jmsExceptionCounter > errorThreshold) {
         if (consumer != null) {
           logger.warn("Exceeded JMSException threshold, closing consumer");
-          sourceCounter.incrementReadFail();
+          sourceCounter.incrementEventReadFail();
           consumer.rollback();
           consumer.close();
           consumer = null;
@@ -309,7 +309,7 @@ public class JMSSource extends AbstractPollableSource {
       }
     } catch (Throwable throwable) {
       logger.error("Unexpected error processing events", throwable);
-      sourceCounter.incrementReadFail();
+      sourceCounter.incrementEventReadFail();
       if (throwable instanceof Error) {
         throw (Error) throwable;
       }
@@ -357,5 +357,10 @@ public class JMSSource extends AbstractPollableSource {
         createDurableSubscription, durableSubscriptionName);
     jmsExceptionCounter = 0;
     return consumer;
+  }
+
+  @VisibleForTesting
+  SourceCounter getSourceCounter() {
+    return sourceCounter;
   }
 }

--- a/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
+++ b/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
@@ -295,11 +295,13 @@ public class JMSSource extends AbstractPollableSource {
       logger.warn("Error appending event to channel. "
           + "Channel might be full. Consider increasing the channel "
           + "capacity or make sure the sinks perform faster.", channelException);
+      sourceCounter.incrementChannelWriteFail();
     } catch (JMSException jmsException) {
       logger.warn("JMSException consuming events", jmsException);
       if (++jmsExceptionCounter > errorThreshold) {
         if (consumer != null) {
           logger.warn("Exceeded JMSException threshold, closing consumer");
+          sourceCounter.incrementReadFail();
           consumer.rollback();
           consumer.close();
           consumer = null;
@@ -307,6 +309,7 @@ public class JMSSource extends AbstractPollableSource {
       }
     } catch (Throwable throwable) {
       logger.error("Unexpected error processing events", throwable);
+      sourceCounter.incrementReadFail();
       if (throwable instanceof Error) {
         throw (Error) throwable;
       }

--- a/flume-ng-sources/flume-jms-source/src/test/java/org/apache/flume/source/jms/TestJMSSource.java
+++ b/flume-ng-sources/flume-jms-source/src/test/java/org/apache/flume/source/jms/TestJMSSource.java
@@ -338,7 +338,27 @@ public class TestJMSSource extends JMSMessageConsumerTestBase {
       Assert.assertEquals(Status.BACKOFF, source.process());
     }
     Assert.assertEquals(Status.BACKOFF, source.process());
+    Assert.assertEquals(1, source.getSourceCounter().getEventReadFail());
     verify(consumer, times(attempts + 1)).rollback();
     verify(consumer, times(1)).close();
   }
+
+  @Test
+  public void testErrorCounterEventReadFail() throws Exception {
+    source.configure(context);
+    source.start();
+    when(consumer.take()).thenThrow(new RuntimeException("dummy"));
+    source.process();
+    Assert.assertEquals(1, source.getSourceCounter().getEventReadFail());
+  }
+
+  @Test
+  public void testErrorCounterChannelWriteFail() throws Exception {
+    source.configure(context);
+    source.start();
+    when(source.getChannelProcessor()).thenThrow(new ChannelException("dummy"));
+    source.process();
+    Assert.assertEquals(1, source.getSourceCounter().getChannelWriteFail());
+  }
+
 }

--- a/flume-ng-sources/flume-jms-source/src/test/java/org/apache/flume/source/jms/TestJMSSource.java
+++ b/flume-ng-sources/flume-jms-source/src/test/java/org/apache/flume/source/jms/TestJMSSource.java
@@ -41,7 +41,9 @@ import org.apache.flume.FlumeException;
 import org.apache.flume.PollableSource.Status;
 import org.apache.flume.channel.ChannelProcessor;
 import org.apache.flume.conf.Configurable;
+import org.apache.flume.instrumentation.SourceCounter;
 import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -338,7 +340,8 @@ public class TestJMSSource extends JMSMessageConsumerTestBase {
       Assert.assertEquals(Status.BACKOFF, source.process());
     }
     Assert.assertEquals(Status.BACKOFF, source.process());
-    Assert.assertEquals(1, source.getSourceCounter().getEventReadFail());
+    SourceCounter sc = (SourceCounter) Whitebox.getInternalState(source, "sourceCounter");
+    Assert.assertEquals(1, sc.getEventReadFail());
     verify(consumer, times(attempts + 1)).rollback();
     verify(consumer, times(1)).close();
   }
@@ -349,7 +352,8 @@ public class TestJMSSource extends JMSMessageConsumerTestBase {
     source.start();
     when(consumer.take()).thenThrow(new RuntimeException("dummy"));
     source.process();
-    Assert.assertEquals(1, source.getSourceCounter().getEventReadFail());
+    SourceCounter sc = (SourceCounter) Whitebox.getInternalState(source, "sourceCounter");
+    Assert.assertEquals(1, sc.getEventReadFail());
   }
 
   @Test
@@ -358,7 +362,8 @@ public class TestJMSSource extends JMSMessageConsumerTestBase {
     source.start();
     when(source.getChannelProcessor()).thenThrow(new ChannelException("dummy"));
     source.process();
-    Assert.assertEquals(1, source.getSourceCounter().getChannelWriteFail());
+    SourceCounter sc = (SourceCounter) Whitebox.getInternalState(source, "sourceCounter");
+    Assert.assertEquals(1, sc.getChannelWriteFail());
   }
 
 }

--- a/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
+++ b/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
@@ -315,7 +315,7 @@ public class KafkaSource extends AbstractPollableSource
       return Status.BACKOFF;
     } catch (Exception e) {
       log.error("KafkaSource EXCEPTION, {}", e);
-      counter.incrementFail(e);
+      counter.incrementReadOrChannelFail(e);
       return Status.BACKOFF;
     }
   }

--- a/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
+++ b/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
@@ -315,6 +315,7 @@ public class KafkaSource extends AbstractPollableSource
       return Status.BACKOFF;
     } catch (Exception e) {
       log.error("KafkaSource EXCEPTION, {}", e);
+      counter.incrementFail(e);
       return Status.BACKOFF;
     }
   }

--- a/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
+++ b/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
@@ -315,7 +315,7 @@ public class KafkaSource extends AbstractPollableSource
       return Status.BACKOFF;
     } catch (Exception e) {
       log.error("KafkaSource EXCEPTION, {}", e);
-      counter.incrementReadOrChannelFail(e);
+      counter.incrementEventReadOrChannelFail(e);
       return Status.BACKOFF;
     }
   }

--- a/flume-ng-sources/flume-scribe-source/pom.xml
+++ b/flume-ng-sources/flume-scribe-source/pom.xml
@@ -178,6 +178,12 @@ limitations under the License.
       <artifactId>libthrift</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/flume-ng-sources/flume-scribe-source/src/main/java/org/apache/flume/source/scribe/ScribeSource.java
+++ b/flume-ng-sources/flume-scribe-source/src/main/java/org/apache/flume/source/scribe/ScribeSource.java
@@ -176,6 +176,7 @@ public class ScribeSource extends AbstractSource implements
           return ResultCode.OK;
         } catch (Exception e) {
           LOG.warn("Scribe source handling failure", e);
+          sourceCounter.incrementEventReadOrChannelFail(e);
         }
       }
 

--- a/flume-ng-sources/flume-scribe-source/src/test/java/org/apache/flume/source/scribe/TestScribeSource.java
+++ b/flume-ng-sources/flume-scribe-source/src/test/java/org/apache/flume/source/scribe/TestScribeSource.java
@@ -24,6 +24,7 @@ import org.apache.flume.channel.ChannelProcessor;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
+import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TFramedTransport;
@@ -32,11 +33,19 @@ import org.apache.thrift.transport.TTransport;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
 
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 /**
  *
@@ -80,8 +89,7 @@ public class TestScribeSource {
     scribeSource.start();
   }
 
-  @Test
-  public void testScribeMessage() throws Exception {
+  private void sendSingle() throws org.apache.thrift.TException {
     TTransport transport = new TFramedTransport(new TSocket("localhost", port));
 
     TProtocol protocol = new TBinaryProtocol(transport);
@@ -91,6 +99,11 @@ public class TestScribeSource {
     List<LogEntry> logEntries = new ArrayList<LogEntry>(1);
     logEntries.add(logEntry);
     client.Log(logEntries);
+  }
+
+  @Test
+  public void testScribeMessage() throws Exception {
+    sendSingle();
 
     // try to get it from Channels
     Transaction tx = memoryChannel.getTransaction();
@@ -129,6 +142,21 @@ public class TestScribeSource {
     }
     tx.commit();
     tx.close();
+  }
+
+  @Test
+  public void testErrorCounter() throws Exception {
+    ChannelProcessor cp = mock(ChannelProcessor.class);
+    doThrow(new ChannelException("dummy")).when(cp).processEventBatch(anyListOf(Event.class));
+    ChannelProcessor origCp = scribeSource.getChannelProcessor();
+    scribeSource.setChannelProcessor(cp);
+
+    sendSingle();
+
+    scribeSource.setChannelProcessor(origCp);
+
+    SourceCounter sc = (SourceCounter) Whitebox.getInternalState(scribeSource, "sourceCounter");
+    org.junit.Assert.assertEquals(1, sc.getChannelWriteFail());
   }
 
   @AfterClass

--- a/flume-ng-sources/flume-taildir-source/pom.xml
+++ b/flume-ng-sources/flume-taildir-source/pom.xml
@@ -41,6 +41,13 @@ limitations under the License.
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
@@ -312,7 +312,7 @@ public class TaildirSource extends AbstractSource implements
         }
       } catch (Throwable t) {
         logger.error("Uncaught exception in IdleFileChecker thread", t);
-        sourceCounter.incrementFileHandlingFail();
+        sourceCounter.incrementGenericProcessingFail();
       }
     }
   }
@@ -339,7 +339,7 @@ public class TaildirSource extends AbstractSource implements
       }
     } catch (Throwable t) {
       logger.error("Failed writing positionFile", t);
-      sourceCounter.incrementFileHandlingFail();
+      sourceCounter.incrementGenericProcessingFail();
     } finally {
       try {
         if (writer != null) writer.close();

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
@@ -234,6 +234,7 @@ public class TaildirSource extends AbstractSource implements
       }
     } catch (Throwable t) {
       logger.error("Unable to tail files", t);
+      sourceCounter.incrementEventReadFail();
       status = Status.BACKOFF;
     }
     return status;
@@ -266,6 +267,7 @@ public class TaildirSource extends AbstractSource implements
         } catch (ChannelException ex) {
           logger.warn("The channel is full or unexpected failure. " +
               "The source will try again after " + retryInterval + " ms");
+          sourceCounter.incrementChannelWriteFail();
           TimeUnit.MILLISECONDS.sleep(retryInterval);
           retryInterval = retryInterval << 1;
           retryInterval = Math.min(retryInterval, maxRetryInterval);
@@ -277,8 +279,7 @@ public class TaildirSource extends AbstractSource implements
         if (events.size() < batchSize) {
           break;
         }
-      } catch (IOException e){
-        sourceCounter.incrementReadFail();
+      } catch (IOException e) {
         throw e;
       }
     }
@@ -311,6 +312,7 @@ public class TaildirSource extends AbstractSource implements
         }
       } catch (Throwable t) {
         logger.error("Uncaught exception in IdleFileChecker thread", t);
+        sourceCounter.incrementFileHandlingFail();
       }
     }
   }
@@ -337,6 +339,7 @@ public class TaildirSource extends AbstractSource implements
       }
     } catch (Throwable t) {
       logger.error("Failed writing positionFile", t);
+      sourceCounter.incrementFileHandlingFail();
     } finally {
       try {
         if (writer != null) writer.close();

--- a/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
@@ -17,9 +17,9 @@
 
 package org.apache.flume.source.taildir;
 
-import static org.mockito.Mockito.*;
-import static org.mockito.Matchers.*;
-
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
@@ -32,27 +32,21 @@ import org.apache.flume.Event;
 import org.apache.flume.Transaction;
 import org.apache.flume.channel.ChannelProcessor;
 import org.apache.flume.channel.MemoryChannel;
-import org.apache.flume.channel.MultiplexingChannelSelector;
 import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
-import org.apache.flume.event.SimpleEvent;
 import org.apache.flume.lifecycle.LifecycleController;
 import org.apache.flume.lifecycle.LifecycleState;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
-import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.FILE_GROUPS;
@@ -369,7 +363,7 @@ public class TestTaildirSource {
     when(reader.getTailFiles()).thenThrow(new RuntimeException("hello"));
     Whitebox.setInternalState(source, "reader", reader);
     TimeUnit.MILLISECONDS.sleep(200);
-    assertTrue(0 < source.getSourceCounter().getFileHandlingFail());
+    assertTrue(0 < source.getSourceCounter().getGenericProcessingFail());
     source.stop();
   }
 
@@ -378,7 +372,8 @@ public class TestTaildirSource {
     prepareFileConsumeOrder();
     ChannelProcessor cp = Mockito.mock(ChannelProcessor.class);
     source.setChannelProcessor(cp);
-    doThrow(new ChannelException("dummy")).doNothing().when(cp).processEventBatch(anyListOf(Event.class));
+    doThrow(new ChannelException("dummy")).doNothing().when(cp)
+        .processEventBatch(anyListOf(Event.class));
     source.start();
     source.process();
     assertEquals(1, source.getSourceCounter().getChannelWriteFail());

--- a/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
@@ -211,29 +211,6 @@ public class TestTaildirSource {
     }
   }
 
-  @Test
-  public void testFileConsumeOrder() throws IOException {
-    ArrayList<String> consumedOrder = Lists.newArrayList();
-    ArrayList<String> expected = prepareFileConsumeOrder();
-
-    source.start();
-    source.process();
-    Transaction txn = channel.getTransaction();
-    txn.begin();
-    for (int i = 0; i < 12; i++) {
-      Event e = channel.take();
-      String body = new String(e.getBody(), Charsets.UTF_8);
-      consumedOrder.add(body);
-    }
-    txn.commit();
-    txn.close();
-
-    System.out.println(consumedOrder);
-
-    assertArrayEquals("Files not consumed in expected order", expected.toArray(),
-                      consumedOrder.toArray());
-  }
-
   private ArrayList<String> prepareFileConsumeOrder() throws IOException {
     System.out.println(tmpDir.toString());
     // 1) Create 1st file
@@ -309,19 +286,26 @@ public class TestTaildirSource {
   }
 
   @Test
-  public void testPutFilenameHeader() throws IOException {
-    File f1 = configureSource();
+  public void testFileConsumeOrder() throws IOException {
+    ArrayList<String> consumedOrder = Lists.newArrayList();
+    ArrayList<String> expected = prepareFileConsumeOrder();
+
     source.start();
     source.process();
     Transaction txn = channel.getTransaction();
     txn.begin();
-    Event e = channel.take();
+    for (int i = 0; i < 12; i++) {
+      Event e = channel.take();
+      String body = new String(e.getBody(), Charsets.UTF_8);
+      consumedOrder.add(body);
+    }
     txn.commit();
     txn.close();
 
-    assertNotNull(e.getHeaders().get("path"));
-    assertEquals(f1.getAbsolutePath(),
-            e.getHeaders().get("path"));
+    System.out.println(consumedOrder);
+
+    assertArrayEquals("Files not consumed in expected order", expected.toArray(),
+                      consumedOrder.toArray());
   }
 
   private File configureSource()  throws IOException {
@@ -338,6 +322,22 @@ public class TestTaildirSource {
     Configurables.configure(source, context);
 
     return f1;
+  }
+
+  @Test
+  public void testPutFilenameHeader() throws IOException {
+    File f1 = configureSource();
+    source.start();
+    source.process();
+    Transaction txn = channel.getTransaction();
+    txn.begin();
+    Event e = channel.take();
+    txn.commit();
+    txn.close();
+
+    assertNotNull(e.getHeaders().get("path"));
+    assertEquals(f1.getAbsolutePath(),
+            e.getHeaders().get("path"));
   }
 
   @Test

--- a/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/test/java/org/apache/flume/source/taildir/TestTaildirSource.java
@@ -17,28 +17,43 @@
 
 package org.apache.flume.source.taildir;
 
+import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.*;
+
+
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import org.apache.flume.Channel;
+import org.apache.flume.ChannelException;
 import org.apache.flume.ChannelSelector;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.Transaction;
 import org.apache.flume.channel.ChannelProcessor;
 import org.apache.flume.channel.MemoryChannel;
+import org.apache.flume.channel.MultiplexingChannelSelector;
 import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
+import org.apache.flume.event.SimpleEvent;
 import org.apache.flume.lifecycle.LifecycleController;
 import org.apache.flume.lifecycle.LifecycleState;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
+import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.FILE_GROUPS;
 import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.FILE_GROUPS_PREFIX;
@@ -204,6 +219,28 @@ public class TestTaildirSource {
 
   @Test
   public void testFileConsumeOrder() throws IOException {
+    ArrayList<String> consumedOrder = Lists.newArrayList();
+    ArrayList<String> expected = prepareFileConsumeOrder();
+
+    source.start();
+    source.process();
+    Transaction txn = channel.getTransaction();
+    txn.begin();
+    for (int i = 0; i < 12; i++) {
+      Event e = channel.take();
+      String body = new String(e.getBody(), Charsets.UTF_8);
+      consumedOrder.add(body);
+    }
+    txn.commit();
+    txn.close();
+
+    System.out.println(consumedOrder);
+
+    assertArrayEquals("Files not consumed in expected order", expected.toArray(),
+                      consumedOrder.toArray());
+  }
+
+  private ArrayList<String> prepareFileConsumeOrder() throws IOException {
     System.out.println(tmpDir.toString());
     // 1) Create 1st file
     File f1 = new File(tmpDir, "file1");
@@ -257,53 +294,29 @@ public class TestTaildirSource {
     f3.setLastModified(System.currentTimeMillis());
 
     // 4) Consume the files
-    ArrayList<String> consumedOrder = Lists.newArrayList();
     Context context = new Context();
     context.put(POSITION_FILE, posFilePath);
     context.put(FILE_GROUPS, "g1");
     context.put(FILE_GROUPS_PREFIX + "g1", tmpDir.getAbsolutePath() + "/.*");
 
     Configurables.configure(source, context);
-    source.start();
-    source.process();
-    Transaction txn = channel.getTransaction();
-    txn.begin();
-    for (int i = 0; i < 12; i++) {
-      Event e = channel.take();
-      String body = new String(e.getBody(), Charsets.UTF_8);
-      consumedOrder.add(body);
-    }
-    txn.commit();
-    txn.close();
-
-    System.out.println(consumedOrder);
 
     // 6) Ensure consumption order is in order of last update time
     ArrayList<String> expected = Lists.newArrayList(line1, line2, line3,    // file1
-                                                    line1b, line2b, line3b, // file2
-                                                    line1d, line2d, line3d, // file4
-                                                    line1c, line2c, line3c  // file3
-                                                   );
+        line1b, line2b, line3b, // file2
+        line1d, line2d, line3d, // file4
+        line1c, line2c, line3c  // file3
+    );
     for (int i = 0; i != expected.size(); ++i) {
       expected.set(i, expected.get(i).trim());
     }
-    assertArrayEquals("Files not consumed in expected order", expected.toArray(),
-                      consumedOrder.toArray());
+
+    return expected;
   }
 
   @Test
   public void testPutFilenameHeader() throws IOException {
-    File f1 = new File(tmpDir, "file1");
-    Files.write("f1\n", f1, Charsets.UTF_8);
-
-    Context context = new Context();
-    context.put(POSITION_FILE, posFilePath);
-    context.put(FILE_GROUPS, "fg");
-    context.put(FILE_GROUPS_PREFIX + "fg", tmpDir.getAbsolutePath() + "/file.*");
-    context.put(FILENAME_HEADER, "true");
-    context.put(FILENAME_HEADER_KEY, "path");
-
-    Configurables.configure(source, context);
+    File f1 = configureSource();
     source.start();
     source.process();
     Transaction txn = channel.getTransaction();
@@ -316,4 +329,60 @@ public class TestTaildirSource {
     assertEquals(f1.getAbsolutePath(),
             e.getHeaders().get("path"));
   }
+
+  private File configureSource()  throws IOException {
+    File f1 = new File(tmpDir, "file1");
+    Files.write("f1\n", f1, Charsets.UTF_8);
+
+    Context context = new Context();
+    context.put(POSITION_FILE, posFilePath);
+    context.put(FILE_GROUPS, "fg");
+    context.put(FILE_GROUPS_PREFIX + "fg", tmpDir.getAbsolutePath() + "/file.*");
+    context.put(FILENAME_HEADER, "true");
+    context.put(FILENAME_HEADER_KEY, "path");
+
+    Configurables.configure(source, context);
+
+    return f1;
+  }
+
+  @Test
+  public void testErrorCounterEventReadFail() throws Exception {
+    configureSource();
+    source.start();
+    ReliableTaildirEventReader reader = Mockito.mock(ReliableTaildirEventReader.class);
+    Whitebox.setInternalState(source, "reader", reader);
+    when(reader.updateTailFiles()).thenReturn(Collections.singletonList(123L));
+    when(reader.getTailFiles()).thenThrow(new RuntimeException("hello"));
+    source.process();
+    assertEquals(1, source.getSourceCounter().getEventReadFail());
+    source.stop();
+  }
+
+  @Test
+  public void testErrorCounterFileHandlingFail() throws Exception {
+    configureSource();
+    Whitebox.setInternalState(source, "idleTimeout", 0);
+    Whitebox.setInternalState(source, "checkIdleInterval", 60);
+    source.start();
+    ReliableTaildirEventReader reader = Mockito.mock(ReliableTaildirEventReader.class);
+    when(reader.getTailFiles()).thenThrow(new RuntimeException("hello"));
+    Whitebox.setInternalState(source, "reader", reader);
+    TimeUnit.MILLISECONDS.sleep(200);
+    assertTrue(0 < source.getSourceCounter().getFileHandlingFail());
+    source.stop();
+  }
+
+  @Test
+  public void testErrorCounterChannelWriteFail() throws Exception {
+    prepareFileConsumeOrder();
+    ChannelProcessor cp = Mockito.mock(ChannelProcessor.class);
+    source.setChannelProcessor(cp);
+    doThrow(new ChannelException("dummy")).doNothing().when(cp).processEventBatch(anyListOf(Event.class));
+    source.start();
+    source.process();
+    assertEquals(1, source.getSourceCounter().getChannelWriteFail());
+    source.stop();
+  }
+
 }


### PR DESCRIPTION
By introducing error counters it will be easier to monitor problems. Also errors are categorized, hopefully this will help setting up better monitoring solutions.
Concept: an error is when an Exception is thrown or an ERROR level log is written during event processing.
In case of an error at least 1 error counter is increased at least once. (Preferably 1 counter once).
Errors during event processing are counted. Initialization errors are not handled here.
3 types of errors are differentiated.
-Channel read/write errors from the channel when the channel throws a ChannelException.
-Event read/write errors. E.g: A source cannot read an event due to 
-Generic errors - e.g.: TaildirSource cannot write position file.
