### PR TITLE
FLUME-3434: TwitterSource fails to cast int to long

### DIFF
--- a/flume-ng-sources/flume-twitter-source/pom.xml
+++ b/flume-ng-sources/flume-twitter-source/pom.xml
@@ -50,6 +50,12 @@ limitations under the License.
     </dependency>
 
     <dependency>
+      <groupId>org.easytesting</groupId>
+      <artifactId>fest-reflect</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.twitter4j</groupId>
       <artifactId>twitter4j-core</artifactId>
     </dependency>


### PR DESCRIPTION
Adds in counters and improved testing