### PR TITLE
Remove redundant placeholder in log format

### DIFF
--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/src/main/java/org/apache/flume/sink/solr/morphline/MorphlineSink.java
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/src/main/java/org/apache/flume/sink/solr/morphline/MorphlineSink.java
@@ -111,7 +111,7 @@ public class MorphlineSink extends AbstractSink implements Configurable, BatchSi
         handler.stop();
       }
       sinkCounter.stop();
-      LOGGER.info("Morphline Sink {} stopped. Metrics: {}, {}", getName(), sinkCounter);
+      LOGGER.info("Morphline Sink {} stopped. Metrics: {}", getName(), sinkCounter);
     } finally {
       super.stop();
     }


### PR DESCRIPTION
There is a redundant placeholder in log format of morphline sink, which may cause unexpected output. 