### PR TITLE
[FLUME_3476] fixing vulnerability CVE-2023-26048

### DIFF
--- a/dev-docs/UpdateLicenses.md
+++ b/dev-docs/UpdateLicenses.md
@@ -484,14 +484,14 @@ CDDL v1.0. Entry in LICENSE and NOTICE.
 BSD-like project specific. Entry in LICENSE and NOTICE.
 
 ```
-   jetty-http-9.4.41.v20210516.jar
-   jetty-io-9.4.41.v20210516.jar
-   jetty-jmx-9.4.41.v20210516.jar
-   jetty-security-9.4.41.v20210516.jar
-   jetty-server-9.4.41.v20210516.jar
-   jetty-servlet-9.4.41.v20210516.jar
-   jetty-util-9.4.41.v20210516.jar
-   jetty-util-ajax-9.4.41.v20210516.jar
+   jetty-http-9.4.51.v20230217.jar
+   jetty-io-9.4.51.v20230217.jar
+   jetty-jmx-9.4.51.v20230217.jar
+   jetty-security-9.4.51.v20230217.jar
+   jetty-server-9.4.51.v20230217.jar
+   jetty-servlet-9.4.51.v20230217.jar
+   jetty-util-9.4.51.v20230217.jar
+   jetty-util-9.4.51.v20230217.jar
 ```
 
 ALv2. Entry in NOTICE. Additional entry for UnixCrypt.

--- a/flume-parent/pom.xml
+++ b/flume-parent/pom.xml
@@ -81,7 +81,7 @@ limitations under the License.
     <httpclient.version>4.5.13</httpclient.version>
     <irclib.version>1.10</irclib.version>
     <jersey.version>1.8</jersey.version>
-    <jetty.version>9.4.48.v20220622</jetty.version>
+    <jetty.version>9.4.51.v20230217</jetty.version>
     <jdom.version>1.1.3</jdom.version>
     <joda-time.version>2.9.9</joda-time.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
Versions affected are for this CVE:
[9.4.10.RC0,9.4.50.v20221201]
[10.0.0-alpha0,10.0.0.alpha1]