### PR TITLE
[FLUME-3477] uptick avro-ipc to 1.11.1

### DIFF
--- a/flume-parent/pom.xml
+++ b/flume-parent/pom.xml
@@ -52,7 +52,7 @@ limitations under the License.
 
     <activemq.version>5.7.0</activemq.version>
     <asynchbase.version>1.8.2</asynchbase.version>
-    <avro.version>1.11.0</avro.version>
+    <avro.version>1.11.1</avro.version>
     <bundle-plugin.version>2.3.7</bundle-plugin.version>
     <checkstyle.tool.version>8.45.1</checkstyle.tool.version>
     <commons-cli.version>1.5.0</commons-cli.version>


### PR DESCRIPTION
This fixes following CVEs
[CVE-2021-46877](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-46877)
[CVE-2020-36518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518) 