### PR TITLE
FLUME-3410 Upgrade HBase client libraries

### DIFF
--- a/flume-ng-sinks/flume-ng-hbase2-sink/pom.xml
+++ b/flume-ng-sinks/flume-ng-hbase2-sink/pom.xml
@@ -93,27 +93,6 @@
         <version>${hbase2.version}</version>
       </dependency>
 
-      <!-- Jetty version needed by HBase2 tests -->
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
-        <version>${hbase2.jetty.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-util</artifactId>
-        <version>${hbase2.jetty.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${hbase2.jetty.version}</version>
-        <scope>test</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@ limitations under the License.
     <stagingDirectory>${project.basedir}/target/docs</stagingDirectory>
 
     <activemq.version>5.7.0</activemq.version>
-    <asynchbase.version>1.7.0</asynchbase.version>
+    <asynchbase.version>1.8.2</asynchbase.version>
     <avro.version>1.11.0</avro.version>
     <bundle-plugin.version>2.3.7</bundle-plugin.version>
     <checkstyle.tool.version>8.45.1</checkstyle.tool.version>
@@ -70,9 +70,8 @@ limitations under the License.
     <guava.version>18.0</guava.version>
     <guava-old.version>11.0.2</guava-old.version>
     <hadoop.version>2.9.0</hadoop.version>
-    <hbase.version>1.6.0</hbase.version>
-    <hbase2.jetty.version>9.3.29.v20201019</hbase2.jetty.version>
-    <hbase2.version>2.4.1</hbase2.version>
+    <hbase.version>1.7.1</hbase.version>
+    <hbase2.version>2.4.11</hbase2.version>
     <hive.version>1.0.0</hive.version>
     <httpcore.version>4.4.6</httpcore.version>
     <httpclient.version>4.5.3</httpclient.version>


### PR DESCRIPTION
- upgrade AsyncHBase to 1.8.2 (minor version)
- upgrade HBase 1 to 1.7.0 (minor version)
- upgrade HBase 2 to 2.4.11 (patch version)

unit tests pass locally for the hbase-sink and hbase2-sink. Also removed the "hbase2 jetty" test dependencies because HBase 2.4 (which was present prior to this patch) relies on an internally relocated jetty for hbase tests.