### PR TITLE
Add Kafka Transactions to KafkaChannel and KafkaSink, including unit tests

### DIFF
--- a/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannelConfiguration.java
+++ b/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannelConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.flume.channel.kafka;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.ProducerConfig;
 
 public class KafkaChannelConfiguration {
 
@@ -37,6 +38,9 @@ public class KafkaChannelConfiguration {
   public static final String TOPIC_CONFIG = KAFKA_PREFIX + "topic";
   public static final String BOOTSTRAP_SERVERS_CONFIG =
       KAFKA_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+
+  public static final String TRANSACTIONAL_ID =
+          KAFKA_PRODUCER_PREFIX + ProducerConfig.TRANSACTIONAL_ID_CONFIG;
   public static final String DEFAULT_TOPIC = "flume-channel";
   public static final String DEFAULT_GROUP_ID = "flume";
   public static final String POLL_TIMEOUT = KAFKA_PREFIX + "pollTimeout";

--- a/flume-ng-channels/flume-kafka-channel/src/test/java/org/apache/flume/channel/kafka/TestRollback.java
+++ b/flume-ng-channels/flume-kafka-channel/src/test/java/org/apache/flume/channel/kafka/TestRollback.java
@@ -29,27 +29,48 @@ public class TestRollback extends TestKafkaChannelBase {
 
   @Test
   public void testSuccess() throws Exception {
-    doTestSuccessRollback(false, false);
+    doTestSuccessRollback(false, false, false);
   }
 
   @Test
   public void testSuccessInterleave() throws Exception {
-    doTestSuccessRollback(false, true);
+    doTestSuccessRollback(false, true, false);
   }
 
   @Test
   public void testRollbacks() throws Exception {
-    doTestSuccessRollback(true, false);
+    doTestSuccessRollback(true, false, false);
   }
 
   @Test
   public void testRollbacksInterleave() throws Exception {
-    doTestSuccessRollback(true, true);
+    doTestSuccessRollback(true, true, false);
+  }
+
+  @Test
+  public void testSuccessTxns() throws Exception {
+    doTestSuccessRollback(false, false, true);
+  }
+
+  @Test
+  public void testSuccessInterleaveTxns() throws Exception {
+    doTestSuccessRollback(false, true, true);
+  }
+
+  @Test
+  public void testRollbacksTxns() throws Exception {
+    doTestSuccessRollback(true, false, true);
+  }
+
+  @Test
+  public void testRollbacksInterleaveTxns() throws Exception {
+    doTestSuccessRollback(true, true, true);
   }
 
   private void doTestSuccessRollback(final boolean rollback,
-                                     final boolean interleave) throws Exception {
-    final KafkaChannel channel = startChannel(true);
+                                     final boolean interleave,
+                                     final boolean useKafkaTxns) throws Exception {
+    final KafkaChannel channel = startChannel(true, useKafkaTxns);
     writeAndVerify(rollback, channel, interleave);
     channel.stop();
   }

--- a/flume-ng-channels/flume-kafka-channel/src/test/resources/kafka-server.properties
+++ b/flume-ng-channels/flume-kafka-channel/src/test/resources/kafka-server.properties
@@ -109,6 +109,13 @@ log.retention.check.interval.ms=60000
 # marked for log compaction.
 log.cleaner.enable=false
 
+############################# Transactions #############################
+
+# Settings only to be used for non-production
+transaction.state.log.replication.factor = 1
+transaction.state.log.min.isr = 1
+transaction.state.log.num.partitions = 1
+
 ############################# Zookeeper #############################
 
 # Zookeeper connection string (see zookeeper docs for details).

--- a/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSinkConstants.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/main/java/org/apache/flume/sink/kafka/KafkaSinkConstants.java
@@ -19,6 +19,7 @@
 package org.apache.flume.sink.kafka;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.ProducerConfig;
 
 public class KafkaSinkConstants {
 
@@ -31,6 +32,8 @@ public class KafkaSinkConstants {
   public static final String BATCH_SIZE = "flumeBatchSize";
   public static final String BOOTSTRAP_SERVERS_CONFIG =
       KAFKA_PREFIX + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+
+  public static final String TRANSACTIONAL_ID = KAFKA_PREFIX + "producer." +  ProducerConfig.TRANSACTIONAL_ID_CONFIG;
 
   public static final String KEY_HEADER = "key";
   public static final String DEFAULT_TOPIC_OVERRIDE_HEADER = "topic";

--- a/flume-ng-sinks/flume-ng-kafka-sink/src/test/java/org/apache/flume/sink/kafka/TestConstants.java
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/test/java/org/apache/flume/sink/kafka/TestConstants.java
@@ -23,6 +23,7 @@ public class TestConstants {
   public static final String HEADER_TOPIC = "%{header1}-topic";
   public static final String CUSTOM_KEY = "custom-key";
   public static final String CUSTOM_TOPIC = "custom-topic";
+  public static final String TRANSACTIONS_TOPIC = "transactions-topic";
   public static final String HEADER_1_VALUE = "test-avro-header";
   public static final String HEADER_1_KEY = "header1";
   public static final String KAFKA_HEADER_1 = "FLUME_CORRELATOR";

--- a/flume-ng-sinks/flume-ng-kafka-sink/src/test/resources/kafka-server.properties
+++ b/flume-ng-sinks/flume-ng-kafka-sink/src/test/resources/kafka-server.properties
@@ -109,6 +109,13 @@ log.retention.check.interval.ms=60000
 # marked for log compaction.
 log.cleaner.enable=false
 
+############################# Transactions #############################
+
+# Settings only to be used for non-production
+transaction.state.log.replication.factor = 1
+transaction.state.log.min.isr = 1
+transaction.state.log.num.partitions = 1
+
 ############################# Zookeeper #############################
 
 # Zookeeper connection string (see zookeeper docs for details).


### PR DESCRIPTION
This PR is to take advantage of Kafka Transactions (https://cwiki.apache.org/confluence/display/KAFKA/KIP-98+-+Exactly+Once+Delivery+and+Transactional+Messaging) as part of KafkaSink and KafkaChannel, which allows cleaner rollback, Exactly Once Semantics (EOS) but also potentially performance improvements (see https://redpanda.com/blog/fast-transactions for how this works).

I have a docs change alongside this, but essentially this is all controlled by setting the producer `transactional.id` and all of the Kafka code works on whether this has been set or not.

Added unit tests to make sure the behaviour is consistent.