### PR TITLE
Fix issues reported by SpotBugs in ElasticSearch sink

### DIFF
--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/pom.xml
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/pom.xml
@@ -25,8 +25,8 @@
   <name>Flume NG ElasticSearch Sink</name>
 
   <properties>
-    <!-- TODO fix spotbugs/pmd violations -->
-    <spotbugs.maxAllowedViolations>8</spotbugs.maxAllowedViolations>
+    <!-- TODO fix pmd violations -->
+    <spotbugs.maxAllowedViolations>0</spotbugs.maxAllowedViolations>
     <pmd.maxAllowedViolations>10</pmd.maxAllowedViolations>
   </properties>
 

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchDynamicSerializer.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchDynamicSerializer.java
@@ -64,9 +64,10 @@ public class ElasticSearchDynamicSerializer implements
   private void appendHeaders(XContentBuilder builder, Event event)
       throws IOException {
     Map<String, String> headers = event.getHeaders();
-    for (String key : headers.keySet()) {
-      ContentBuilderUtil.appendField(builder, key,
-          headers.get(key).getBytes(charset));
+    for (Map.Entry<String,String> entry : headers.entrySet()) {
+      String key = entry.getKey();
+      byte[] val = entry.getValue().getBytes(charset);
+      ContentBuilderUtil.appendField(builder, key, val);
     }
   }
 

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchLogStashEventSerializer.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchLogStashEventSerializer.java
@@ -126,8 +126,9 @@ public class ElasticSearchLogStashEventSerializer implements
     }
 
     builder.startObject("@fields");
-    for (String key : headers.keySet()) {
-      byte[] val = headers.get(key).getBytes(charset);
+    for (Map.Entry<String,String> entry : headers.entrySet()) {
+      String key = entry.getKey();
+      byte[] val = entry.getValue().getBytes(charset);
       ContentBuilderUtil.appendField(builder, key, val);
     }
     builder.endObject();

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
@@ -305,9 +305,8 @@ public class ElasticSearchSink extends AbstractSink implements Configurable, Bat
         throw new IllegalArgumentException(serializerClazz
             + " is not an ElasticSearchEventSerializer");
       }
-    } catch (Exception e) {
-      logger.error("Could not instantiate event serializer.", e);
-      Throwables.propagate(e);
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException("Could not instantiate index name builder.", e);
     }
 
     if (sinkCounter == null) {
@@ -331,13 +330,8 @@ public class ElasticSearchSink extends AbstractSink implements Configurable, Bat
       indexNameBuilder = clazz.newInstance();
       indexnameBuilderContext.put(INDEX_NAME, indexName);
       indexNameBuilder.configure(indexnameBuilderContext);
-    } catch (Exception e) {
-      logger.error("Could not instantiate index name builder.", e);
-      Throwables.propagate(e);
-    }
-
-    if (sinkCounter == null) {
-      sinkCounter = new SinkCounter(getName());
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException("Could not instantiate index name builder.", e);
     }
 
     Preconditions.checkState(StringUtils.isNotBlank(indexName),
@@ -419,7 +413,7 @@ public class ElasticSearchSink extends AbstractSink implements Configurable, Bat
       } else if (matcher.group(2).equals("d")) {
         return TimeUnit.DAYS.toMillis(Integer.parseInt(matcher.group(1)));
       } else if (matcher.group(2).equals("w")) {
-        return TimeUnit.DAYS.toMillis(7 * Integer.parseInt(matcher.group(1)));
+        return TimeUnit.DAYS.toMillis(7L * (long)Integer.parseInt(matcher.group(1)));
       } else if (matcher.group(2).equals("")) {
         logger.info("TTL qualifier is empty. Defaulting to day qualifier.");
         return TimeUnit.DAYS.toMillis(Integer.parseInt(matcher.group(1)));

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/TimestampedEvent.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/TimestampedEvent.java
@@ -49,7 +49,7 @@ final class TimestampedEvent extends SimpleEvent {
       this.timestamp = DateTimeUtils.currentTimeMillis();
       headers.put("timestamp", String.valueOf(timestamp ));
     } else {
-      this.timestamp = Long.valueOf(timestampString);
+      this.timestamp = Long.parseLong(timestampString);
     }
     setHeaders(headers);
   }

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/client/ElasticSearchClientFactory.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/client/ElasticSearchClientFactory.java
@@ -71,7 +71,6 @@ public class ElasticSearchClientFactory {
       return new ElasticSearchTransportClient(serializer);
     } else if (clientType.equalsIgnoreCase(TransportClient) && indexBuilder != null)  {
       return new ElasticSearchTransportClient(indexBuilder);
-    } else if (clientType.equalsIgnoreCase(RestClient)) {
     }
     throw new NoSuchClientTypeException();
   }

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/client/ElasticSearchRestClient.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/client/ElasticSearchRestClient.java
@@ -105,7 +105,7 @@ public class  ElasticSearchRestClient implements ElasticSearchClient {
     parameters.put(INDEX_OPERATION_NAME, indexParameters);
 
     Gson gson = new Gson();
-    synchronized (bulkBuilder) {
+    synchronized (this) {
       bulkBuilder.append(gson.toJson(parameters));
       bulkBuilder.append("\n");
       bulkBuilder.append(content.toBytesArray().toUtf8());
@@ -118,7 +118,7 @@ public class  ElasticSearchRestClient implements ElasticSearchClient {
     int statusCode = 0, triesCount = 0;
     HttpResponse response = null;
     String entity;
-    synchronized (bulkBuilder) {
+    synchronized (this) {
       entity = bulkBuilder.toString();
       bulkBuilder = new StringBuilder();
     }


### PR DESCRIPTION
I'm working on some minor contributions to the ElasticSearch sink and I noticed that `mvn install -pl flume-ng-sinks/flume-ng-elasticsearch-sink` fails out of the box due to issues reported by SpotBugs.

In this pull request, I am fixing said issues to keep future diffs clean when contributing changes.