### PR TITLE
FLUME-3452. Upgrade libthrift version to fix CVE 2020-1938

### DIFF
--- a/dev-docs/UpdateLicenses.md
+++ b/dev-docs/UpdateLicenses.md
@@ -533,7 +533,7 @@ ALv2. Entry in NOTICE.  Additional entry in NOTICE and LICENSE for
 PureJavaCrc32C; portions 2-Clause BSD.
 
 ```
-   libthrift-0.14.1.jar
+   libthrift-0.14.2.jar
 ```
 
 same as jar-with-dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ limitations under the License.
     <solr-global.version>4.3.0</solr-global.version>
     <slf4j.version>1.7.32</slf4j.version>
     <system-rules.version>1.17.0</system-rules.version>
-    <thrift.version>0.14.1</thrift.version>
+    <thrift.version>0.14.2</thrift.version>
     <twitter4j.version>4.0.7</twitter4j.version>
     <twitter4j-media.version>4.0.6</twitter4j-media.version>
     <wiremock.version>1.53</wiremock.version>


### PR DESCRIPTION
org.apache.thrift:libthrift:0.14.1 has dependency on tomcat-embed-core : 8.5.46 which is causing CVE 2020-1938.

org.apache.thrift:libthrift:0.14.2 solved the problem for https://mvnrepository.com/artifact/org.apache.thrift/libthrift/0.14.2,

see https://issues.apache.org/jira/browse/FLUME-3452.