### PR TITLE
FLUME-3299 Fix log4j scopes in pom files

### DIFF
--- a/flume-ng-auth/pom.xml
+++ b/flume-ng-auth/pom.xml
@@ -50,11 +50,13 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/flume-ng-configuration/pom.xml
+++ b/flume-ng-configuration/pom.xml
@@ -48,11 +48,13 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/flume-ng-core/pom.xml
+++ b/flume-ng-core/pom.xml
@@ -304,6 +304,7 @@ limitations under the License.
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/flume-ng-dist/pom.xml
+++ b/flume-ng-dist/pom.xml
@@ -236,6 +236,14 @@
       <groupId>org.apache.flume</groupId>
       <artifactId>flume-ng-auth</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/flume-ng-node/pom.xml
+++ b/flume-ng-node/pom.xml
@@ -87,6 +87,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Moving log4j dependencies to test scope.
Adding log4j as dependency to flume-ng-dist to pack it in the binary tarball.