### PR TITLE
FLUME-3243 hdfs.callTimeout deafault increased and deprecated

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -2396,8 +2396,6 @@ hdfs.fileType           SequenceFile  File format: currently ``SequenceFile``, `
 hdfs.maxOpenFiles       5000          Allow only this number of open files. If this number is exceeded, the oldest file is closed.
 hdfs.minBlockReplicas   --            Specify minimum number of replicas per HDFS block. If not specified, it comes from the default Hadoop config in the classpath.
 hdfs.writeFormat        Writable      Format for sequence file records. One of ``Text`` or ``Writable``. Set to ``Text`` before creating data files with Flume, otherwise those files cannot be read by either Apache Impala (incubating) or Apache Hive.
-hdfs.callTimeout        10000         Number of milliseconds allowed for HDFS operations, such as open, write, flush, close.
-                                      This number should be increased if many HDFS timeout operations are occurring.
 hdfs.threadsPoolSize    10            Number of threads per HDFS sink for HDFS IO ops (open, write, etc.)
 hdfs.rollTimerPoolSize  1             Number of threads per HDFS sink for scheduling timed file rolling
 hdfs.kerberosPrincipal  --            Kerberos user principal for accessing secure HDFS
@@ -2419,6 +2417,14 @@ serializer              ``TEXT``      Other possible options include ``avro_even
                                       fully-qualified class name of an implementation of the
                                       ``EventSerializer.Builder`` interface.
 serializer.*
+======================  ============  ======================================================================
+
+Deprecated Properties
+
+Name                    Default       Description
+======================  ============  ======================================================================
+hdfs.callTimeout        30000         Number of milliseconds allowed for HDFS operations, such as open, write, flush, close.
+                                      This number should be increased if many HDFS timeout operations are occurring.
 ======================  ============  ======================================================================
 
 Example for agent named a1:

--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/AbstractHDFSWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/AbstractHDFSWriter.java
@@ -63,7 +63,8 @@ public abstract class AbstractHDFSWriter implements HDFSWriter {
 
     if (numberOfCloseRetries > 1) {
       try {
-        timeBetweenCloseRetries = context.getLong("hdfs.callTimeout", 10000L);
+        //hdfs.callTimeout is deprecated from 1.9
+        timeBetweenCloseRetries = context.getLong("hdfs.callTimeout", 30000L);
       } catch (NumberFormatException e) {
         logger.warn("hdfs.callTimeout can not be parsed to a long: " +
                     context.getLong("hdfs.callTimeout"));

--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/HDFSEventSink.java
@@ -90,7 +90,7 @@ public class HDFSEventSink extends AbstractSink implements Configurable, BatchSi
    * Default length of time we wait for blocking BucketWriter calls
    * before timing out the operation. Intended to prevent server hangs.
    */
-  private static final long defaultCallTimeout = 10000;
+  private static final long defaultCallTimeout = 30000;
   /**
    * Default number of threads available for tasks
    * such as append/open/close/flush with hdfs.


### PR DESCRIPTION
The default hdfs.callTimeout used by the HDFS sink was too low only 10 seconds that can cause problems on a busy system.
The new default is 30 sec.
I think this parameter should be deprecated and some new more error tolerant solution should be used. To enable the future change I indicated this in the code and in the Users Guide.
Tested only with the unit tests.