### PR TITLE
Update log4j2 dependency to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ limitations under the License.
     <kite.version>1.1.0</kite.version>
     <kudu.version>1.10.0</kudu.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
-    <log4j.version>2.15.0</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <mapdb.version>0.9.9</mapdb.version>
     <mina.version>2.0.4</mina.version>
     <mockito.version>1.9.0</mockito.version>


### PR DESCRIPTION
There is some concern that 2.15.0 is still vulnerable.