### PR TITLE
FLUME-2989 added 2 KafkaChannel metrics

### DIFF
--- a/flume-ng-channels/flume-kafka-channel/pom.xml
+++ b/flume-ng-channels/flume-kafka-channel/pom.xml
@@ -66,6 +66,11 @@ limitations under the License.
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
+++ b/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
@@ -454,6 +454,7 @@ public class KafkaChannel extends BasicChannelSemantics {
               new ProducerRecord<String, byte[]>(topic.get(), key,
                                                  serializeValue(event, parseAsFlumeEvent)));
         }
+        counter.incrementEventPutAttemptCount();
       } catch (NumberFormatException e) {
         throw new ChannelException("Non integer partition id specified", e);
       } catch (Exception e) {
@@ -518,6 +519,7 @@ public class KafkaChannel extends BasicChannelSemantics {
           } else {
             return null;
           }
+          counter.incrementEventTakeAttemptCount();
         } catch (Exception ex) {
           logger.warn("Error while getting events from Kafka. This is usually caused by " +
                       "trying to read a non-flume event. Ensure the setting for " +


### PR DESCRIPTION
KafkaChannel was missing some metrics:  eventTakeAttemptCount, eventPutAttemptCount

This PR is based on the patch included in the issue that was the work of Umesh Chaudhary.
I reworked the test a bit to use Mockito, and made some other minor modifications to the test.
