### PR TITLE
Fix FLUME-3233: only use inode to identify files then taildirSource will support file rename/rotation

### DIFF
--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -43,7 +43,7 @@ public class TailFile {
   private static final int NEED_READING = -1;
 
   private RandomAccessFile raf;
-  private final String path;
+  private String path;
   private final long inode;
   private long pos;
   private long lastUpdated;
@@ -107,6 +107,10 @@ public class TailFile {
     this.pos = pos;
   }
 
+  public void setPath(String path) {
+    this.path = path;
+  }
+
   public void setLastUpdated(long lastUpdated) {
     this.lastUpdated = lastUpdated;
   }
@@ -128,6 +132,19 @@ public class TailFile {
     }
     return false;
   }
+
+  public boolean updatePosAndPath(String path, long inode, long pos) throws IOException {
+    if (this.inode == inode) {
+      setPos(pos);
+      setPath(path);
+      updateFilePos(pos);
+      logger.info("Updated position and path, file: " + path + ", inode: " + inode +
+              ", pos: " + pos);
+      return true;
+    }
+    return false;
+  }
+
   public void updateFilePos(long pos) throws IOException {
     raf.seek(pos);
     lineReadPos = pos;

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
@@ -88,6 +88,7 @@ public class TaildirSource extends AbstractSource implements
   private boolean fileHeader;
   private String fileHeaderKey;
   private Long maxBatchCount;
+  private boolean inodeOnly;
 
   @Override
   public synchronized void start() {
@@ -102,6 +103,7 @@ public class TaildirSource extends AbstractSource implements
           .cachePatternMatching(cachePatternMatching)
           .annotateFileName(fileHeader)
           .fileNameHeader(fileHeaderKey)
+          .inodeOnly(inodeOnly)
           .build();
     } catch (IOException e) {
       throw new FlumeException("Error instantiating ReliableTaildirEventReader", e);
@@ -187,6 +189,7 @@ public class TaildirSource extends AbstractSource implements
     fileHeaderKey = context.getString(FILENAME_HEADER_KEY,
             DEFAULT_FILENAME_HEADER_KEY);
     maxBatchCount = context.getLong(MAX_BATCH_COUNT, DEFAULT_MAX_BATCH_COUNT);
+    inodeOnly = context.getBoolean(INODE_ONLY, DEFAULT_INODE_ONLY);
     if (maxBatchCount <= 0) {
       maxBatchCount = DEFAULT_MAX_BATCH_COUNT;
       logger.warn("Invalid maxBatchCount specified, initializing source "

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSourceConfigurationConstants.java
@@ -67,4 +67,8 @@ public class TaildirSourceConfigurationConstants {
   /** The max number of batch reads from a file in one loop */
   public static final String MAX_BATCH_COUNT = "maxBatchCount";
   public static final Long DEFAULT_MAX_BATCH_COUNT = Long.MAX_VALUE;
+
+  /** Whether to support file rotation in case it only checks inode nor both inode and file name */
+  public static final String INODE_ONLY = "inodeOnly";
+  public static final Boolean DEFAULT_INODE_ONLY = false;
 }


### PR DESCRIPTION
The issue:
When file is renamed or rotated,  just as it is in log4j or other similar log system, currently Flume taildirSource will treat it as a new file then all contents will be collected again. It will cause data duplicated, which has been described in [FLUME-3233](https://issues.apache.org/jira/browse/FLUME-3233)、 [FLUME-3219](https://issues.apache.org/jira/browse/FLUME-3219)、[FLUME-3094](https://issues.apache.org/jira/browse/FLUME-3094)、[FLUME-3216](https://issues.apache.org/jira/browse/FLUME-3216) and [FLUME-2777](https://issues.apache.org/jira/browse/FLUME-2777).
The general solution is only monitor original  *.log and NOT monitor the renamed *.log.xxx. But for below two reasons, we must monitor both *.log and  renamed *.log.xxx:
1、 Sometimes log system uses async writting. Contents may be flushed to disk after file is renamed. If we do not monitor renamed *.log.xxx, the content will only be sent out when Flume close inactive file. Though Flume will send it out finally, but it will cause sending delay and curreny the interval is decided by _idleTimeout_, default 120 seconds. In many cases it is unacceptable.
2、Sometimes both service and Flume are shutdown. Service is restarted firstly then it writes something to *.log and rename it as *.log.xxx before Flume is restarted successfully. If we do not monitor renamed *.log.xxx, the data will get lost certernly.

The solution:
The PR add a new _inodeOnly_ paramater to reslove data duplication  problem when monitoring both *.log and *.log.xx. And it will bring taildirSource ability of supporting file rename/rotation. By default,  _inodeOnly_  is false and Flume just works same with now. When _inodeOnly_ in config is set as true, Flume only use inode to identify file then taildirSource will support file rename/rotation. And the above 2 problems will be solved perfectly.
