### PR TITLE
FLUME-3379 Include maven repos needed for transitive dependencies

### DIFF
--- a/flume-ng-sinks/flume-hive-sink/pom.xml
+++ b/flume-ng-sinks/flume-hive-sink/pom.xml
@@ -36,6 +36,23 @@ limitations under the License.
   <artifactId>flume-hive-sink</artifactId>
   <name>Flume NG Hive Sink</name>
 
+  <repositories>
+    <!-- Our current hive version needs a calcite version that has dependencies not available in Maven Central.
+         The pom from calcite gives the HTTP version of this repo address, which gets ignored by current maven.
+      -->
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <id>conjars</id>
+      <name>Conjars</name>
+      <url>https://conjars.org/repo</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
+
   <dependencies>
 
     <dependency>

--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
@@ -37,6 +37,33 @@ limitations under the License.
     <solr.expected.version>${solr-global.version}</solr.expected.version> <!-- sanity check to verify we actually run against the expected version rather than some outdated version -->
   </properties>
 
+  <repositories>
+    <!-- Morphlines needs the ua-parser library, which isn't published to Maven central.
+         This repo from Twitter is where Morphlines gets this dependency from normally,
+         but we need to specify HTTPS so that Maven won't ignore the repo.
+    -->
+    <repository>
+      <id>maven-twttr</id>
+      <name>Twitter Public Maven Repo</name>
+      <url>https://maven.twttr.com</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <!-- Morphlines brings in a version of solr-core that needs the restlet jar which isn't
+         in Maven central. We need to include the HTTPS version of the repo Solr gives in
+         order to keep Maven using the repo.
+    -->
+    <repository>
+      <id>maven-restlet</id>
+      <name>Restlet Public Maven Repo</name>
+      <url>https://maven.restlet.org</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
Several dependencies are still old enough that they or their transitive poms refer to HTTP repo urls that get blocked by current versions of maven.

Add HTTPS version where needed for:

* Twitter public repo for ua-parser lib
* Restlet public repo for restlet lib
* Conjars public repo for transitive libs of calcite