### PR TITLE
Fix broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+dist: trusty
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Travis builds have been failing recently with "Expected feature release number in range of 9 to 14, but got: 8".
According to
https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/6
adding "dist: trusty" to .travis.yml should fix the issue.