### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-hdfs to 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ limitations under the License.
     <gson.version>2.9.1</gson.version>
     <guava.version>18.0</guava.version>
     <guava-old.version>11.0.2</guava-old.version>
-    <hadoop.version>2.10.1</hadoop.version>
+    <hadoop.version>3.3.2</hadoop.version>
     <hbase.version>1.7.1</hbase.version>
     <hbase2.version>2.4.11</hbase2.version>
     <hive.version>1.2.2</hive.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hadoop:hadoop-hdfs 2.10.1
- [MPS-2022-12474](https://www.oscs1024.com/hd/MPS-2022-12474)


### What did I do？
Upgrade org.apache.hadoop:hadoop-hdfs from 2.10.1 to 3.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS