### PR TITLE
FLUME-3311 Update User Guide In HDFS Sink

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -2092,7 +2092,7 @@ Example for agent named a1:
   a1.sinks = k1
   a1.sinks.k1.type = hdfs
   a1.sinks.k1.channel = c1
-  a1.sinks.k1.hdfs.path = /flume/events/%y-%m-%d/%H%M/%S
+  a1.sinks.k1.hdfs.path = /flume/events/%Y-%m-%d/%H%M/%S
   a1.sinks.k1.hdfs.filePrefix = events-
   a1.sinks.k1.hdfs.round = true
   a1.sinks.k1.hdfs.roundValue = 10


### PR DESCRIPTION
As the doc describe.
%y	last two digits of year (00..99)
%Y	year (2010)
BUT
there is somthing wrong in 'a1.sinks.k1.hdfs.path = /flume/events/%y-%m-%d/%H%M/%S'

I think the right example is 'a1.sinks.k1.hdfs.path = /flume/events/%Y-%m-%d/%H%M/%S'