### PR TITLE
FLUME-3183 Maven: generate SHA-512 checksum during deploy

### DIFF
--- a/dev-docs/HowToRelease.md
+++ b/dev-docs/HowToRelease.md
@@ -249,6 +249,17 @@ And commit the changes.
 
 ### Generating and signing the source artifacts
 
+Generation of the source artifact is created by the maven-assembly-plugin in the package phase.
+Signing is done by the maven-gpg-plugin using the `sign` profile in the verify phase
+Checksum generation for the source and binary artifacts is done by checksum-maven-plugin 
+in the verify phase, an SHA512 checksum is generated
+      
+      mvn clean package -Psign -DskipTests 
+
+The generated artifacts can be found in the `flume-ng-dist/target` directory
+
+If you would like to create it manually, the previous process is:
+
 There is a script in the Flume source tree for generating and signing the Flume
 source artifacts. Once the release candidate is tagged, generate the source
 release with the following steps.
@@ -349,7 +360,7 @@ will have a numeric id associated with it that will be used later
     $ cd public_html
     $ mkdir apache-flume-X.Y.Z-rcN
     $ cd apache-flume-X.Y.Z-rcN
-    $ wget --no-check-certificate https://repository.apache.org/content/repositories/orgapacheflume-XXXX/org/apache/flume/flume-ng-dist/X.Y.Z/flume-ng-dist-X.Y.Z-bin.tar.gz{,.{asc,md5,sha1}}
+    $ wget --no-check-certificate https://repository.apache.org/content/repositories/orgapacheflume-XXXX/org/apache/flume/flume-ng-dist/X.Y.Z/flume-ng-dist-X.Y.Z-bin.tar.gz{,.{asc,sha512}}
     $ for file in flume-ng-dist-*; do mv $file $(echo $file | sed -e "s/flume-ng-dist/apache-flume/g");done
 
 

--- a/dev-support/sign-checksum-artifact.sh
+++ b/dev-support/sign-checksum-artifact.sh
@@ -36,11 +36,9 @@ fi
 
 # The tools we need.
 GPG=$(find_in_path gpg)
-MD5=$(find_in_path md5sum md5)
-SHA1=$(find_in_path sha1sum shasum)
+SHA512=$(find_in_path sha512sum)
 
 # Now sign and checksum the artifact.
 set -x
 $GPG --sign $ARTIFACT
-$MD5 < $ARTIFACT > $ARTIFACT.md5
-$SHA1 < $ARTIFACT > $ARTIFACT.sha1
+$SHA512 < $ARTIFACT > $ARTIFACT.sha512

--- a/flume-ng-clients/flume-ng-log4jappender/pom.xml
+++ b/flume-ng-clients/flume-ng-log4jappender/pom.xml
@@ -1,4 +1,4 @@
-<!--
+0<!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
 this work for additional information regarding copyright ownership.

--- a/flume-ng-configuration/pom.xml
+++ b/flume-ng-configuration/pom.xml
@@ -1,4 +1,4 @@
-<!--
+0<!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
 this work for additional information regarding copyright ownership.

--- a/flume-ng-dist/pom.xml
+++ b/flume-ng-dist/pom.xml
@@ -54,6 +54,35 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>net.nicoulaj.maven.plugins</groupId>
+        <artifactId>checksum-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>checksum</id>
+            <phase>package</phase>
+            <goals>
+              <goal>files</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <algorithms>
+            <algorithm>SHA-512</algorithm>
+          </algorithms>
+          <attachChecksums>true</attachChecksums>
+          <csvSummary>false</csvSummary>
+          <fileSets>
+            <fileSet>
+              <directory>${project.build.directory}</directory>
+              <includes>
+                <include>*.tar.gz</include>
+              </includes>
+            </fileSet>
+          </fileSets>
+          <failIfNoFiles>false</failIfNoFiles><!-- usually, no file to do checksum: don't consider error -->
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@ limitations under the License.
     <mvn-assembly-plugin.version>3.1.0</mvn-assembly-plugin.version>
     <mvn-build-helper-plugin>3.0.0</mvn-build-helper-plugin>
     <mvn-checkstyle-plugin.version>3.0.0</mvn-checkstyle-plugin.version>
+    <mvn-checksum-plugin.version>1.7</mvn-checksum-plugin.version>
     <mvn-clean-plugin.version>3.1.0</mvn-clean-plugin.version>
     <mvn-compiler-plugin.version>3.8.0</mvn-compiler-plugin.version>
     <mvn-gpg-plugin.version>1.6</mvn-gpg-plugin.version>
@@ -669,6 +670,12 @@ limitations under the License.
               </goals>
             </execution>
           </executions>
+        </plugin>
+
+        <plugin>
+          <groupId>net.nicoulaj.maven.plugins</groupId>
+          <artifactId>checksum-maven-plugin</artifactId>
+          <version>${mvn-checksum-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Added SHA-512 checksum generation to maven.
Removed deprecated checksums.
Updated documentation.