### PR TITLE
FLUME-3223 Flume HDFS Sink should retry close prior recover lease

### DIFF
--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
@@ -67,7 +67,7 @@ class BucketWriter {
   private static final Integer staticLock = new Integer(1);
   private Method isClosedMethod = null;
 
-  private HDFSWriter writer;
+  private final HDFSWriter writer;
   private final long rollInterval;
   private final long rollSize;
   private final long rollCount;
@@ -108,7 +108,7 @@ class BucketWriter {
   private boolean mockFsInjected = false;
 
   private final long retryInterval;
-  private final int maxRenameTries;
+  private final int maxRetries;
 
   // flag that the bucket writer was closed due to idling and thus shouldn't be
   // reopened. Not ideal, but avoids internals of owners
@@ -123,7 +123,7 @@ class BucketWriter {
       SinkCounter sinkCounter, int idleTimeout, WriterCallback onCloseCallback,
       String onCloseCallbackPath, long callTimeout,
       ExecutorService callTimeoutPool, long retryInterval,
-      int maxCloseTries) {
+      int maxRetries) {
     this(rollInterval, rollSize, rollCount, batchSize,
             context, filePath, fileName, inUsePrefix,
             inUseSuffix, fileSuffix, codeC,
@@ -132,7 +132,7 @@ class BucketWriter {
             sinkCounter, idleTimeout, onCloseCallback,
             onCloseCallbackPath, callTimeout,
             callTimeoutPool, retryInterval,
-            maxCloseTries, new SystemClock());
+            maxRetries, new SystemClock());
   }
 
   BucketWriter(long rollInterval, long rollSize, long rollCount, long batchSize,
@@ -143,7 +143,7 @@ class BucketWriter {
            SinkCounter sinkCounter, int idleTimeout, WriterCallback onCloseCallback,
            String onCloseCallbackPath, long callTimeout,
            ExecutorService callTimeoutPool, long retryInterval,
-           int maxCloseTries, Clock clock) {
+           int maxRetries, Clock clock) {
     this.rollInterval = rollInterval;
     this.rollSize = rollSize;
     this.rollCount = rollCount;
@@ -167,7 +167,7 @@ class BucketWriter {
     fileExtensionCounter = new AtomicLong(clock.currentTimeMillis());
 
     this.retryInterval = retryInterval;
-    this.maxRenameTries = maxCloseTries;
+    this.maxRetries = maxRetries;
     isOpen = false;
     isUnderReplicated = false;
     this.writer.configure(context);
@@ -178,12 +178,6 @@ class BucketWriter {
     this.fileSystem = fs;
     mockFsInjected = true;
   }
-
-  @VisibleForTesting
-  void setMockStream(HDFSWriter dataWriter) {
-    this.writer = dataWriter;
-  }
-
 
   /**
    * Clear the class counters
@@ -292,7 +286,7 @@ class BucketWriter {
               bucketPath, rollInterval);
           try {
             // Roll the file and remove reference from sfWriters map.
-            close(true);
+            close(true, false);
           } catch (Throwable t) {
             LOG.error("Unexpected error", t);
           }
@@ -312,51 +306,87 @@ class BucketWriter {
    * method will not cause the bucket writer to be dereferenced from the HDFS
    * sink that owns it. This method should be used only when size or count
    * based rolling closes this file.
-   * @throws IOException On failure to rename if temp file exists.
-   * @throws InterruptedException
    */
-  public synchronized void close() throws IOException, InterruptedException {
-    close(false);
+  public synchronized void close() throws InterruptedException {
+    close(false, false);
   }
 
   private CallRunner<Void> createCloseCallRunner() {
     return new CallRunner<Void>() {
-      private final HDFSWriter localWriter = writer;
       @Override
       public Void call() throws Exception {
-        localWriter.close(); // could block
+        writer.close(); // could block
         return null;
       }
     };
   }
 
-  private Callable<Void> createScheduledRenameCallable() {
+  private class CloseCallable implements Callable<Void> {
+    private final String path = bucketPath;
+    private int closeTries = 0;
 
-    return new Callable<Void>() {
-      private final String path = bucketPath;
-      private final String finalPath = targetPath;
-      private FileSystem fs = fileSystem;
-      private int renameTries = 1; // one attempt is already done
+    @Override
+    public Void call() throws Exception {
+      close(false);
+      return null;
+    }
 
-      @Override
-      public Void call() throws Exception {
-        if (renameTries >= maxRenameTries) {
-          LOG.warn("Unsuccessfully attempted to rename " + path + " " +
-              maxRenameTries + " times. File may still be open.");
-          return null;
+    /**
+     * Tries to close the writer. Repeats the close if the maximum number
+     * of retries is not reached or an immediate close is not reuqested.
+     * If all close attempts were unsuccessful we try to recover the lease.
+     * @param immediate An immediate close is required
+     */
+    public void close(boolean immediate) {
+      closeTries++;
+      boolean shouldRetry = closeTries < maxRetries || !immediate;
+      try {
+        callWithTimeout(createCloseCallRunner());
+        sinkCounter.incrementConnectionClosedCount();
+      } catch (InterruptedException | IOException e) {
+        LOG.warn("Closing file: " + path + " failed. Will " +
+            "retry again in " + retryInterval + " seconds.", e);
+        if (timedRollerPool != null && !timedRollerPool.isTerminated()) {
+          if (shouldRetry) {
+            timedRollerPool.schedule(this, retryInterval, TimeUnit.SECONDS);
+          }
+        } else {
+          LOG.warn("Cannot retry close any more timedRollerPool is null or terminated");
         }
-        renameTries++;
-        try {
-          renameBucket(path, finalPath, fs);
-        } catch (Exception e) {
-          LOG.warn("Renaming file: " + path + " failed. Will " +
-              "retry again in " + retryInterval + " seconds.", e);
-          timedRollerPool.schedule(this, retryInterval, TimeUnit.SECONDS);
-          return null;
+        if (!shouldRetry || immediate) {
+          LOG.warn("Unsuccessfully attempted to close " + path + " " +
+                  maxRetries + " times. Initializing lease recovery.");
+          sinkCounter.incrementConnectionFailedCount();
+          recoverLease();
         }
+      }
+    }
+  }
+
+  private class ScheduledRenameCallable implements Callable<Void> {
+    private final String path = bucketPath;
+    private final String finalPath = targetPath;
+    private FileSystem fs = fileSystem;
+    private int renameTries = 1; // one attempt is already done
+
+    @Override
+    public Void call() throws Exception {
+      if (renameTries >= maxRetries) {
+        LOG.warn("Unsuccessfully attempted to rename " + path + " " +
+                maxRetries + " times. File may still be open.");
         return null;
       }
-    };
+      renameTries++;
+      try {
+        renameBucket(path, finalPath, fs);
+      } catch (Exception e) {
+        LOG.warn("Renaming file: " + path + " failed. Will " +
+            "retry again in " + retryInterval + " seconds.", e);
+        timedRollerPool.schedule(this, retryInterval, TimeUnit.SECONDS);
+        return null;
+      }
+      return null;
+    }
   }
 
   /**
@@ -375,14 +405,16 @@ class BucketWriter {
     }
   }
 
+  public void close(boolean callCloseCallback) throws InterruptedException {
+    close(callCloseCallback, false);
+  }
+
   /**
    * Close the file handle and rename the temp file to the permanent filename.
    * Safe to call multiple times. Logs HDFSWriter.close() exceptions.
-   * @throws IOException On failure to rename if temp file exists.
-   * @throws InterruptedException
    */
-  public synchronized void close(boolean callCloseCallback)
-      throws IOException, InterruptedException {
+  public synchronized void close(boolean callCloseCallback, boolean immediate)
+      throws InterruptedException {
     checkAndThrowInterruptedException();
     try {
       flush();
@@ -391,18 +423,8 @@ class BucketWriter {
     }
 
     LOG.info("Closing {}", bucketPath);
-    CallRunner<Void> closeCallRunner = createCloseCallRunner();
     if (isOpen) {
-      try {
-        callWithTimeout(closeCallRunner);
-        sinkCounter.incrementConnectionClosedCount();
-      } catch (IOException e) {
-        LOG.warn("failed to close() HDFSWriter for file (" + bucketPath +
-                 "). Exception follows.", e);
-        sinkCounter.incrementConnectionFailedCount();
-        // starting lease recovery process, see FLUME-3080
-        recoverLease();
-      }
+      new CloseCallable().close(immediate);
       isOpen = false;
     } else {
       LOG.info("HDFSWriter is already closed: {}", bucketPath);
@@ -427,7 +449,7 @@ class BucketWriter {
         LOG.warn("failed to rename() file (" + bucketPath +
                  "). Exception follows.", e);
         sinkCounter.incrementConnectionFailedCount();
-        final Callable<Void> scheduledRename = createScheduledRenameCallable();
+        final Callable<Void> scheduledRename =  new ScheduledRenameCallable();
         timedRollerPool.schedule(scheduledRename, retryInterval, TimeUnit.SECONDS);
       }
     }
@@ -582,12 +604,7 @@ class BucketWriter {
       LOG.warn("Caught IOException writing to HDFSWriter ({}). Closing file (" +
           bucketPath + ") and rethrowing exception.",
           e.getMessage());
-      try {
-        close(true);
-      } catch (IOException e2) {
-        LOG.warn("Caught IOException while closing file (" +
-             bucketPath + "). Exception follows.", e2);
-      }
+      close(true);
       throw e;
     }
 

--- a/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestBucketWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestBucketWriter.java
@@ -402,22 +402,22 @@ public class TestBucketWriter {
 
   @Test
   public void testSequenceFileRenameRetries() throws Exception {
-    SequenceFileRenameRetryCoreTest(1, true);
-    SequenceFileRenameRetryCoreTest(5, true);
-    SequenceFileRenameRetryCoreTest(2, true);
+    sequenceFileRenameRetryCoreTest(1, true);
+    sequenceFileRenameRetryCoreTest(5, true);
+    sequenceFileRenameRetryCoreTest(2, true);
 
-    SequenceFileRenameRetryCoreTest(1, false);
-    SequenceFileRenameRetryCoreTest(5, false);
-    SequenceFileRenameRetryCoreTest(2, false);
+    sequenceFileRenameRetryCoreTest(1, false);
+    sequenceFileRenameRetryCoreTest(5, false);
+    sequenceFileRenameRetryCoreTest(2, false);
   }
 
   @Test
-  public void testSequenceFileSystemCloseRetries() throws Exception {
-    SequenceFileCloseRetryCoreTest(5);
-    SequenceFileCloseRetryCoreTest(1);
+  public void testSequenceFileCloseRetries() throws Exception {
+    sequenceFileCloseRetryCoreTest(5);
+    sequenceFileCloseRetryCoreTest(1);
   }
 
-  public void SequenceFileRenameRetryCoreTest(int numberOfRetriesRequired, boolean closeSucceed)
+  public void sequenceFileRenameRetryCoreTest(int numberOfRetriesRequired, boolean closeSucceed)
       throws Exception {
     String hdfsPath = "file:///tmp/flume-test." +
                       Calendar.getInstance().getTimeInMillis() +
@@ -456,7 +456,7 @@ public class TestBucketWriter {
                       bucketWriter.renameTries.get() == numberOfRetriesRequired);
   }
 
-  private void SequenceFileCloseRetryCoreTest(int numberOfRetriesRequired)
+  private void sequenceFileCloseRetryCoreTest(int numberOfRetriesRequired)
       throws Exception {
     String hdfsPath = "file:///tmp/flume-test." +
         Calendar.getInstance().getTimeInMillis() +

--- a/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSinkOnMiniCluster.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/test/java/org/apache/flume/sink/hdfs/TestHDFSEventSinkOnMiniCluster.java
@@ -293,6 +293,7 @@ public class TestHDFSEventSinkOnMiniCluster {
     sinkCtx.put("hdfs.path", nnURL + outputDir);
     sinkCtx.put("hdfs.fileType", HDFSWriterFactory.DataStreamType);
     sinkCtx.put("hdfs.batchSize", Integer.toString(1));
+    sinkCtx.put("hdfs.retryInterval", "10"); //to speed up test
 
     HDFSEventSink sink = new HDFSEventSink();
     sink.setName("simpleHDFSTest-hdfs-sink");
@@ -531,6 +532,7 @@ public class TestHDFSEventSinkOnMiniCluster {
     ctx.put("hdfs.fileType", HDFSWriterFactory.DataStreamType);
     ctx.put("hdfs.batchSize", Integer.toString(1));
     ctx.put("hdfs.callTimeout", Integer.toString(1000));
+    ctx.put("hdfs.retryInterval", "10"); //to speed up test
 
     HDFSWriter hdfsWriter = new HDFSDataStream() {
       @Override


### PR DESCRIPTION
This is based on @mcsanady 's original pull request #202 
I took the test changes from him but reworked the new feature implementation since it failed some unit tests.
Previously when a close failed we immediately did a recover lease. This PR introduces a background retry mechanism. It uses the already existing "hdfs.closeTries" parameter. Unfortunately it has infinite retries by default, that seems a bit too long for me.

I also did a minimal code clean up. The most important is that   HDFSWriter writer in BucketWriter became final. This is essential for later use in inner classes. Only some testing solutions made it not final. I reworked those to use the constructor.