### PR TITLE
fixed the key of map in 266 line

### DIFF
--- a/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
+++ b/flume-ng-sources/flume-kafka-source/src/main/java/org/apache/flume/source/kafka/KafkaSource.java
@@ -263,7 +263,7 @@ public class KafkaSource extends AbstractPollableSource
         }
         // Only set the topic header if setTopicHeader and it isn't already populated
         if (setTopicHeader && !headers.containsKey(topicHeader)) {
-          headers.put(topicHeader, message.topic());
+          headers.put("topicHeader", message.topic());
         }
         if (!headers.containsKey(KafkaSourceConstants.PARTITION_HEADER)) {
           headers.put(KafkaSourceConstants.PARTITION_HEADER,


### PR DESCRIPTION
When I use the Multiplexing Channel Selector in apache-flume-ng-1.9.0, I found that the topicHeader parameter specified in KafkaSource does not work properly for mapping. Refer to the source code of kafkasource and found that in line 266, the key of the map that put into the header is a dynamic parameter,  but in my humbly opinion , this should be a static string ("topicHeader"). after I modify the source code, the selector works normally !