### PR TITLE
FLUME-3347:Direct buffer memory causes sink thread to die

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/SinkRunner.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/SinkRunner.java
@@ -166,6 +166,13 @@ public class SinkRunner implements LifecycleAware {
           } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
           }
+        } catch (Throwable th){
+          logger.error("sink process failure",th);
+          try {
+            Thread.sleep(maxBackoffSleep);
+          } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+          }
         }
       }
       logger.debug("Polling runner exiting. Metrics:{}", counterGroup);


### PR DESCRIPTION
When the java.lang.OutOfMemoryError: Direct buffer memory exception occurs in the hdfsSink thread, the exception is thrown to the SinkRunner thread, but the SinkRunner thread does not catch the Throwable exception, causing the hdfsSink thread to die。