### PR TITLE
FLUME-3306.patch.RollingFileSink sink.directory not exits

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
@@ -99,7 +99,9 @@ public class RollingFileSink extends AbstractSink implements Configurable, Batch
 
     batchSize = context.getInteger("sink.batchSize", defaultBatchSize);
 
-    this.directory = new File(directory);
+    if (!this.directory.exists()){
+      this.directory.mkdirs();
+    }
 
     if (sinkCounter == null) {
       sinkCounter = new SinkCounter(getName());

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
@@ -99,7 +99,7 @@ public class RollingFileSink extends AbstractSink implements Configurable, Batch
 
     batchSize = context.getInteger("sink.batchSize", defaultBatchSize);
 
-    if (!this.directory.exists()){
+    if (!this.directory.exists()) {
       this.directory.mkdirs();
     }
 


### PR DESCRIPTION
When sink.directory does not exits，will report an error，flume will exit.

I think the sink.directory should be created by flume, if it dose not exits.

So I fixed.