### PR TITLE
WIP: Honor UUID interceptor in ElasticSearch sink

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -3054,6 +3054,12 @@ serializer.*      --                                                            
           Caution should be used in using this feature as the event submitter now has control of the indexName and indexType.
           Furthermore, if the elasticsearch REST client is used then the event submitter has control of the URL path used.
 
+.. note:: Deduplication of events in ElasticSearch can be implemented by
+          setting ``serializer.idHeaderHame`` to the name of a header which
+          should be renamed to ``_id`` in documents submitted to ElasticSearch.
+          When using the :ref:`uuid-interceptor`, it should match the
+          ``headerName`` property.
+
 Example for agent named a1:
 
 .. code-block:: properties
@@ -4458,6 +4464,8 @@ fromListSeparator      \\s*,\\s*    Regular expression used to separate multiple
 matching               --           All the headers which names match this regular expression are removed
 =====================  ===========  ===============================================================
 
+
+.. _uuid-interceptor:
 
 UUID Interceptor
 ~~~~~~~~~~~~~~~~

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchDynamicSerializer.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchDynamicSerializer.java
@@ -18,11 +18,13 @@
  */
 package org.apache.flume.sink.elasticsearch;
 
+import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.ID_HEADER_NAME;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 import java.io.IOException;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.conf.ComponentConfiguration;
@@ -38,9 +40,13 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 public class ElasticSearchDynamicSerializer implements
     ElasticSearchEventSerializer {
 
+  private String idHeaderName = null;
+
   @Override
   public void configure(Context context) {
-    // NO-OP...
+    if (StringUtils.isNotBlank(context.getString(ID_HEADER_NAME))) {
+      idHeaderName = context.getString(ID_HEADER_NAME);
+    }
   }
 
   @Override
@@ -64,9 +70,13 @@ public class ElasticSearchDynamicSerializer implements
   private void appendHeaders(XContentBuilder builder, Event event)
       throws IOException {
     Map<String, String> headers = event.getHeaders();
-    for (String key : headers.keySet()) {
-      ContentBuilderUtil.appendField(builder, key,
-          headers.get(key).getBytes(charset));
+    for (Map.Entry<String,String> entry : headers.entrySet()) {
+      String key = entry.getKey();
+      if (StringUtils.equals(key, idHeaderName)) {
+        continue;
+      }
+      byte[] val = entry.getValue().getBytes(charset);
+      ContentBuilderUtil.appendField(builder, key, val);
     }
   }
 

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchLogStashEventSerializer.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchLogStashEventSerializer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.flume.sink.elasticsearch;
 
+import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.ID_HEADER_NAME;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 import java.io.IOException;
@@ -73,6 +74,8 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 public class ElasticSearchLogStashEventSerializer implements
     ElasticSearchEventSerializer {
 
+  private String idHeaderName = null;
+
   @Override
   public XContentBuilder getContentBuilder(Event event) throws IOException {
     XContentBuilder builder = jsonBuilder().startObject();
@@ -126,8 +129,12 @@ public class ElasticSearchLogStashEventSerializer implements
     }
 
     builder.startObject("@fields");
-    for (String key : headers.keySet()) {
-      byte[] val = headers.get(key).getBytes(charset);
+    for (Map.Entry<String,String> entry : headers.entrySet()) {
+      String key = entry.getKey();
+      if (StringUtils.equals(key, idHeaderName)) {
+        continue;
+      }
+      byte[] val = entry.getValue().getBytes(charset);
       ContentBuilderUtil.appendField(builder, key, val);
     }
     builder.endObject();
@@ -135,7 +142,9 @@ public class ElasticSearchLogStashEventSerializer implements
 
   @Override
   public void configure(Context context) {
-    // NO-OP...
+    if (StringUtils.isNotBlank(context.getString(ID_HEADER_NAME))) {
+      idHeaderName = context.getString(ID_HEADER_NAME);
+    }
   }
 
   @Override

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSink.java
@@ -31,6 +31,7 @@ import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.SER
 import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.SERIALIZER_PREFIX;
 import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.TTL;
 import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.TTL_REGEX;
+import static org.apache.flume.sink.elasticsearch.ElasticSearchSinkConstants.ID_HEADER_NAME;
 import org.apache.commons.lang.StringUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
@@ -106,6 +107,7 @@ public class ElasticSearchSink extends AbstractSink implements Configurable, Bat
   private Matcher matcher = pattern.matcher("");
 
   private String[] serverAddresses = null;
+  private String idHeaderName = null;
 
   private ElasticSearchClient client = null;
   private Context elasticSearchClientContext = null;
@@ -277,7 +279,14 @@ public class ElasticSearchSink extends AbstractSink implements Configurable, Bat
       clientType = context.getString(CLIENT_TYPE);
     }
 
+    if (StringUtils.isNotBlank(context.getString(ID_HEADER_NAME))) {
+      idHeaderName = context.getString(ID_HEADER_NAME);
+    }
+
     elasticSearchClientContext = new Context();
+    if (idHeaderName != null) {
+      elasticSearchClientContext.put(ID_HEADER_NAME, idHeaderName);
+    }
     elasticSearchClientContext.putAll(context.getSubProperties(CLIENT_PREFIX));
 
     String serializerClazz = DEFAULT_SERIALIZER_CLASS;
@@ -286,6 +295,9 @@ public class ElasticSearchSink extends AbstractSink implements Configurable, Bat
     }
 
     Context serializerContext = new Context();
+    if (idHeaderName != null) {
+      serializerContext.put(ID_HEADER_NAME, idHeaderName);
+    }
     serializerContext.putAll(context.getSubProperties(SERIALIZER_PREFIX));
 
     try {

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSinkConstants.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSinkConstants.java
@@ -70,6 +70,11 @@ public class ElasticSearchSinkConstants {
   public static final String SERIALIZER_PREFIX = SERIALIZER + ".";
 
   /**
+   * Name of the header that will be used as the ElasticSearch document ID.
+   */
+  public static final String ID_HEADER_NAME = "idHeaderName";
+
+  /**
    * The fully qualified class name of the index name builder the sink
    * should use to determine name of index where the event should be sent.
    */


### PR DESCRIPTION
ElasticSearch provides support for deduplication of events using the
`_id` field when inserting documents using the bulk insert facility.

When using the UUID interceptor with `headerName = _id` for this
purpose, the logstash serializer will rename this as `@fields._id`,
which is stored as though it were any other field.

In order to enable deduplication of events in the ElasticSearch sink, we
need to ensure the header containing the document ID is sent as `_id`,
no matter what its original name is.

The dynamic serializer probably does not have the same limitation, but
it currently counts on the UUID interceptor's `headerName` property to
be set to `_id`.  This is not the default and it is unlikely to work in
complex Flume networks that replicate events to multiple sinks.
Therefore, I fixed it to support the same logic as the logstash
serializer.