### PR TITLE
[FLUME-3468] fix default value of passwordFile property when userName is set for jms source

### DIFF
--- a/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
+++ b/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java
@@ -170,7 +170,12 @@ public class JMSSource extends AbstractPollableSource implements BatchSizeSuppor
     String passwordFile = context.getString(JMSSourceConfiguration.PASSWORD_FILE, "").trim();
 
     if (passwordFile.isEmpty()) {
-      password = Optional.absent();
+      if (userName.isPresent()){
+        logger.warn("passwordFile property is not set but userName property is set. Setting password to default value");
+        password = Optional.of("");
+      }else{
+        password = Optional.absent();
+      }
     } else {
       try {
         password = Optional.of(Files.toString(new File(passwordFile),


### PR DESCRIPTION
In jms source, when passwordFile property in agent config is not set, currently null value is getting passed which causes exception due to `password = Optional.absent();` in https://github.com/apache/flume/blob/trunk/flume-ng-sources/flume-jms-source/src/main/java/org/apache/flume/source/jms/JMSSource.java#L173. 

This PR, sets default value to empty string in case passwordFile property is not set. 