### PR TITLE
FLUME-3320 Fix:Taildir source reset position bug

### DIFF
--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
@@ -253,7 +253,7 @@ public class ReliableTaildirEventReader implements ReliableEventReader {
             if (tf.getRaf() == null) {
               tf = openFile(f, headers, inode, tf.getPos());
             }
-            if (f.length() < tf.getPos()) {
+            if (f.length() < tf.getPos() && tf.getPath().equals(f.getAbsolutePath())) {
               logger.info("Pos " + tf.getPos() + " is larger than file size! "
                   + "Restarting from pos 0, file: " + tf.getPath() + ", inode: " + inode);
               tf.updatePos(tf.getPath(), inode, 0);


### PR DESCRIPTION
Taildir source has chance to reset position to 0 incorrectly, so data while be duplicated. When log rotate happens just in time so that f and tf are not the same file in between code.
```
f (f.length() < tf.getPos()) {
    logger.info("Pos " + tf.getPos() + " is larger than file size! "
        + "Restarting from pos 0, file: " + tf.getPath() + ", inode: " + inode);
    tf.updatePos(tf.getPath(), inode, 0);
}
```