### PR TITLE
Update repository in VersionInfo

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/tools/VersionInfo.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/tools/VersionInfo.java
@@ -116,7 +116,7 @@ public class VersionInfo {
   public static void main(String[] args) {
     System.out.println("Flume " + getVersion());
     System.out.println("Source code repository: "
-            + "https://git-wip-us.apache.org/repos/asf/flume.git");
+            + "https://git.apache.org/repos/asf/flume.git");
     System.out.println("Revision: " + getRevision());
     System.out.println("Compiled by " + getUser() + " on " + getDate());
     System.out.println("From source with checksum " + getSrcChecksum());


### PR DESCRIPTION
The repository reported by `version` is not available. This PR updates the info. See also: https://lists.apache.org/thread/w9tyst37b1l0trf5sx621l86vlsxzzr6 