### PR TITLE
FLUME-3447. Upgrade commons-text version to fix CVE-2022-42889

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@ limitations under the License.
     <commons-dbcp.version>1.4</commons-dbcp.version>
     <commons-io.version>2.11.0</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>
-    <commons-text.version>1.9</commons-text.version>
+    <commons-text.version>1.10.0</commons-text.version>
     <curator.version>5.1.0</curator.version>
     <derby.version>10.14.2.0</derby.version>
     <dropwizard-metrics.version>4.1.18</dropwizard-metrics.version>


### PR DESCRIPTION
Signed-off-by: nikita15p <37657012+nikita15p@users.noreply.github.com>