### PR TITLE
FLUME-3316 Fixed Syslog Rfc3164Date test failure when the test date f…

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUtils.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SyslogUtils.java
@@ -33,6 +33,8 @@ import java.net.SocketAddress;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -405,7 +407,7 @@ public class SyslogUtils {
             }
             // Add year to timestamp if needed
             if (fmt.addYear) {
-              value = String.valueOf(Calendar.getInstance().get(Calendar.YEAR)) + value;
+              value = clock.instant().atOffset(ZoneOffset.UTC).get(ChronoField.YEAR) + value;
             }
             // try the available time formats to timestamp
             for (int dt = 0; dt < fmt.dateFormat.size(); dt++) {
@@ -426,10 +428,6 @@ public class SyslogUtils {
                  * 1 month in the future) of timestamps.
                  */
                 if (fmt.addYear) {
-                  // Parsing from dateformatter without year part would use system clock
-                  // so we have to set the year part from the used clock instance
-                  parsedDate.setYear(new Date(clock.millis()).getYear());
-
                   Calendar calParsed = Calendar.getInstance();
                   calParsed.setTime(parsedDate);
                   Calendar calMinusOneMonth = Calendar.getInstance();


### PR DESCRIPTION
…alls on a leap day

Syslog Rfc3164Date test changes the time via a mock Clock instance so that it can test
dates in the past/future (it goes 13 months forward).
The test failed due to a bug in SyslogSource when the test date fell on a leap day (2020-02-29).

Background:
RFC 3164 Syslog messages do not contain the year and SyslogSource tries to find it out (in order to
set the timestamp Flume event header).
First it adds the current year, and then adjusts it with +/- 1 year if needed (it can happen
around 31 Dec / 1 Jan).
In the previous implementation SyslogSource added the current year based on the system time,
not the (mocked) Clock instance.
When the test date was 2020-02-29 (so the syslog message contained Feb 29), SyslogSource added
2019 to Feb 29 which is not a real date and was parsed to 2019-03-01, then adjusted with +1 year
to 2020-03-01. This caused the test error.

Solution:
SyslogSource has been modified to use the Clock instance when adding the current year to the
date coming in the syslog message.
The year was also set in another place in the code which was redundant (and used deprecated
Date API), so it has been deleted too.