### PR TITLE
Set KafkaSink error message log level from DEBUG to WARN

### DIFF
--- a/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
@@ -513,7 +513,7 @@ class SinkCallback implements Callback {
 
   public void onCompletion(RecordMetadata metadata, Exception exception) {
     if (exception != null) {
-      logger.debug("Error sending message to Kafka {} ", exception.getMessage());
+      logger.warn("Error sending message to Kafka: {} ", exception.getMessage());
     }
 
     if (logger.isDebugEnabled()) {

--- a/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
@@ -513,7 +513,7 @@ class SinkCallback implements Callback {
 
   public void onCompletion(RecordMetadata metadata, Exception exception) {
     if (exception != null) {
-      logger.warn("Error sending message to Kafka: {} ", exception.getMessage());
+      logger.debug("Error sending message to Kafka {} ", exception.getMessage());
     }
 
     if (logger.isDebugEnabled()) {

--- a/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSink.java
@@ -513,7 +513,7 @@ class SinkCallback implements Callback {
 
   public void onCompletion(RecordMetadata metadata, Exception exception) {
     if (exception != null) {
-      logger.debug("Error sending message to Kafka {} ", exception.getMessage());
+      logger.warn("Error sending message to Kafka {} ", exception.getMessage());
     }
 
     if (logger.isDebugEnabled()) {


### PR DESCRIPTION
Set exception output message log level from **DEBUG** to **WARN** When sending data to kafka error occurred,，because in production environment log level usually be info or higher level,debug level error message is invisible and we don't know lost data when send data to kafka.

`  
 if (exception != null) {
      logger.warn("Error sending message to Kafka {} ", exception.getMessage());
    }
`