### PR TITLE
[FLUME-3473] fixed testMinimumRequiredSpaceTooSmallforPut test by changing buffer size dynamic

### DIFF
--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestLog.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestLog.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -228,12 +229,14 @@ public class TestLog {
                            .build();
     log.replay();
     File filler = new File(checkpointDir, "filler");
-    byte[] buffer = new byte[64 * 1024];
     FileOutputStream out = new FileOutputStream(filler);
+    BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(out);
     while (checkpointDir.getUsableSpace() > minimumRequiredSpace) {
-      out.write(buffer);
+      String data = "this is dynamic data byte";
+      byte[] dataBytes = data.getBytes();
+      bufferedOutputStream.write(dataBytes);
     }
-    out.close();
+    bufferedOutputStream.flush();
     try {
       FlumeEvent eventIn = TestUtils.newPersistableEvent();
       long transactionID = ++this.transactionID;


### PR DESCRIPTION
Current state: Since the buffer size is limited by the size  
```
byte[] buffer = new byte[64 * 1024];
```
This was causing while loop to execute limited by buffer size. This was causing test failure since "checkpointDir.getUsableSpace() > minimumRequiredSpace" was still satisfied even after the byte size is exhausted. 

The change in PR introduces dynamic size of buffer, so that always we get checkpointDir.getUsableSpace() <= minimumRequiredSpace post while loop and hence test always passes.
Tested it in pipeline many times and it passed always with this fix.

A snippet of TestLog-output.txt with extra logs to check if the condition is satisfied.
```
2023-05-21 19:40:50,774 (main) [INFO - org.apache.flume.channel.file.TestLog.doTestMinimumRequiredSpaceTooSmallForPut(TestLog.java:245)] checkpointDir.getUsableSpace(): 449352470528
2023-05-21 19:40:50,774 (main) [INFO - org.apache.flume.channel.file.TestLog.doTestMinimumRequiredSpaceTooSmallForPut(TestLog.java:246)] minimumRequiredSpace: 449358696448
2023-05-21 19:40:50,791 (main) [INFO - org.apache.flume.channel.file.Log.put(Log.java:656)] usableSpace449352470528
2023-05-21 19:40:50,791 (main) [INFO - org.apache.flume.channel.file.Log.put(Log.java:657)] minimumRequiredSpace449358696528
2023-05-21 19:40:50,791 (main) [INFO - org.apache.flume.channel.file.Log.put(Log.java:659)] usableSpace <= requiredSpace
```