### PR TITLE
Fix minor typo in EmbeddedAgent javadoc

### DIFF
--- a/flume-ng-embedded-agent/src/main/java/org/apache/flume/agent/embedded/EmbeddedAgent.java
+++ b/flume-ng-embedded-agent/src/main/java/org/apache/flume/agent/embedded/EmbeddedAgent.java
@@ -48,7 +48,7 @@ import com.google.common.base.Preconditions;
  * EmbeddedAgent gives Flume users the ability to embed simple agents in
  * applications. This Agent is mean to be much simpler than a traditional
  * agent and as such it's more restrictive than what can be configured
- * for a traditional agent. For specifics see the Flume User Guide.
+ * for a traditional agent. For specifics see the Flume Developer Guide.
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable


### PR DESCRIPTION
Embedded agent doc is not present in http://flume.apache.org/FlumeUserGuide.html , however it's there in http://flume.apache.org/FlumeDeveloperGuide.html .