### PR TITLE
FLUME-3269: Support JSSE keystore/trustore -D system properties

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/client/avro/AvroCLIClient.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/client/avro/AvroCLIClient.java
@@ -44,6 +44,7 @@ import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.api.RpcClient;
 import org.apache.flume.api.RpcClientFactory;
 import org.apache.flume.instrumentation.SourceCounter;
+import org.apache.flume.util.SSLUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +67,8 @@ public class AvroCLIClient {
   private int sent;
 
   public static void main(String[] args) {
+    SSLUtil.initGlobalSSLParameters();
+
     AvroCLIClient client = new AvroCLIClient();
 
     try {

--- a/flume-ng-core/src/main/java/org/apache/flume/source/AvroSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/AvroSource.java
@@ -41,6 +41,7 @@ import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.avro.AvroFlumeEvent;
 import org.apache.flume.source.avro.AvroSourceProtocol;
 import org.apache.flume.source.avro.Status;
+import org.apache.flume.util.SSLUtil;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.Channels;
@@ -180,9 +181,10 @@ public class AvroSource extends AbstractSource implements EventDrivenSource,
     }
 
     enableSsl = context.getBoolean(SSL_KEY, false);
-    keystore = context.getString(KEYSTORE_KEY);
-    keystorePassword = context.getString(KEYSTORE_PASSWORD_KEY);
-    keystoreType = context.getString(KEYSTORE_TYPE_KEY, "JKS");
+    keystore = context.getString(KEYSTORE_KEY, SSLUtil.getGlobalKeystorePath());
+    keystorePassword = context.getString(KEYSTORE_PASSWORD_KEY,
+        SSLUtil.getGlobalKeystorePassword());
+    keystoreType = context.getString(KEYSTORE_TYPE_KEY, SSLUtil.getGlobalKeystoreType("JKS"));
     String excludeProtocolsStr = context.getString(EXCLUDE_PROTOCOLS);
     if (excludeProtocolsStr == null) {
       excludeProtocols.add("SSLv3");

--- a/flume-ng-core/src/main/java/org/apache/flume/source/ThriftSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/ThriftSource.java
@@ -34,6 +34,7 @@ import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.thrift.Status;
 import org.apache.flume.thrift.ThriftSourceProtocol;
 import org.apache.flume.thrift.ThriftFlumeEvent;
+import org.apache.flume.util.SSLUtil;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -160,9 +161,10 @@ public class ThriftSource extends AbstractSource implements Configurable, EventD
 
     enableSsl = context.getBoolean(SSL_KEY, false);
     if (enableSsl) {
-      keystore = context.getString(KEYSTORE_KEY);
-      keystorePassword = context.getString(KEYSTORE_PASSWORD_KEY);
-      keystoreType = context.getString(KEYSTORE_TYPE_KEY, "JKS");
+      keystore = context.getString(KEYSTORE_KEY, SSLUtil.getGlobalKeystorePath());
+      keystorePassword = context.getString(KEYSTORE_PASSWORD_KEY,
+          SSLUtil.getGlobalKeystorePassword());
+      keystoreType = context.getString(KEYSTORE_TYPE_KEY, SSLUtil.getGlobalKeystoreType("JKS"));
       String excludeProtocolsStr = context.getString(EXCLUDE_PROTOCOLS);
       if (excludeProtocolsStr == null) {
         excludeProtocols.add("SSLv3");

--- a/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
@@ -28,6 +28,7 @@ import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.AbstractSource;
 import org.apache.flume.tools.FlumeBeanConfigurator;
 import org.apache.flume.tools.HTTPServerConstraintUtil;
+import org.apache.flume.util.SSLUtil;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
@@ -130,11 +131,13 @@ public class HTTPSource extends AbstractSource implements
 
       if (sslEnabled) {
         LOG.debug("SSL configuration enabled");
-        keyStorePath = context.getString(HTTPSourceConfigurationConstants.SSL_KEYSTORE);
+        keyStorePath = context.getString(HTTPSourceConfigurationConstants.SSL_KEYSTORE,
+                SSLUtil.getGlobalKeystorePath());
         Preconditions.checkArgument(keyStorePath != null && !keyStorePath.isEmpty(),
                                     "Keystore is required for SSL Conifguration" );
-        keyStorePassword =
-            context.getString(HTTPSourceConfigurationConstants.SSL_KEYSTORE_PASSWORD);
+        keyStorePassword = context.getString(
+                HTTPSourceConfigurationConstants.SSL_KEYSTORE_PASSWORD,
+                SSLUtil.getGlobalKeystorePassword());
         Preconditions.checkArgument(keyStorePassword != null,
             "Keystore password is required for SSL Configuration");
         String excludeProtocolsStr =

--- a/flume-ng-core/src/test/java/org/apache/flume/sink/TestAvroSink.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/sink/TestAvroSink.java
@@ -401,7 +401,7 @@ public class TestAvroSink {
   }
 
   @Test
-  public void testSslProcess() throws InterruptedException,
+  public void testSslProcessTrustAllCerts() throws InterruptedException,
       EventDeliveryException, InstantiationException, IllegalAccessException {
     setUp();
 
@@ -430,6 +430,20 @@ public class TestAvroSink {
   }
 
   @Test
+  public void testSslProcessWithComponentTruststoreNoPassword() throws InterruptedException,
+      EventDeliveryException, InstantiationException, IllegalAccessException {
+    setUp();
+
+    Context context = createBaseContext();
+    context.put("ssl", String.valueOf(true));
+    context.put("truststore", "src/test/resources/truststore.jks");
+
+    Configurables.configure(sink, context);
+
+    doTestSslProcess();
+  }
+
+  @Test
   public void testSslProcessWithGlobalTruststore() throws InterruptedException,
       EventDeliveryException, InstantiationException, IllegalAccessException {
     setUp();
@@ -446,6 +460,23 @@ public class TestAvroSink {
 
     System.clearProperty("javax.net.ssl.trustStore");
     System.clearProperty("javax.net.ssl.trustStorePassword");
+  }
+
+  @Test
+  public void testSslProcessWithGlobalTruststoreNoPassword() throws InterruptedException,
+      EventDeliveryException, InstantiationException, IllegalAccessException {
+    setUp();
+
+    System.setProperty("javax.net.ssl.trustStore", "src/test/resources/truststore.jks");
+
+    Context context = createBaseContext();
+    context.put("ssl", String.valueOf(true));
+
+    Configurables.configure(sink, context);
+
+    doTestSslProcess();
+
+    System.clearProperty("javax.net.ssl.trustStore");
   }
 
   private void doTestSslProcess() throws InterruptedException,

--- a/flume-ng-core/src/test/java/org/apache/flume/sink/TestThriftSink.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/sink/TestThriftSink.java
@@ -60,17 +60,24 @@ public class TestThriftSink {
     try (ServerSocket socket = new ServerSocket(0)) {
       port = socket.getLocalPort();
     }
-    Context context = new Context();
-
-    context.put("hostname", hostname);
-    context.put("port", String.valueOf(port));
-    context.put("batch-size", String.valueOf(2));
-    context.put("request-timeout", String.valueOf(2000L));
+    Context context = createBaseContext();
     context.put(ThriftRpcClient.CONFIG_PROTOCOL, ThriftRpcClient.COMPACT_PROTOCOL);
     sink.setChannel(channel);
 
     Configurables.configure(sink, context);
     Configurables.configure(channel, context);
+  }
+
+  private Context createBaseContext() {
+    Context context = new Context();
+
+    context.put("hostname", hostname);
+    context.put("port", String.valueOf(port));
+    context.put("batch-size", String.valueOf(2));
+    context.put("connect-timeout", String.valueOf(2000L));
+    context.put("request-timeout", String.valueOf(2000L));
+
+    return context;
   }
 
   @After
@@ -146,7 +153,7 @@ public class TestThriftSink {
     sink.process();
 
     // should throw another EventDeliveryException due to request timeout
-    delay.set(2500L); // because request-timeout = 3000
+    delay.set(2500L); // because request-timeout = 2000
     threw = false;
     try {
       sink.process();
@@ -201,32 +208,52 @@ public class TestThriftSink {
   }
 
   @Test
-  public void testSslProcess() throws Exception {
-    Event event = EventBuilder.withBody("test event 1", Charsets.UTF_8);
-    src = new ThriftTestingSource(ThriftTestingSource.HandlerType.OK.name(), port,
-            ThriftRpcClient.COMPACT_PROTOCOL, "src/test/resources/keystorefile.jks",
-            "password", KeyManagerFactory.getDefaultAlgorithm(), "JKS");
-    Context context = new Context();
-    context.put("hostname", hostname);
-    context.put("port", String.valueOf(port));
+  public void testSslProcessWithComponentTruststore() throws Exception {
+    Context context = createBaseContext();
     context.put("ssl", String.valueOf(true));
-    context.put("batch-size", String.valueOf(2));
-    context.put("connect-timeout", String.valueOf(2000L));
-    context.put("request-timeout", String.valueOf(3000L));
     context.put("truststore", "src/test/resources/truststorefile.jks");
     context.put("truststore-password", "password");
-    context.put("trustmanager-type", TrustManagerFactory.getDefaultAlgorithm());
 
     Configurables.configure(sink, context);
+
+    doTestSslProcess();
+  }
+
+  @Test
+  public void testSslProcessWithGlobalTruststore() throws Exception {
+    System.setProperty("javax.net.ssl.trustStore", "src/test/resources/truststorefile.jks");
+    System.setProperty("javax.net.ssl.trustStorePassword", "password");
+
+    Context context = createBaseContext();
+    context.put("ssl", String.valueOf(true));
+
+    Configurables.configure(sink, context);
+
+    doTestSslProcess();
+
+    System.clearProperty("javax.net.ssl.trustStore");
+    System.clearProperty("javax.net.ssl.trustStorePassword");
+  }
+
+  private void doTestSslProcess() throws Exception {
+    src = new ThriftTestingSource(ThriftTestingSource.HandlerType.OK.name(), port,
+        ThriftRpcClient.COMPACT_PROTOCOL, "src/test/resources/keystorefile.jks",
+        "password", KeyManagerFactory.getDefaultAlgorithm(), "JKS");
+
     channel.start();
     sink.start();
+
     Transaction transaction = channel.getTransaction();
     transaction.begin();
+
+    Event event = EventBuilder.withBody("test event 1", Charsets.UTF_8);
     for (int i = 0; i < 11; i++) {
       channel.put(event);
     }
+
     transaction.commit();
     transaction.close();
+
     for (int i = 0; i < 6; i++) {
       Sink.Status status = sink.process();
       Assert.assertEquals(Sink.Status.READY, status);
@@ -241,48 +268,18 @@ public class TestThriftSink {
 
   @Test
   public void testSslSinkWithNonSslServer() throws Exception {
-    Event event = EventBuilder.withBody("test event 1", Charsets.UTF_8);
     src = new ThriftTestingSource(ThriftTestingSource.HandlerType.OK.name(),
             port, ThriftRpcClient.COMPACT_PROTOCOL);
 
-    Context context = new Context();
-    context.put("hostname", hostname);
-    context.put("port", String.valueOf(port));
+    Context context = createBaseContext();
     context.put("ssl", String.valueOf(true));
-    context.put("batch-size", String.valueOf(2));
-    context.put("connect-timeout", String.valueOf(2000L));
-    context.put("request-timeout", String.valueOf(3000L));
     context.put("truststore", "src/test/resources/truststorefile.jks");
     context.put("truststore-password", "password");
-    context.put("trustmanager-type", TrustManagerFactory.getDefaultAlgorithm());
 
     Configurables.configure(sink, context);
-    channel.start();
-    sink.start();
-    Assert.assertTrue(LifecycleController.waitForOneOf(sink,
-            LifecycleState.START_OR_ERROR, 5000));
-    Transaction transaction = channel.getTransaction();
-    transaction.begin();
-    for (int i = 0; i < 11; i++) {
-      channel.put(event);
-    }
-    transaction.commit();
-    transaction.close();
 
-    boolean failed = false;
-    try {
-      for (int i = 0; i < 6; i++) {
-        Sink.Status status = sink.process();
-        failed = true;
-      }
-    } catch (EventDeliveryException ex) {
-      // This is correct
-    }
-
-    sink.stop();
-    Assert.assertTrue(LifecycleController.waitForOneOf(sink,
-            LifecycleState.STOP_OR_ERROR, 5000));
-    if (failed) {
+    boolean failed = doRequestWhenFailureExpected();
+    if (!failed) {
       Assert.fail("SSL-enabled sink successfully connected to a non-SSL-enabled server, " +
                   "that's wrong.");
     }
@@ -290,48 +287,51 @@ public class TestThriftSink {
 
   @Test
   public void testSslSinkWithNonTrustedCert() throws Exception {
-    Event event = EventBuilder.withBody("test event 1", Charsets.UTF_8);
     src = new ThriftTestingSource(ThriftTestingSource.HandlerType.OK.name(), port,
             ThriftRpcClient.COMPACT_PROTOCOL, "src/test/resources/keystorefile.jks",
             "password", KeyManagerFactory.getDefaultAlgorithm(), "JKS");
 
-    Context context = new Context();
-    context.put("hostname", hostname);
-    context.put("port", String.valueOf(port));
+    Context context = createBaseContext();
     context.put("ssl", String.valueOf(true));
-    context.put("batch-size", String.valueOf(2));
-    context.put("connect-timeout", String.valueOf(2000L));
-    context.put("request-timeout", String.valueOf(3000L));
 
     Configurables.configure(sink, context);
-    channel.start();
-    sink.start();
-    Assert.assertTrue(LifecycleController.waitForOneOf(sink,
-            LifecycleState.START_OR_ERROR, 5000));
-    Transaction transaction = channel.getTransaction();
-    transaction.begin();
-    for (int i = 0; i < 11; i++) {
-      channel.put(event);
-    }
-    transaction.commit();
-    transaction.close();
 
-    boolean failed = false;
-    try {
-      for (int i = 0; i < 6; i++) {
-        Sink.Status status = sink.process();
-        failed = true;
-      }
-    } catch (EventDeliveryException ex) {
-      // This is correct
-    }
-
-    sink.stop();
-    Assert.assertTrue(LifecycleController.waitForOneOf(sink,
-            LifecycleState.STOP_OR_ERROR, 5000));
-    if (failed) {
+    boolean failed = doRequestWhenFailureExpected();
+    if (!failed) {
       Assert.fail("SSL-enabled sink successfully connected to a server with an " +
                   "untrusted certificate when it should have failed");
     }
   }
+
+  private boolean doRequestWhenFailureExpected() throws Exception {
+    channel.start();
+    sink.start();
+    Assert.assertTrue(LifecycleController.waitForOneOf(sink,
+        LifecycleState.START_OR_ERROR, 5000));
+
+    Transaction transaction = channel.getTransaction();
+    transaction.begin();
+
+    Event event = EventBuilder.withBody("test event 1", Charsets.UTF_8);
+    channel.put(event);
+
+    transaction.commit();
+    transaction.close();
+
+    boolean failed;
+    try {
+      Sink.Status status = sink.process();
+      failed = false;
+    } catch (EventDeliveryException ex) {
+      // This is correct
+      failed = true;
+    }
+
+    sink.stop();
+    Assert.assertTrue(LifecycleController.waitForOneOf(sink,
+        LifecycleState.STOP_OR_ERROR, 5000));
+
+    return failed;
+  }
+
 }

--- a/flume-ng-core/src/test/java/org/apache/flume/sink/TestThriftSink.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/sink/TestThriftSink.java
@@ -220,6 +220,17 @@ public class TestThriftSink {
   }
 
   @Test
+  public void testSslProcessWithComponentTruststoreNoPassword() throws Exception {
+    Context context = createBaseContext();
+    context.put("ssl", String.valueOf(true));
+    context.put("truststore", "src/test/resources/truststorefile.jks");
+
+    Configurables.configure(sink, context);
+
+    doTestSslProcess();
+  }
+
+  @Test
   public void testSslProcessWithGlobalTruststore() throws Exception {
     System.setProperty("javax.net.ssl.trustStore", "src/test/resources/truststorefile.jks");
     System.setProperty("javax.net.ssl.trustStorePassword", "password");
@@ -233,6 +244,20 @@ public class TestThriftSink {
 
     System.clearProperty("javax.net.ssl.trustStore");
     System.clearProperty("javax.net.ssl.trustStorePassword");
+  }
+
+  @Test
+  public void testSslProcessWithGlobalTruststoreNoPassword() throws Exception {
+    System.setProperty("javax.net.ssl.trustStore", "src/test/resources/truststorefile.jks");
+
+    Context context = createBaseContext();
+    context.put("ssl", String.valueOf(true));
+
+    Configurables.configure(sink, context);
+
+    doTestSslProcess();
+
+    System.clearProperty("javax.net.ssl.trustStore");
   }
 
   private void doTestSslProcess() throws Exception {

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestAvroSource.java
@@ -58,7 +58,6 @@ import org.apache.flume.lifecycle.LifecycleState;
 import org.apache.flume.source.avro.AvroFlumeEvent;
 import org.apache.flume.source.avro.AvroSourceProtocol;
 import org.apache.flume.source.avro.Status;
-import org.apache.flume.util.SSLUtil;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.socket.SocketChannel;
 import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -841,6 +841,8 @@ the commands including the passwords will be saved to the command history.)
 
   * in case of keystores: configuration error
   * in case of truststores: the default truststore will be used (``jssecacerts`` / ``cacerts`` in Oracle JDK)
+* The trustore password is optional in all cases. If not specified, then no integrity check will be
+  performed on the truststore when it is opened by the JDK.
 
 
 Flume Sources

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -872,7 +872,7 @@ compression-type     none              This can be "none" or "deflate".  The com
 ssl                  false             Set this to true to enable SSL encryption. If SSL is enabled,
                                        you must also specify a "keystore" and a "keystore-password",
                                        either through component level parameters (see below)
-                                       or as global SSL parameters (see *SSL/TLS support* section).
+                                       or as global SSL parameters (see `SSL/TLS support`_ section).
 keystore             --                This is the path to a Java keystore file.
                                        If not specified here, then the global keystore will be used
                                        (if defined, otherwise configuration error).
@@ -939,7 +939,7 @@ interceptors.*
 ssl                  false        Set this to true to enable SSL encryption. If SSL is enabled,
                                   you must also specify a "keystore" and a "keystore-password",
                                   either through component level parameters (see below)
-                                  or as global SSL parameters (see *SSL/TLS support* section)
+                                  or as global SSL parameters (see `SSL/TLS support`_ section)
 keystore             --           This is the path to a Java keystore file.
                                   If not specified here, then the global keystore will be used
                                   (if defined, otherwise configuration error).
@@ -1129,7 +1129,7 @@ Flume Wiki.
 
 If the JMS server uses self-signed certificate or its certificate is signed by a non-trusted CA (eg. the company's own
 CA), then a truststore (containing the right certificate) needs to be set up and passed to Flume. It can be done via
-the global SSL parameters. For more details about the global SSL setup, see the *SSL/TLS support* section.
+the global SSL parameters. For more details about the global SSL setup, see the `SSL/TLS support`_ section.
 
 Some JMS providers require SSL specific JNDI Initial Context Factory and/or Provider URL settings when using SSL (eg.
 ActiveMQ uses ssl:// URL prefix instead of tcp://).
@@ -1142,7 +1142,7 @@ JMS Source can authenticate to the JMS server through client certificate authent
 user/password login (when SSL is used and the JMS server is configured to accept this kind of authentication).
 
 The keystore containing Flume's key used for the authentication needs to be configured via the global SSL parameters
-again. For more details about the global SSL setup, see the *SSL/TLS support* section.
+again. For more details about the global SSL setup, see the `SSL/TLS support`_ section.
 
 The keystore should contain only one key (if multiple keys are present, then the first one will be used).
 The key password must be the same as the keystore password.
@@ -1553,7 +1553,7 @@ Example configuration with server side authentication and data encryption.
     a1.sources.source1.kafka.consumer.ssl.truststore.password=<password to access the truststore>
 
 Specyfing the truststore is optional here, the global truststore can be used instead.
-For more details about the global SSL setup, see the *SSL/TLS support* section.
+For more details about the global SSL setup, see the `SSL/TLS support`_ section.
 
 Note: By default the property ``ssl.endpoint.identification.algorithm``
 is not defined, so hostname verification is not performed.
@@ -1570,7 +1570,7 @@ against one of the following two fields:
 #) Subject Alternative Name (SAN) https://tools.ietf.org/html/rfc5280#section-4.2.1.6
 
 If client side authentication is also required then additionally the following needs to be added to Flume agent
-configuration or the global SSL setup can be used (see *SSL/TLS support* section).
+configuration or the global SSL setup can be used (see `SSL/TLS support`_ section).
 Each Flume agent has to have its client certificate which has to be trusted by Kafka brokers either
 individually or by their signature chain. Common example is to sign each client certificate by a single Root CA
 which in turn is trusted by Kafka brokers.
@@ -3127,7 +3127,7 @@ Example configuration with server side authentication and data encryption.
     a1.sinks.sink1.kafka.producer.ssl.truststore.password = <password to access the truststore>
 
 Specyfing the truststore is optional here, the global truststore can be used instead.
-For more details about the global SSL setup, see the *SSL/TLS support* section.
+For more details about the global SSL setup, see the `SSL/TLS support`_ section.
 
 Note: By default the property ``ssl.endpoint.identification.algorithm``
 is not defined, so hostname verification is not performed.
@@ -3144,7 +3144,7 @@ against one of the following two fields:
 #) Subject Alternative Name (SAN) https://tools.ietf.org/html/rfc5280#section-4.2.1.6
 
 If client side authentication is also required then additionally the following needs to be added to Flume agent
-configuration or the global SSL setup can be used (see *SSL/TLS support* section).
+configuration or the global SSL setup can be used (see `SSL/TLS support`_ section).
 Each Flume agent has to have its client certificate which has to be trusted by Kafka brokers either
 individually or by their signature chain. Common example is to sign each client certificate by a single Root CA
 which in turn is trusted by Kafka brokers.
@@ -3536,7 +3536,7 @@ Example configuration with server side authentication and data encryption.
     a1.channels.channel1.kafka.consumer.ssl.truststore.password = <password to access the truststore>
 
 Specyfing the truststore is optional here, the global truststore can be used instead.
-For more details about the global SSL setup, see the *SSL/TLS support* section.
+For more details about the global SSL setup, see the `SSL/TLS support`_ section.
 
 Note: By default the property ``ssl.endpoint.identification.algorithm``
 is not defined, so hostname verification is not performed.
@@ -3554,7 +3554,7 @@ against one of the following two fields:
 #) Subject Alternative Name (SAN) https://tools.ietf.org/html/rfc5280#section-4.2.1.6
 
 If client side authentication is also required then additionally the following needs to be added to Flume agent
-configuration or the global SSL setup can be used (see *SSL/TLS support* section).
+configuration or the global SSL setup can be used (see `SSL/TLS support`_ section).
 Each Flume agent has to have its client certificate which has to be trusted by Kafka brokers either
 individually or by their signature chain. Common example is to sign each client certificate by a single Root CA
 which in turn is trusted by Kafka brokers.

--- a/flume-ng-node/src/main/java/org/apache/flume/node/Application.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/Application.java
@@ -41,6 +41,7 @@ import org.apache.flume.lifecycle.LifecycleAware;
 import org.apache.flume.lifecycle.LifecycleState;
 import org.apache.flume.lifecycle.LifecycleSupervisor;
 import org.apache.flume.lifecycle.LifecycleSupervisor.SupervisorPolicy;
+import org.apache.flume.util.SSLUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -251,8 +252,7 @@ public class Application {
   public static void main(String[] args) {
 
     try {
-
-      boolean isZkConfigured = false;
+      SSLUtil.initGlobalSSLParameters();
 
       Options options = new Options();
 
@@ -294,10 +294,12 @@ public class Application {
       String agentName = commandLine.getOptionValue('n');
       boolean reload = !commandLine.hasOption("no-reload-conf");
 
+      boolean isZkConfigured = false;
       if (commandLine.hasOption('z') || commandLine.hasOption("zkConnString")) {
         isZkConfigured = true;
       }
-      Application application = null;
+
+      Application application;
       if (isZkConfigured) {
         // get options
         String zkConnectionStr = commandLine.getOptionValue('z');

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/NettyAvroRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/NettyAvroRpcClient.java
@@ -719,12 +719,10 @@ public class NettyAvroRpcClient extends AbstractRpcClient implements RpcClient {
             KeyStore keystore = null;
 
             if (truststore != null) {
-              if (truststorePassword == null) {
-                throw new NullPointerException("truststore password is null");
-              }
               InputStream truststoreStream = new FileInputStream(truststore);
               keystore = KeyStore.getInstance(truststoreType);
-              keystore.load(truststoreStream, truststorePassword.toCharArray());
+              keystore.load(truststoreStream,
+                  truststorePassword != null ? truststorePassword.toCharArray() : null);
             }
 
             TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/NettyAvroRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/NettyAvroRpcClient.java
@@ -65,6 +65,7 @@ import org.apache.flume.FlumeException;
 import org.apache.flume.source.avro.AvroFlumeEvent;
 import org.apache.flume.source.avro.AvroSourceProtocol;
 import org.apache.flume.source.avro.Status;
+import org.apache.flume.util.SSLUtil;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.socket.SocketChannel;
 import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
@@ -586,11 +587,13 @@ public class NettyAvroRpcClient extends AbstractRpcClient implements RpcClient {
     trustAllCerts = Boolean.parseBoolean(properties.getProperty(
         RpcClientConfigurationConstants.CONFIG_TRUST_ALL_CERTS));
     truststore = properties.getProperty(
-        RpcClientConfigurationConstants.CONFIG_TRUSTSTORE);
+        RpcClientConfigurationConstants.CONFIG_TRUSTSTORE, SSLUtil.getGlobalTruststorePath());
     truststorePassword = properties.getProperty(
-        RpcClientConfigurationConstants.CONFIG_TRUSTSTORE_PASSWORD);
+        RpcClientConfigurationConstants.CONFIG_TRUSTSTORE_PASSWORD,
+        SSLUtil.getGlobalTruststorePassword());
     truststoreType = properties.getProperty(
-        RpcClientConfigurationConstants.CONFIG_TRUSTSTORE_TYPE, "JKS");
+        RpcClientConfigurationConstants.CONFIG_TRUSTSTORE_TYPE,
+        SSLUtil.getGlobalTruststoreType("JKS"));
     String excludeProtocolsStr = properties.getProperty(
         RpcClientConfigurationConstants.CONFIG_EXCLUDE_PROTOCOLS);
     if (excludeProtocolsStr == null) {

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/ThriftRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/ThriftRpcClient.java
@@ -523,7 +523,8 @@ public class ThriftRpcClient extends AbstractRpcClient {
       KeyStore ts = null;
       if (truststore != null && truststoreType != null) {
         ts = KeyStore.getInstance(truststoreType);
-        ts.load(new FileInputStream(truststore), truststorePassword.toCharArray());
+        ts.load(new FileInputStream(truststore),
+            truststorePassword != null ? truststorePassword.toCharArray() : null);
         tmf.init(ts);
       }
 

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/ThriftRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/ThriftRpcClient.java
@@ -24,6 +24,7 @@ import org.apache.flume.FlumeException;
 import org.apache.flume.thrift.Status;
 import org.apache.flume.thrift.ThriftFlumeEvent;
 import org.apache.flume.thrift.ThriftSourceProtocol;
+import org.apache.flume.util.SSLUtil;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.transport.TFastFramedTransport;
@@ -318,11 +319,13 @@ public class ThriftRpcClient extends AbstractRpcClient {
           RpcClientConfigurationConstants.CONFIG_SSL));
       if (enableSsl) {
         truststore = properties.getProperty(
-            RpcClientConfigurationConstants.CONFIG_TRUSTSTORE);
+            RpcClientConfigurationConstants.CONFIG_TRUSTSTORE, SSLUtil.getGlobalTruststorePath());
         truststorePassword = properties.getProperty(
-            RpcClientConfigurationConstants.CONFIG_TRUSTSTORE_PASSWORD);
+            RpcClientConfigurationConstants.CONFIG_TRUSTSTORE_PASSWORD,
+            SSLUtil.getGlobalTruststorePassword());
         truststoreType = properties.getProperty(
-            RpcClientConfigurationConstants.CONFIG_TRUSTSTORE_TYPE, "JKS");
+            RpcClientConfigurationConstants.CONFIG_TRUSTSTORE_TYPE,
+            SSLUtil.getGlobalTruststoreType("JKS"));
         String excludeProtocolsStr = properties.getProperty(
             RpcClientConfigurationConstants.CONFIG_EXCLUDE_PROTOCOLS);
         if (excludeProtocolsStr == null) {

--- a/flume-ng-sdk/src/main/java/org/apache/flume/util/SSLUtil.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/util/SSLUtil.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SSLUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SSLUtil.class);
+
+  private static final String SYS_PROP_KEYSTORE_PATH = "javax.net.ssl.keyStore";
+  private static final String SYS_PROP_KEYSTORE_PASSWORD = "javax.net.ssl.keyStorePassword";
+  private static final String SYS_PROP_KEYSTORE_TYPE = "javax.net.ssl.keyStoreType";
+  private static final String SYS_PROP_TRUSTSTORE_PATH = "javax.net.ssl.trustStore";
+  private static final String SYS_PROP_TRUSTSTORE_PASSWORD = "javax.net.ssl.trustStorePassword";
+  private static final String SYS_PROP_TRUSTSTORE_TYPE = "javax.net.ssl.trustStoreType";
+
+  private static final String ENV_VAR_KEYSTORE_PATH = "FLUME_SSL_KEYSTORE_PATH";
+  private static final String ENV_VAR_KEYSTORE_PASSWORD = "FLUME_SSL_KEYSTORE_PASSWORD";
+  private static final String ENV_VAR_KEYSTORE_TYPE = "FLUME_SSL_KEYSTORE_TYPE";
+  private static final String ENV_VAR_TRUSTSTORE_PATH = "FLUME_SSL_TRUSTSTORE_PATH";
+  private static final String ENV_VAR_TRUSTSTORE_PASSWORD = "FLUME_SSL_TRUSTSTORE_PASSWORD";
+  private static final String ENV_VAR_TRUSTSTORE_TYPE = "FLUME_SSL_TRUSTSTORE_TYPE";
+
+  private static final String DESCR_KEYSTORE_PATH = "keystore path";
+  private static final String DESCR_KEYSTORE_PASSWORD = "keystore password";
+  private static final String DESCR_KEYSTORE_TYPE = "keystore type";
+  private static final String DESCR_TRUSTSTORE_PATH = "truststore path";
+  private static final String DESCR_TRUSTSTORE_PASSWORD = "truststore password";
+  private static final String DESCR_TRUSTSTORE_TYPE = "truststore type";
+
+  public static void initGlobalSSLParameters() {
+    initSysPropFromEnvVar(
+        SYS_PROP_KEYSTORE_PATH, ENV_VAR_KEYSTORE_PATH, DESCR_KEYSTORE_PATH);
+    initSysPropFromEnvVar(
+        SYS_PROP_KEYSTORE_PASSWORD, ENV_VAR_KEYSTORE_PASSWORD, DESCR_KEYSTORE_PASSWORD);
+    initSysPropFromEnvVar(
+        SYS_PROP_KEYSTORE_TYPE, ENV_VAR_KEYSTORE_TYPE, DESCR_KEYSTORE_TYPE);
+    initSysPropFromEnvVar(
+        SYS_PROP_TRUSTSTORE_PATH, ENV_VAR_TRUSTSTORE_PATH, DESCR_TRUSTSTORE_PATH);
+    initSysPropFromEnvVar(
+        SYS_PROP_TRUSTSTORE_PASSWORD, ENV_VAR_TRUSTSTORE_PASSWORD, DESCR_TRUSTSTORE_PASSWORD);
+    initSysPropFromEnvVar(
+        SYS_PROP_TRUSTSTORE_TYPE, ENV_VAR_TRUSTSTORE_TYPE, DESCR_TRUSTSTORE_TYPE);
+  }
+
+  private static void initSysPropFromEnvVar(String sysPropName, String envVarName,
+                                            String description) {
+    if (System.getProperty(sysPropName) != null) {
+      LOGGER.debug("Global SSL " + description + " has been initialized from system property.");
+    } else {
+      String envVarValue = System.getenv(envVarName);
+      if (envVarValue != null) {
+        System.setProperty(sysPropName, envVarValue);
+        LOGGER.debug("Global SSL " + description +
+            " has been initialized from environment variable.");
+      } else {
+        LOGGER.debug("No global SSL " + description + " specified.");
+      }
+    }
+  }
+
+  public static String getGlobalKeystorePath() {
+    return System.getProperty(SYS_PROP_KEYSTORE_PATH);
+  }
+
+  public static String getGlobalKeystorePassword() {
+    return System.getProperty(SYS_PROP_KEYSTORE_PASSWORD);
+  }
+
+  public static String getGlobalKeystoreType(String defaultValue) {
+    String sysPropValue = System.getProperty(SYS_PROP_KEYSTORE_TYPE);
+    return sysPropValue != null ? sysPropValue : defaultValue;
+  }
+
+  public static String getGlobalTruststorePath() {
+    return System.getProperty(SYS_PROP_TRUSTSTORE_PATH);
+  }
+
+  public static String getGlobalTruststorePassword() {
+    return System.getProperty(SYS_PROP_TRUSTSTORE_PASSWORD);
+  }
+
+  public static String getGlobalTruststoreType(String defaultValue) {
+    String sysPropValue = System.getProperty(SYS_PROP_TRUSTSTORE_TYPE);
+    return sysPropValue != null ? sysPropValue : defaultValue;
+  }
+
+}

--- a/flume-ng-sdk/src/test/java/org/apache/flume/api/TestThriftRpcClient.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/api/TestThriftRpcClient.java
@@ -41,9 +41,9 @@ import java.util.concurrent.TimeoutException;
 public class TestThriftRpcClient {
   private static final String SEQ = "sequence";
   private final Properties props = new Properties();
-  ThriftRpcClient client;
-  ThriftTestingSource src;
-  int port;
+  private ThriftRpcClient client;
+  private ThriftTestingSource src;
+  private int port;
 
   @Before
   public void setUp() throws Exception {
@@ -70,7 +70,7 @@ public class TestThriftRpcClient {
    * @param count
    * @throws Exception
    */
-  public static void insertEvents(RpcClient client, int count) throws Exception {
+  private  static void insertEvents(RpcClient client, int count) throws Exception {
     for (int i = 0; i < count; i++) {
       Map<String, String> header = new HashMap<String, String>();
       header.put(SEQ, String.valueOf(i));
@@ -87,7 +87,7 @@ public class TestThriftRpcClient {
    * @throws Exception
    */
 
-  public static void insertAsBatch(RpcClient client, int start,
+  private static void insertAsBatch(RpcClient client, int start,
                                    int limit) throws Exception {
     List<Event> events = new ArrayList<Event>();
     for (int i = start; i <= limit; i++) {

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/AbstractSSLUtilTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/AbstractSSLUtilTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+@RunWith(Parameterized.class)
+public abstract class AbstractSSLUtilTest {
+
+  @Parameters
+  public static Collection<?> data() {
+    return Arrays.asList(new Object[][]{
+        // system property value, environment variable value, expected value
+        { null, null, null },
+        { "sysprop", null, "sysprop" },
+        { null, "envvar", "envvar" },
+        { "sysprop", "envvar", "sysprop" }
+    });
+  }
+
+  protected String sysPropValue;
+  protected String envVarValue;
+  protected String expectedValue;
+
+  protected AbstractSSLUtilTest(String sysPropValue, String envVarValue, String expectedValue) {
+    this.sysPropValue = sysPropValue;
+    this.envVarValue = envVarValue;
+    this.expectedValue = expectedValue;
+  }
+
+  protected abstract String getSysPropName();
+
+  protected abstract String getEnvVarName();
+
+  @Before
+  public void setUp() {
+    setSysProp(getSysPropName(), sysPropValue);
+    setEnvVar(getEnvVarName(), envVarValue);
+  }
+
+  @After
+  public void tearDown() {
+    setSysProp(getSysPropName(), null);
+    setEnvVar(getEnvVarName(), null);
+  }
+
+  private static void setSysProp(String name, String value) {
+    if (value != null) {
+      System.setProperty(name, value);
+    } else {
+      System.clearProperty(name);
+    }
+  }
+
+  private static void setEnvVar(String name, String value) {
+    try {
+      injectEnvironmentVariable(name, value);
+    } catch(ReflectiveOperationException e) {
+      throw new AssertionError("Test setup  failed.", e);
+    }
+  }
+
+  // based on https://dzone.com/articles/how-to-change-environment-variables-in-java
+  private static void injectEnvironmentVariable(String key, String value)
+      throws ReflectiveOperationException {
+    Class<?> processEnvironment = Class.forName("java.lang.ProcessEnvironment");
+    Field unmodifiableMapField = getAccessibleField(processEnvironment,
+        "theUnmodifiableEnvironment");
+    Object unmodifiableMap = unmodifiableMapField.get(null);
+    injectIntoUnmodifiableMap(key, value, unmodifiableMap);
+    Field mapField = getAccessibleField(processEnvironment, "theEnvironment");
+    Map<String, String> map = (Map<String, String>) mapField.get(null);
+    if (value != null) {
+      map.put(key, value);
+    } else {
+      map.remove(key);
+    }
+  }
+
+  private static Field getAccessibleField(Class<?> clazz, String fieldName)
+      throws NoSuchFieldException {
+    Field field = clazz.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field;
+  }
+
+  private static void injectIntoUnmodifiableMap(String key, String value, Object map)
+      throws ReflectiveOperationException {
+    Class unmodifiableMap = Class.forName("java.util.Collections$UnmodifiableMap");
+    Field field = getAccessibleField(unmodifiableMap, "m");
+    Object obj = field.get(map);
+    if (value != null) {
+      ((Map<String, String>) obj).put(key, value);
+    } else {
+      ((Map<String, String>) obj).remove(key);
+    }
+  }
+
+}

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/AbstractSSLUtilTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/AbstractSSLUtilTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractSSLUtilTest {
   private static void setEnvVar(String name, String value) {
     try {
       injectEnvironmentVariable(name, value);
-    } catch(ReflectiveOperationException e) {
+    } catch (ReflectiveOperationException e) {
       throw new AssertionError("Test setup  failed.", e);
     }
   }

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystorePasswordTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystorePasswordTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SSLUtilKeystorePasswordTest extends AbstractSSLUtilTest {
+
+  public SSLUtilKeystorePasswordTest(String sysPropValue, String envVarValue, String expectedValue) {
+    super(sysPropValue, envVarValue, expectedValue);
+  }
+
+  @Override
+  protected String getSysPropName() {
+    return "javax.net.ssl.keyStorePassword";
+  }
+
+  @Override
+  protected String getEnvVarName() {
+    return "FLUME_SSL_KEYSTORE_PASSWORD";
+  }
+
+  @Test
+  public void testKeystorePassword() {
+    SSLUtil.initGlobalSSLParameters();
+    String keystorePassword = SSLUtil.getGlobalKeystorePassword();
+
+    Assert.assertEquals(expectedValue, keystorePassword);
+  }
+
+}

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystorePasswordTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystorePasswordTest.java
@@ -23,7 +23,8 @@ import org.junit.Test;
 
 public class SSLUtilKeystorePasswordTest extends AbstractSSLUtilTest {
 
-  public SSLUtilKeystorePasswordTest(String sysPropValue, String envVarValue, String expectedValue) {
+  public SSLUtilKeystorePasswordTest(String sysPropValue, String envVarValue,
+                                     String expectedValue) {
     super(sysPropValue, envVarValue, expectedValue);
   }
 

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystorePathTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystorePathTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SSLUtilKeystorePathTest extends AbstractSSLUtilTest {
+
+  public SSLUtilKeystorePathTest(String sysPropValue, String envVarValue, String expectedValue) {
+    super(sysPropValue, envVarValue, expectedValue);
+  }
+
+  @Override
+  protected String getSysPropName() {
+    return "javax.net.ssl.keyStore";
+  }
+
+  @Override
+  protected String getEnvVarName() {
+    return "FLUME_SSL_KEYSTORE_PATH";
+  }
+
+  @Test
+  public void testKeystorePath() {
+    SSLUtil.initGlobalSSLParameters();
+    String keystorePath = SSLUtil.getGlobalKeystorePath();
+
+    Assert.assertEquals(expectedValue, keystorePath);
+  }
+
+}

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystoreTypeTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystoreTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SSLUtilKeystoreTypeTest extends AbstractSSLUtilTest {
+
+  public SSLUtilKeystoreTypeTest(String sysPropValue, String envVarValue, String expectedValue) {
+    super(sysPropValue, envVarValue, expectedValue);
+  }
+
+  @Override
+  protected String getSysPropName() {
+    return "javax.net.ssl.keyStoreType";
+  }
+
+  @Override
+  protected String getEnvVarName() {
+    return "FLUME_SSL_KEYSTORE_TYPE";
+  }
+
+  @Test
+  public void testKeystoreType() {
+    SSLUtil.initGlobalSSLParameters();
+    String keystoreType = SSLUtil.getGlobalKeystoreType(null);
+
+    Assert.assertEquals(expectedValue, keystoreType);
+  }
+
+}

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystoreTypeWithDefaultTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystoreTypeWithDefaultTest.java
@@ -38,7 +38,8 @@ public class SSLUtilKeystoreTypeWithDefaultTest extends AbstractSSLUtilTest {
     });
   }
 
-  public SSLUtilKeystoreTypeWithDefaultTest(String sysPropValue, String envVarValue, String expectedValue) {
+  public SSLUtilKeystoreTypeWithDefaultTest(String sysPropValue, String envVarValue,
+                                            String expectedValue) {
     super(sysPropValue, envVarValue, expectedValue);
   }
 

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystoreTypeWithDefaultTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilKeystoreTypeWithDefaultTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class SSLUtilKeystoreTypeWithDefaultTest extends AbstractSSLUtilTest {
+
+  @Parameters
+  public static Collection<?> data() {
+    return Arrays.asList(new Object[][]{
+        // system property value, environment variable value, expected value
+        { null, null, "default" },
+        { "sysprop", null, "sysprop" },
+        { null, "envvar", "envvar" },
+        { "sysprop", "envvar", "sysprop" }
+    });
+  }
+
+  public SSLUtilKeystoreTypeWithDefaultTest(String sysPropValue, String envVarValue, String expectedValue) {
+    super(sysPropValue, envVarValue, expectedValue);
+  }
+
+  @Override
+  protected String getSysPropName() {
+    return "javax.net.ssl.keyStoreType";
+  }
+
+  @Override
+  protected String getEnvVarName() {
+    return "FLUME_SSL_KEYSTORE_TYPE";
+  }
+
+  @Test
+  public void testKeystoreType() {
+    SSLUtil.initGlobalSSLParameters();
+    String keystoreType = SSLUtil.getGlobalKeystoreType("default");
+
+    Assert.assertEquals(expectedValue, keystoreType);
+  }
+
+}

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststorePasswordTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststorePasswordTest.java
@@ -23,7 +23,8 @@ import org.junit.Test;
 
 public class SSLUtilTruststorePasswordTest extends AbstractSSLUtilTest {
 
-  public SSLUtilTruststorePasswordTest(String sysPropValue, String envVarValue, String expectedValue) {
+  public SSLUtilTruststorePasswordTest(String sysPropValue, String envVarValue,
+                                       String expectedValue) {
     super(sysPropValue, envVarValue, expectedValue);
   }
 

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststorePasswordTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststorePasswordTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SSLUtilTruststorePasswordTest extends AbstractSSLUtilTest {
+
+  public SSLUtilTruststorePasswordTest(String sysPropValue, String envVarValue, String expectedValue) {
+    super(sysPropValue, envVarValue, expectedValue);
+  }
+
+  @Override
+  protected String getSysPropName() {
+    return "javax.net.ssl.trustStorePassword";
+  }
+
+  @Override
+  protected String getEnvVarName() {
+    return "FLUME_SSL_TRUSTSTORE_PASSWORD";
+  }
+
+  @Test
+  public void testTruststorePassword() {
+    SSLUtil.initGlobalSSLParameters();
+    String truststorePassword = SSLUtil.getGlobalTruststorePassword();
+
+    Assert.assertEquals(expectedValue, truststorePassword);
+  }
+
+}

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststorePathTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststorePathTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SSLUtilTruststorePathTest extends AbstractSSLUtilTest {
+
+  public SSLUtilTruststorePathTest(String sysPropValue, String envVarValue, String expectedValue) {
+    super(sysPropValue, envVarValue, expectedValue);
+  }
+
+  @Override
+  protected String getSysPropName() {
+    return "javax.net.ssl.trustStore";
+  }
+
+  @Override
+  protected String getEnvVarName() {
+    return "FLUME_SSL_TRUSTSTORE_PATH";
+  }
+
+  @Test
+  public void testTruststorePath() {
+    SSLUtil.initGlobalSSLParameters();
+    String truststorePath = SSLUtil.getGlobalTruststorePath();
+
+    Assert.assertEquals(expectedValue, truststorePath);
+  }
+
+}

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststoreTypeTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststoreTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SSLUtilTruststoreTypeTest extends AbstractSSLUtilTest {
+
+  public SSLUtilTruststoreTypeTest(String sysPropValue, String envVarValue, String expectedValue) {
+    super(sysPropValue, envVarValue, expectedValue);
+  }
+
+  @Override
+  protected String getSysPropName() {
+    return "javax.net.ssl.trustStoreType";
+  }
+
+  @Override
+  protected String getEnvVarName() {
+    return "FLUME_SSL_TRUSTSTORE_TYPE";
+  }
+
+  @Test
+  public void testTruststoreType() {
+    SSLUtil.initGlobalSSLParameters();
+    String truststoreType = SSLUtil.getGlobalTruststoreType(null);
+
+    Assert.assertEquals(expectedValue, truststoreType);
+  }
+
+}

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststoreTypeWithDefaultTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststoreTypeWithDefaultTest.java
@@ -38,7 +38,8 @@ public class SSLUtilTruststoreTypeWithDefaultTest extends AbstractSSLUtilTest {
     });
   }
 
-  public SSLUtilTruststoreTypeWithDefaultTest(String sysPropValue, String envVarValue, String expectedValue) {
+  public SSLUtilTruststoreTypeWithDefaultTest(String sysPropValue, String envVarValue,
+                                              String expectedValue) {
     super(sysPropValue, envVarValue, expectedValue);
   }
 

--- a/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststoreTypeWithDefaultTest.java
+++ b/flume-ng-sdk/src/test/java/org/apache/flume/util/SSLUtilTruststoreTypeWithDefaultTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class SSLUtilTruststoreTypeWithDefaultTest extends AbstractSSLUtilTest {
+
+  @Parameters
+  public static Collection<?> data() {
+    return Arrays.asList(new Object[][]{
+        // system property value, environment variable value, expected value
+        { null, null, "default" },
+        { "sysprop", null, "sysprop" },
+        { null, "envvar", "envvar" },
+        { "sysprop", "envvar", "sysprop" }
+    });
+  }
+
+  public SSLUtilTruststoreTypeWithDefaultTest(String sysPropValue, String envVarValue, String expectedValue) {
+    super(sysPropValue, envVarValue, expectedValue);
+  }
+
+  @Override
+  protected String getSysPropName() {
+    return "javax.net.ssl.trustStoreType";
+  }
+
+  @Override
+  protected String getEnvVarName() {
+    return "FLUME_SSL_TRUSTSTORE_TYPE";
+  }
+
+  @Test
+  public void testTruststoreType() {
+    SSLUtil.initGlobalSSLParameters();
+    String truststoreType = SSLUtil.getGlobalTruststoreType("default");
+
+    Assert.assertEquals(expectedValue, truststoreType);
+  }
+
+}


### PR DESCRIPTION
It makes possible to specify global/common SSL keystore parameters (path,
password and type) at Flume agent (process) level for all sources/sinks.
In this way, it is not necessary to define (=copy) the SSL config for each
component in the agent config.

The global SSL parameters can be specified through the standard -D JSSE
system properties or in environment variables.
Component level configuration is still possible.

Priority:
 1. component parameters in agent config
 2. -D system properties
 2. environment variables