### PR TITLE
WIP: Enable configuration of HTTP client in ElasticSearch sink

### DIFF
--- a/flume-ng-doc/sphinx/FlumeUserGuide.rst
+++ b/flume-ng-doc/sphinx/FlumeUserGuide.rst
@@ -3045,6 +3045,9 @@ ttl               --                                                            
                                                                                            integer only e.g. a1.sinks.k1.ttl = 5 and also with a qualifier ms (millisecond), s (second), m (minute),
                                                                                            h (hour), d (day) and w (week). Example a1.sinks.k1.ttl = 5d will set TTL to 5 days. Follow
                                                                                            http://www.elasticsearch.org/guide/reference/mapping/ttl-field/ for more information.
+client            transport                                                                Set to "rest" to send data using HTTP bulk insert API.
+client.rest       org.apache.flume.sink.elasticsearch.client.HttpClient                    The HttpClientBuilder to use to create the HTTP client.
+client.rest.*     --                                                                       Properties to be passed to the HTTP client.
 serializer        org.apache.flume.sink.elasticsearch.ElasticSearchLogStashEventSerializer The ElasticSearchIndexRequestBuilderFactory or ElasticSearchEventSerializer to use. Implementations of
                                                                                            either class are accepted but ElasticSearchIndexRequestBuilderFactory is preferred.
 serializer.*      --                                                                       Properties to be passed to the serializer.
@@ -3053,6 +3056,10 @@ serializer.*      --                                                            
 .. note:: Header substitution is a handy to use the value of an event header to dynamically decide the indexName and indexType to use when storing the event.
           Caution should be used in using this feature as the event submitter now has control of the indexName and indexType.
           Furthermore, if the elasticsearch REST client is used then the event submitter has control of the URL path used.
+
+.. note:: By default, access to ElasticSearch is not authenticated.
+          Authentication to ElasticSearch can be configured by providing your
+          own implementation of the HTTPClientBuilder.
 
 Example for agent named a1:
 

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSinkConstants.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/ElasticSearchSinkConstants.java
@@ -94,6 +94,17 @@ public class ElasticSearchSinkConstants {
   public static final String CLIENT_PREFIX = CLIENT_TYPE + ".";
 
   /**
+   * The HTTP client type used for sending bulks to ElasticSearch
+   */
+  public static final String HTTP_CLIENT = "rest";
+
+  /**
+   * The client prefix to extract the configuration that will be passed to
+   * the HTTP client.
+   */
+  public static final String HTTP_CLIENT_PREFIX = HTTP_CLIENT + ".";
+
+  /**
    * DEFAULTS USED BY THE SINK
    */
 
@@ -108,4 +119,6 @@ public class ElasticSearchSinkConstants {
           "sink.elasticsearch.ElasticSearchLogStashEventSerializer";
   public static final String DEFAULT_INDEX_NAME_BUILDER_CLASS =
           "org.apache.flume.sink.elasticsearch.TimeBasedIndexNameBuilder";
+  public static final String DEFAULT_HTTP_CLIENT_CLASS =
+          "org.apache.flume.sink.elasticsearch.client.HttpClientBuilder";
 }

--- a/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/client/HttpClientBuilder.java
+++ b/flume-ng-sinks/flume-ng-elasticsearch-sink/src/main/java/org/apache/flume/sink/elasticsearch/client/HttpClientBuilder.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flume.sink.elasticsearch.client;
+
+import org.apache.flume.Context;
+import org.apache.flume.conf.Configurable;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.DefaultHttpClient;
+
+/**
+ * HTTP client which is used for sending bulks of events to ElasticSearch using
+ * ElasticSearch HTTP API.  This is configurable, so any config params required
+ * should be taken through this.
+ *
+ * You can extend this class in your own Flume plug-ins to customize HTTP
+ * request and response processing (e.g. to handle authentication).
+ */
+public class HttpClientBuilder implements Configurable {
+
+  /**
+   * Create the HTTP client.
+   */
+  public HttpClient newHttpClient() {
+    return new DefaultHttpClient();
+  }
+
+  @Override
+  public void configure(Context context) {
+    // NO-OP...
+  }
+}


### PR DESCRIPTION
It's quite common to deploy ElasticSearch behind some authenticating reverse proxy (e.g. with AWS ElasticSearch).

The original implementation directly instantiates `org.apache.http.impl.client.DefaultHttpClient` with no form of control over authentication.

This change enables configuring the HTTP client with any form of authentication.

**NOTE**: this is a draft change to get feedback.  I will add proper tests once I get initial feedback about the design.