### PR TITLE
FLUME-3133 Add client IP / hostname headers to Syslog sources.

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogSourceConfigurationConstants.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogSourceConfigurationConstants.java
@@ -61,6 +61,7 @@ public final class SyslogSourceConfigurationConstants {
 
   public static final String CONFIG_PORT_HEADER = "portHeader";
 
+  @Deprecated
   public static final String DEFAULT_PORT_HEADER = "port";
 
   public static final String CONFIG_READBUF_SIZE = "readBufferBytes";
@@ -73,6 +74,9 @@ public final class SyslogSourceConfigurationConstants {
   public static final String CONFIG_KEEP_FIELDS_VERSION = "version";
   public static final String CONFIG_KEEP_FIELDS_TIMESTAMP = "timestamp";
   public static final String CONFIG_KEEP_FIELDS_HOSTNAME = "hostname";
+
+  public static final String CONFIG_CLIENT_IP_HEADER = "clientIPHeader";
+  public static final String CONFIG_CLIENT_HOSTNAME_HEADER = "clientHostnameHeader";
 
   private SyslogSourceConfigurationConstants() {
     // Disable explicit creation of objects.

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUtils.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUtils.java
@@ -28,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
@@ -184,6 +186,38 @@ public class SyslogUtils {
     }
 
     return body;
+  }
+
+  public static String getIP(SocketAddress socketAddress) {
+    try {
+      InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
+      String ip = inetSocketAddress.getAddress().getHostAddress();
+      if (ip != null) {
+        return ip;
+      } else {
+        throw new NullPointerException("The returned IP is null");
+      }
+    } catch (Exception e) {
+      logger.warn("Unable to retrieve client IP address", e);
+    }
+    // return a safe value instead of null
+    return "";
+  }
+
+  public static String getHostname(SocketAddress socketAddress) {
+    try {
+      InetSocketAddress inetSocketAddress = (InetSocketAddress) socketAddress;
+      String hostname = inetSocketAddress.getHostName();
+      if (hostname != null) {
+        return hostname;
+      } else {
+        throw new NullPointerException("The returned hostname is null");
+      }
+    } catch (Exception e) {
+      logger.warn("Unable to retrieve client hostname", e);
+    }
+    // return a safe value instead of null
+    return "";
   }
 
   public SyslogUtils() {

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestMultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestMultiportSyslogTCPSource.java
@@ -64,6 +64,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import javax.net.SocketFactory;
@@ -132,6 +134,7 @@ public class TestMultiportSyslogTCPSource {
     Context context = new Context();
     context.put(SyslogSourceConfigurationConstants.CONFIG_PORTS,
         ports.toString().trim());
+    context.put("portHeader", "port");
     context.putAll(additionalContext.getParameters());
     source.configure(context);
     source.start();
@@ -257,10 +260,8 @@ public class TestMultiportSyslogTCPSource {
         Map<String, String> headers = e.getHeaders();
         // rely on port to figure out which event it is
         Integer port = null;
-        if (headers.containsKey(
-            SyslogSourceConfigurationConstants.DEFAULT_PORT_HEADER)) {
-          port = Integer.parseInt(headers.get(
-              SyslogSourceConfigurationConstants.DEFAULT_PORT_HEADER));
+        if (headers.containsKey("port")) {
+          port = Integer.parseInt(headers.get("port"));
         }
         iter.remove();
 
@@ -311,12 +312,10 @@ public class TestMultiportSyslogTCPSource {
         parsedLine.buffer.getString(Charsets.UTF_8.newDecoder()));
     parsedLine.buffer.rewind();
 
-    MultiportSyslogTCPSource.MultiportSyslogHandler handler =
-        new MultiportSyslogTCPSource.MultiportSyslogHandler(maxLen, 100, null,
-        null, SyslogSourceConfigurationConstants.DEFAULT_PORT_HEADER,
+    MultiportSyslogHandler handler = new MultiportSyslogHandler(
+        maxLen, 100, null, null, null, null, null,
         new ThreadSafeDecoder(Charsets.UTF_8),
-        new ConcurrentHashMap<Integer, ThreadSafeDecoder>(),
-        null);
+        new ConcurrentHashMap<Integer, ThreadSafeDecoder>(),null);
 
     Event event = handler.parseEvent(parsedLine, Charsets.UTF_8.newDecoder());
     String body = new String(event.getBody(), Charsets.UTF_8);
@@ -340,10 +339,9 @@ public class TestMultiportSyslogTCPSource {
     // defaults to UTF-8
     MultiportSyslogHandler handler = new MultiportSyslogHandler(
         1000, 10, new ChannelProcessor(new ReplicatingChannelSelector()),
-        new SourceCounter("test"), "port",
+        new SourceCounter("test"), null, null, null,
         new ThreadSafeDecoder(Charsets.UTF_8),
-        new ConcurrentHashMap<Integer, ThreadSafeDecoder>(),
-        null);
+        new ConcurrentHashMap<Integer, ThreadSafeDecoder>(),null);
 
     ParsedBuffer parsedBuf = new ParsedBuffer();
     parsedBuf.incomplete = false;
@@ -393,10 +391,9 @@ public class TestMultiportSyslogTCPSource {
     // defaults to UTF-8
     MultiportSyslogHandler handler = new MultiportSyslogHandler(
         1000, 10, new ChannelProcessor(new ReplicatingChannelSelector()),
-        new SourceCounter("test"), "port",
+        new SourceCounter("test"), null, null, null,
         new ThreadSafeDecoder(Charsets.UTF_8),
-        new ConcurrentHashMap<Integer, ThreadSafeDecoder>(),
-        null);
+        new ConcurrentHashMap<Integer, ThreadSafeDecoder>(), null);
 
     handler.exceptionCaught(null, new RuntimeException("dummy"));
     SourceCounter sc = (SourceCounter) Whitebox.getInternalState(handler, "sourceCounter");
@@ -460,9 +457,8 @@ public class TestMultiportSyslogTCPSource {
 
     // defaults to UTF-8
     MultiportSyslogHandler handler = new MultiportSyslogHandler(
-        1000, 10, chanProc, new SourceCounter("test"), "port",
-        new ThreadSafeDecoder(Charsets.UTF_8), portCharsets,
-        null);
+        1000, 10, chanProc, new SourceCounter("test"), null, null, null,
+        new ThreadSafeDecoder(Charsets.UTF_8), portCharsets, null);
 
     // initialize buffers
     handler.sessionCreated(session1);
@@ -530,6 +526,54 @@ public class TestMultiportSyslogTCPSource {
     SourceCounter sc = (SourceCounter) Whitebox.getInternalState(source, "sourceCounter");
     Assert.assertEquals(1, sc.getChannelWriteFail());
     source.stop();
+  }
+
+  @Test
+  public void testClientHeaders() throws IOException {
+    String testClientIPHeader = "testClientIPHeader";
+    String testClientHostnameHeader = "testClientHostnameHeader";
+
+    MultiportSyslogTCPSource source = new MultiportSyslogTCPSource();
+    Channel channel = new MemoryChannel();
+
+    Configurables.configure(channel, new Context());
+
+    List<Channel> channels = Lists.newArrayList();
+    channels.add(channel);
+
+    ChannelSelector rcs = new ReplicatingChannelSelector();
+    rcs.setChannels(channels);
+
+    source.setChannelProcessor(new ChannelProcessor(rcs));
+    int port = getFreePort();
+    Context context = new Context();
+    context.put("host", InetAddress.getLoopbackAddress().getHostAddress());
+    context.put("ports", String.valueOf(port));
+    context.put("clientIPHeader", testClientIPHeader);
+    context.put("clientHostnameHeader", testClientHostnameHeader);
+
+    source.configure(context);
+    source.start();
+
+    //create a socket to send a test event
+    Socket syslogSocket = new Socket(InetAddress.getLocalHost(), port);
+    syslogSocket.getOutputStream().write(getEvent(0));
+
+    Event e = takeEvent(channel);
+
+    source.stop();
+
+    Map<String, String> headers = e.getHeaders();
+
+    checkHeader(headers, testClientIPHeader, InetAddress.getLoopbackAddress().getHostAddress());
+    checkHeader(headers, testClientHostnameHeader, InetAddress.getLoopbackAddress().getHostName());
+  }
+
+  private static void checkHeader(Map<String, String> headers, String headerName,
+      String expectedValue) {
+    assertTrue("Missing event header: " + headerName, headers.containsKey(headerName));
+    assertEquals("Event header value does not match: " + headerName,
+        expectedValue, headers.get(headerName));
   }
 
 }

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestMultiportSyslogTCPSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestMultiportSyslogTCPSource.java
@@ -556,7 +556,7 @@ public class TestMultiportSyslogTCPSource {
     source.start();
 
     //create a socket to send a test event
-    Socket syslogSocket = new Socket(InetAddress.getLocalHost(), port);
+    Socket syslogSocket = new Socket(InetAddress.getLoopbackAddress().getHostAddress(), port);
     syslogSocket.getOutputStream().write(getEvent(0));
 
     Event e = takeEvent(channel);

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestSyslogUtils.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestSyslogUtils.java
@@ -18,12 +18,16 @@
  */
 package org.apache.flume.source;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.flume.Event;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
@@ -594,6 +598,60 @@ public class TestSyslogUtils {
                 format1, host1, data5);
     checkHeader("all", msg1, stamp1 + "+0800", format1, host1, data5);
     checkHeader("true", msg1, stamp1 + "+0800", format1, host1, data5);
+  }
+
+  @Test
+  public void testGetIPWhenSuccessful() {
+    SocketAddress socketAddress = new InetSocketAddress("localhost", 2000);
+
+    String ip = SyslogUtils.getIP(socketAddress);
+
+    assertEquals("127.0.0.1", ip);
+  }
+
+  @Test
+  public void testGetIPWhenInputIsNull() {
+    SocketAddress socketAddress = null;
+
+    String ip = SyslogUtils.getIP(socketAddress);
+
+    assertEquals("", ip);
+  }
+
+  @Test
+  public void testGetIPWhenInputIsNotInetSocketAddress() {
+    SocketAddress socketAddress = new SocketAddress() {};
+
+    String ip = SyslogUtils.getIP(socketAddress);
+
+    assertEquals("", ip);
+  }
+
+  @Test
+  public void testGetHostnameWhenSuccessful() {
+    SocketAddress socketAddress = new InetSocketAddress("127.0.0.1", 2000);
+
+    String hostname = SyslogUtils.getHostname(socketAddress);
+
+    assertEquals("localhost", hostname);
+  }
+
+  @Test
+  public void testGetHostnameWhenInputIsNull() {
+    SocketAddress socketAddress = null;
+
+    String hostname = SyslogUtils.getHostname(socketAddress);
+
+    assertEquals("", hostname);
+  }
+
+  @Test
+  public void testGetHostnameWhenInputIsNotInetSocketAddress() {
+    SocketAddress socketAddress = new SocketAddress() {};
+
+    String hostname = SyslogUtils.getHostname(socketAddress);
+
+    assertEquals("", hostname);
   }
 
 }

--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -1809,6 +1809,20 @@ keepFields            none         Setting this to 'all' will preserve the Prior
                                    fields can be included: priority, version,
                                    timestamp, hostname. The values 'true' and 'false'
                                    have been deprecated in favor of 'all' and 'none'.
+clientIPHeader        --           If specified, the IP address of the client will be stored in
+                                   the header of each event using the header name specified here.
+                                   This allows for interceptors and channel selectors to customize
+                                   routing logic based on the IP address of the client.
+                                   Do not use the standard Syslog header names here (like _host_)
+                                   because the event header will be overridden in that case.
+clientHostnameHeader  --           If specified, the host name of the client will be stored in
+                                   the header of each event using the header name specified here.
+                                   This allows for interceptors and channel selectors to customize
+                                   routing logic based on the host name of the client.
+                                   Retrieving the host name may involve a name service reverse
+                                   lookup which may affect the performance.
+                                   Do not use the standard Syslog header names here (like _host_)
+                                   because the event header will be overridden in that case.
 selector.type                      replicating or multiplexing
 selector.*            replicating  Depends on the selector.type value
 interceptors          --           Space-separated list of interceptors
@@ -1875,6 +1889,20 @@ keepFields            none              Setting this to 'all' will preserve the
                                         timestamp, hostname. The values 'true' and 'false'
                                         have been deprecated in favor of 'all' and 'none'.
 portHeader            --                If specified, the port number will be stored in the header of each event using the header name specified here. This allows for interceptors and channel selectors to customize routing logic based on the incoming port.
+clientIPHeader        --                If specified, the IP address of the client will be stored in
+                                        the header of each event using the header name specified here.
+                                        This allows for interceptors and channel selectors to customize
+                                        routing logic based on the IP address of the client.
+                                        Do not use the standard Syslog header names here (like _host_)
+                                        because the event header will be overridden in that case.
+clientHostnameHeader  --                If specified, the host name of the client will be stored in
+                                        the header of each event using the header name specified here.
+                                        This allows for interceptors and channel selectors to customize
+                                        routing logic based on the host name of the client.
+                                        Retrieving the host name may involve a name service reverse
+                                        lookup which may affect the performance.
+                                        Do not use the standard Syslog header names here (like _host_)
+                                        because the event header will be overridden in that case.
 charset.default       UTF-8             Default character set used while parsing syslog events into strings.
 charset.port.<port>   --                Character set is configurable on a per-port basis.
 batchSize             100               Maximum number of events to attempt to process per request loop. Using the default is usually fine.
@@ -1923,20 +1951,34 @@ For example, a multiport syslog TCP source for agent named a1:
 Syslog UDP Source
 '''''''''''''''''
 
-==============  ===========  ==============================================
-Property Name   Default      Description
-==============  ===========  ==============================================
-**channels**    --
-**type**        --           The component type name, needs to be ``syslogudp``
-**host**        --           Host name or IP address to bind to
-**port**        --           Port # to bind to
-keepFields      false        Setting this to true will preserve the Priority,
-                             Timestamp and Hostname in the body of the event.
-selector.type                replicating or multiplexing
-selector.*      replicating  Depends on the selector.type value
-interceptors    --           Space-separated list of interceptors
+====================  ===========  ================================================================
+Property Name         Default      Description
+====================  ===========  ================================================================
+**channels**          --
+**type**              --           The component type name, needs to be ``syslogudp``
+**host**              --           Host name or IP address to bind to
+**port**              --           Port # to bind to
+keepFields            false        Setting this to true will preserve the Priority,
+                                   Timestamp and Hostname in the body of the event.
+clientIPHeader        --           If specified, the IP address of the client will be stored in
+                                   the header of each event using the header name specified here.
+                                   This allows for interceptors and channel selectors to customize
+                                   routing logic based on the IP address of the client.
+                                   Do not use the standard Syslog header names here (like _host_)
+                                   because the event header will be overridden in that case.
+clientHostnameHeader  --           If specified, the host name of the client will be stored in
+                                   the header of each event using the header name specified here.
+                                   This allows for interceptors and channel selectors to customize
+                                   routing logic based on the host name of the client.
+                                   Retrieving the host name may involve a name service reverse
+                                   lookup which may affect the performance.
+                                   Do not use the standard Syslog header names here (like _host_)
+                                   because the event header will be overridden in that case.
+selector.type                      replicating or multiplexing
+selector.*            replicating  Depends on the selector.type value
+interceptors          --           Space-separated list of interceptors
 interceptors.*
-==============  ===========  ==============================================
+====================  ===========  =================================================================
 
 
 For example, a syslog UDP source for agent named a1:


### PR DESCRIPTION
In the newer version of the Syslog message format (RFC-5424) the hostname
is not a mandatory header anymore so the Syslog client might not send it.
On the Flume side it would be a useful information that could be used
in interceptors or for event routing.
To keep this information, two new properties have been added to the Syslog
sources: clientIPHeader and clientHostnameHeader.
Flume users can define custom event header names through these parameters
for storing the IP address / hostname of the Syslog client in the Flume
event as headers.
The IP address / hostname are retrieved from the underlying network sockets,
not from the Syslog message.

This change is based on the patch submitted by Jinjiang Ling which has been
rebased onto the current trunk and the review comments have been implemented.