### PR TITLE
ElasticSearch cluster name is optional for REST client

### DIFF
--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
@@ -31,6 +31,7 @@ import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.SER
 import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.SERIALIZER_PREFIX;
 import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.TTL;
 import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.TTL_REGEX;
+import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.REST_CLIENT;
 import org.apache.commons.lang.StringUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
@@ -344,7 +345,8 @@ public class ElasticSearchSink extends AbstractSink implements Configurable, Bat
         "Missing Param:" + INDEX_NAME);
     Preconditions.checkState(StringUtils.isNotBlank(indexType),
         "Missing Param:" + INDEX_TYPE);
-    Preconditions.checkState(StringUtils.isNotBlank(clusterName),
+    Preconditions.checkState(
+        StringUtils.isNotBlank(clusterName) || StringUtils.equals(clientType, REST_CLIENT),
         "Missing Param:" + CLUSTER_NAME);
     Preconditions.checkState(batchSize >= 1, BATCH_SIZE
         + " must be greater than 0");

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSinkConstants.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSinkConstants.java
@@ -88,6 +88,16 @@ public class ElasticSearchSinkConstants {
   public static final String CLIENT_TYPE = "client";
 
   /**
+   * Value to use with CLIENT_TYPE to get the transport client.
+   */
+  public static final String TRANSPORT_CLIENT = "transport";
+
+  /**
+   * Value to use with CLIENT_TYPE to get the REST client.
+   */
+  public static final String REST_CLIENT = "rest";
+
+  /**
    * The client prefix to extract the configuration that will be passed to
    * elasticsearch client.
    */

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/client/ElasticSearchClientFactory.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/client/ElasticSearchClientFactory.java
@@ -20,14 +20,16 @@ package org.apache.flume.sink.elasticsearch.client;
 
 import org.apache.flume.sink.elasticsearch.ElasticSearchEventSerializer;
 import org.apache.flume.sink.elasticsearch.ElasticSearchIndexRequestBuilderFactory;
+import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.TRANSPORT_CLIENT;
+import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.REST_CLIENT;
 
 /**
  * Internal ElasticSearch client factory. Responsible for creating instance
  * of ElasticSearch clients.
  */
 public class ElasticSearchClientFactory {
-  public static final String TransportClient = "transport";
-  public static final String RestClient = "rest";
+  public static final String TransportClient = TRANSPORT_CLIENT;
+  public static final String RestClient = REST_CLIENT;
 
   /**
    *


### PR DESCRIPTION
When using `.client = rest`, the `.clusterName` argument is never used.
It should be optional in this case.