### PR TITLE
Resolved that when using KafkaChannel, Kafka-related metadata information could not be obtained in sink

### DIFF
--- a/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
+++ b/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
@@ -516,6 +516,18 @@ public class KafkaChannel extends BasicChannelSemantics {
             if (record.key() != null) {
               e.getHeaders().put(KEY_HEADER, record.key());
             }
+            //Add the topic to the header
+            if(null != record.topic()){
+              e.getHeaders().put(TOPIC_HEADER,record.topic());
+            }
+            //Add the offset to the header
+            if(-1 != record.offset()){
+              e.getHeaders().put(OFFSET_HEADER,String.valueOf(record.offset()));
+            }
+            //Add the timestamp to the header
+            if(-1 != record.timestamp()){
+              e.getHeaders().put(TIMESTAMP_HEADER,String.valueOf(record.timestamp()));
+            }
 
             long endTime = System.nanoTime();
             counter.addToKafkaEventGetTimer((endTime - startTime) / (1000 * 1000));

--- a/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannelConfiguration.java
+++ b/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannelConfiguration.java
@@ -43,6 +43,9 @@ public class KafkaChannelConfiguration {
   public static final long DEFAULT_POLL_TIMEOUT = 500;
 
   public static final String KEY_HEADER = "key";
+  public static final String TOPIC_HEADER = "topic";
+  public static final String OFFSET_HEADER = "offset";
+  public static final String TIMESTAMP_HEADER = "timestamp";
 
   public static final String DEFAULT_AUTO_OFFSET_RESET = "earliest";
 


### PR DESCRIPTION
When using memory-channel, the header is retrieved from sink and the metadata information of Kafka is retrieved from it, but when using kafka-channel, it is not retrieved

```
HDFSEventSink.class
public Status process() throws EventDeliveryException{
.....
Channel channel = getChannel();
Event event = channel.take();
Map<String, String> headers = event.getHeaders();
String topic = headers.get("topic");
String key = headers.get("key");
String offset = headers.get("offset");
System.out.println("topic = " + topic);
System.out.println("key = " + key);
System.out.println("offset = " + offset);
}
```


In the above code, the printed value is empty, so this solves the problem


