### PR TITLE
[FLUME-3480] remove log4j 1.2.17 due to eol

### DIFF
--- a/build-support/pom.xml
+++ b/build-support/pom.xml
@@ -29,9 +29,15 @@ limitations under the License.
         <maven.site.skip>true</maven.site.skip>
         <deploy.plugin.version>2.8.2</deploy.plugin.version>
         <mvn-gpg-plugin.version>1.6</mvn-gpg-plugin.version>
+        <mvn-compiler-plugin.version>3.8.1</mvn-compiler-plugin.version>
     </properties>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${mvn-compiler-plugin.version}</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>

--- a/dev-docs/UpdateLicenses.md
+++ b/dev-docs/UpdateLicenses.md
@@ -150,7 +150,7 @@ CDDLv1.1. Entry in NOTICE and LICENSE.
 ALv2. Etnry in NOTICE.
 
 ```
-   log4j:log4j:jar:1.2.17:compile
+   ch.qos.reload4j:reload4j:jar:1.2.25:compile
 ```
 
 ALv2. Entry in NOTICE.
@@ -414,7 +414,7 @@ derby NOTICE is not relevant.
    flume-twitter-source-<version>.jar
 ```
 
-ALv2. Entry in NOTICE for log4j 1.2.17 from log4jappender
+ALv2. Entry in NOTICE for reload4j 1.2.25 from log4jappender
 jar-with-dependencies.
 
 ```

--- a/flume-ng-clients/flume-ng-log4jappender/pom.xml
+++ b/flume-ng-clients/flume-ng-log4jappender/pom.xml
@@ -67,9 +67,9 @@ limitations under the License.
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>1.2.25</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
ISSUE: log4j 1.x is EOL. It is being used in build-support module and flume-ng-log4jappender. Since the dependency is EOL and vulnerable, this is not allowed to be used in enterprise environment.

SOL: This change will prevent use of log4j 1.x 