### PR TITLE
Fix typo in the flume-ng script

### DIFF
--- a/bin/flume-ng
+++ b/bin/flume-ng
@@ -168,7 +168,7 @@ global options:
   --conf-uri, -u <conf>     use configs located at <conf>
   --conf-provider, -prov <provider-class> use the configuration provided by the provider class
   --conf-user, -user <user>    the user for accessing the configuration uri
-  --conf-oassword, -pwd <password> the password for accessing the configuration uri
+  --conf-password, -pwd <password> the password for accessing the configuration uri
   --classpath,-C <cp>       append to the classpath
   --dryrun,-d               do not actually start Flume, just print the command
   --plugins-path <dirs>     colon-separated list of plugins.d directories. See the


### PR DESCRIPTION
There's a typo in the `flume-ng` script: `conf-oassword`. This PR changes that to `conf-password`.

Edit: mind that the typo is local / isolated. It looks fine where it's referenced: https://github.com/apache/flume/blob/55206a891a7159af31243902a09aa05f1f45a138/flume-ng-node/src/main/java/org/apache/flume/node/Application.java#L332