### PR TITLE
FLUME-3304.patch.hdfs sink rename empty file

### DIFF
--- a/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
+++ b/flume-ng-sinks/flume-hdfs-sink/src/main/java/org/apache/flume/sink/hdfs/BucketWriter.java
@@ -680,7 +680,9 @@ class BucketWriter {
         if (fs.exists(srcPath)) { // could block
           LOG.info("Renaming " + srcPath + " to " + dstPath);
           renameTries.incrementAndGet();
-          fs.rename(srcPath, dstPath); // could block
+          if (fs.getStatus(srcPath).getCapacity() != 0) {
+            fs.rename(srcPath, dstPath); // could block
+          }
         }
         return null;
       }


### PR DESCRIPTION
When the archive file is in compressed format, if a empty file be renamed, mr will report an error when reading the file.

 

eg:

a1.sinks.k1.hdfs.codeC = lzop