### PR TITLE
[FLUME-3462]the maven.restlet.org domain redirects to maven.restlet.talend.com

### DIFF
--- a/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
+++ b/flume-ng-sinks/flume-ng-morphline-solr-sink/pom.xml
@@ -58,7 +58,7 @@ limitations under the License.
     <repository>
       <id>maven-restlet</id>
       <name>Restlet Public Maven Repo</name>
-      <url>https://maven.restlet.org</url>
+      <url>https://maven.restlet.talend.com</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
As mentioned in the issue, to deal with the issue of certificate expiration due to the old domain name maven.restlet.org, visit the new domain name maven.restlet.talend.com.

See: https://issues.apache.org/jira/browse/FLUME-3462