### PR TITLE
[FLUME-3454] fixing exception while starting agent configured to jms source when passwordFile field is missing

### DIFF
--- a/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSMessageConsumer.java
+++ b/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSMessageConsumer.java
@@ -67,7 +67,7 @@ class JMSMessageConsumer {
 
     try {
       try {
-        if (userName.isPresent()) {
+        if (userName.isPresent() && password.isPresent()) {
           connection = connectionFactory.createConnection(userName.get(), password.get());
         } else {
           connection = connectionFactory.createConnection();


### PR DESCRIPTION
Fixing exception while starting agent configured to jms source when passwordFile field is missing in the flume.conf file