### PR TITLE
fix bug in adding headers

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/http/BLOBHandler.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/http/BLOBHandler.java
@@ -18,10 +18,7 @@
 package org.apache.flume.source.http;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -65,18 +62,13 @@ public class BLOBHandler implements HTTPSourceHandler {
 
     InputStream inputStream = request.getInputStream();
 
-    Map<String, String[]> parameters = request.getParameterMap();
-    for (String parameter : parameters.keySet()) {
-      String value = parameters.get(parameter)[0];
+    Enumeration<String> parameters = request.getHeaderNames();
+    while (parameters.hasMoreElements()){
+      String value = parameters.nextElement();
       if (LOG.isDebugEnabled() && LogPrivacyUtil.allowLogRawData()) {
-        LOG.debug("Setting Header [Key, Value] as [{},{}] ", parameter, value);
+        LOG.debug("Setting Header [Key, Value] as [{},{}] ", request.getHeader(value), value);
       }
-      headers.put(parameter, value);
-    }
-
-    for (String header : mandatoryHeaders) {
-      Preconditions.checkArgument(headers.containsKey(header),
-          "Please specify " + header + " parameter in the request.");
+      headers.put(request.getHeader(value), value);
     }
 
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/flume-ng-core/src/test/java/org/apache/flume/source/http/TestBLOBHandler.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/http/TestBLOBHandler.java
@@ -52,9 +52,9 @@ public class TestBLOBHandler {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Test
   public void testCSVData() throws Exception {
-    Map requestParameterMap = new HashMap();
-    requestParameterMap.put("param1", new String[] { "value1" });
-    requestParameterMap.put("param2", new String[] { "value2" });
+    Map requestHeaders = new HashMap();
+    requestHeaders.put("param1", "value1");
+    requestHeaders.put("param2", "value2");
 
     HttpServletRequest req = mock(HttpServletRequest.class);
     final String csvData = "a,b,c";
@@ -63,7 +63,7 @@ public class TestBLOBHandler {
         new ByteArrayInputStream(csvData.getBytes()));
 
     when(req.getInputStream()).thenReturn(servletInputStream);
-    when(req.getParameterMap()).thenReturn(requestParameterMap);
+    when(req.getParameterMap()).thenReturn(requestHeaders);
 
     Context context = mock(Context.class);
     when(
@@ -85,7 +85,7 @@ public class TestBLOBHandler {
   @Test
   public void testTabData() throws Exception {
     Map requestParameterMap = new HashMap();
-    requestParameterMap.put("param1", new String[] { "value1" });
+    requestParameterMap.put("param1", "value1");
 
     HttpServletRequest req = mock(HttpServletRequest.class);
     final String tabData = "a\tb\tc";


### PR DESCRIPTION
When I executed GET/POST request with headers and body from Postman I received an error:
`2019-07-26 20:39:33,520 (qtp428933649-22) [WARN - org.apache.flume.source.http.HTTPSource$FlumeHTTPServlet.doPost(HTTPSource.java:244)] Deserializer threw unexpected exception. 
java.lang.IllegalArgumentException: Please specify  parameter in the request.
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:88)
	at org.apache.flume.source.http.BLOBHandler.getEvents(BLOBHandler.java:78)`
and headers from the request were not transmitted  
My commit allows you to transfer all request headers and body.
