### PR TITLE
Calculate batchElapsedTime correctly by converting startTime from nan…

### DIFF
--- a/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
+++ b/flume-ng-channels/flume-kafka-channel/src/main/java/org/apache/flume/channel/kafka/KafkaChannel.java
@@ -60,6 +60,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
 
+import java.util.concurrent.TimeUnit;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -810,7 +811,8 @@ class ChannelCallback implements Callback {
       log.trace("Error sending message to Kafka due to " + exception.getMessage());
     }
     if (log.isDebugEnabled()) {
-      long batchElapsedTime = System.currentTimeMillis() - startTime;
+      long batchElapsedTime = System.currentTimeMillis() 
+        - TimeUnit.NANOSECONDS.toMillis(startTime);
       if (metadata != null) {
         log.debug("Acked message_no " + index + ": " + metadata.topic() + "-" +
                 metadata.partition() + "-" + metadata.offset() + "-" + batchElapsedTime);


### PR DESCRIPTION
ISSUE: batchElapsedTime calculated incorrectly.

[DEBUG - org.apache.flume.channel.kafka.ChannelCallback.onCompletion(KafkaChannel.java:760)] Acked message_no 793: test-3-280448-1667034684768

