### PR TITLE
flume-ng-sdk add dependency: commons-lang

### DIFF
--- a/flume-ng-sdk/pom.xml
+++ b/flume-ng-sdk/pom.xml
@@ -239,6 +239,11 @@ limitations under the License.
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
     </dependency>
+       
+     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+    </dependency>
 
   </dependencies>
 </project>


### PR DESCRIPTION
When I use maven to build the flume 1.9.0 and trunk source code, I get an error and lack of dependencies
[ERROR] /D:/apache-flume-1.9.0-src/flume-ng-sdk/src/main/java/org/apache/flume/api/NettyAvroRpcClient.java:[62,31] 程序包org.apache.commons.lang不存在
[ERROR] /D:/apache-flume-1.9.0-src/flume-ng-sdk/src/main/java/org/apache/flume/api/NettyAvroRpcClient.java:[583,10] 找不到符号
  符号:   变量 StringUtils
  位置: 类 org.apache.flume.api.NettyAvroRpcClient


the maven dependency tree:
[INFO] org.apache.flume:flume-ng-sdk:jar:1.9.0
[INFO] +- junit:junit:jar:4.10:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.1:test
[INFO] +- org.slf4j:slf4j-api:jar:1.7.25:compile
[INFO] +- org.slf4j:slf4j-log4j12:jar:1.7.25:test
[INFO] +- log4j:log4j:jar:1.2.17:test
[INFO] +- org.apache.avro:avro:jar:1.7.4:compile
[INFO] |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.3:compile
[INFO] |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.3:compile
[INFO] |  +- com.thoughtworks.paranamer:paranamer:jar:2.3:compile
[INFO] |  +- org.xerial.snappy:snappy-java:jar:1.1.4:compile
[INFO] |  \- org.apache.commons:commons-compress:jar:1.4.1:compile
[INFO] |     \- org.tukaani:xz:jar:1.0:compile
[INFO] +- org.apache.avro:avro-ipc:jar:1.7.4:compile
[INFO] +- io.netty:netty:jar:3.10.6.Final:compile
[INFO] \- org.apache.thrift:libthrift:jar:0.9.3:compile
[INFO]    +- org.apache.httpcomponents:httpclient:jar:4.5.3:compile
[INFO]    |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO]    |  \- commons-codec:commons-codec:jar:1.8:compile
[INFO]    \- org.apache.httpcomponents:httpcore:jar:4.4.6:compile