### PR TITLE
fix bug : Flume Configuration

### DIFF
--- a/flume-ng-configuration/src/main/java/org/apache/flume/conf/FlumeConfiguration.java
+++ b/flume-ng-configuration/src/main/java/org/apache/flume/conf/FlumeConfiguration.java
@@ -576,7 +576,7 @@ public class FlumeConfiguration {
               srcContext.put(BasicConfigurationConstants.CONFIG_CHANNELS,
                   this.getSpaceDelimitedList(channels));
             }
-            if ((configSpecified && srcConf.isNotFoundConfigClass()) ||
+            if ((configSpecified && !srcConf.isNotFoundConfigClass()) ||
                 !configSpecified) {
               newContextMap.put(sourceName, srcContext);
             } else if (configSpecified) {


### PR DESCRIPTION
I found that i can't load sink properties when i use LOGGER sink because of  here get a 'false' and it result in create a new empty map to cover sinkContextMap