### PR TITLE
[FLUME-3472] fix vulnerability CVE 2020-1938 caused by tomcat-embed-core

### DIFF
--- a/flume-parent/pom.xml
+++ b/flume-parent/pom.xml
@@ -896,6 +896,11 @@ limitations under the License.
       </dependency>
 
       <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>9.0.68</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
         <version>${thrift.version}</version>


### PR DESCRIPTION
org.apache.thrift:libthrift:0.14.2 has dependency on tomcat-embed-core : 8.5.46 which is causing CVE 2020-1938. So added tomcat-embed-core. 

Without this change dep tree looks like
```
[INFO] +- org.apache.thrift:libthrift:jar:0.14.2:compile
[INFO] |  +- org.apache.tomcat.embed:tomcat-embed-core:jar:8.5.46:compile
[INFO] |  |  \- org.apache.tomcat:tomcat-annotations-api:jar:8.5.46:compile
[INFO] |  \- javax.annotation:javax.annotation-api:jar:1.3.2:compile
```

With this change, dep tree looks like
```
[INFO] |  |  +- org.apache.thrift:libthrift:jar:0.14.2:compile
[INFO] |  |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] |  |  |  |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.15:compile
[INFO] |  |  |  +- org.apache.tomcat.embed:tomcat-embed-core:jar:9.0.68:compile
[INFO] |  |  |  |  \- org.apache.tomcat:tomcat-annotations-api:jar:9.0.68:compile
[INFO] |  |  |  \- javax.annotation:javax.annotation-api:jar:1.3.2:compile

```