### PR TITLE
Fix `TestRegexExtractorInterceptor*`

### DIFF
--- a/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestRegexExtractorInterceptor.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestRegexExtractorInterceptor.java
@@ -20,6 +20,7 @@ package org.apache.flume.interceptor;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 import org.apache.flume.Context;
@@ -169,8 +170,7 @@ public class TestRegexExtractorInterceptor {
     long now = (System.currentTimeMillis() / 60000L) * 60000L;
     String pattern = "yyyy-MM-dd HH:mm:ss,SSS";
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
-    LocalDateTime current = Instant.ofEpochMilli(now).atOffset(UTC)
-            .toLocalDateTime();
+    LocalDateTime current = LocalDateTime.ofInstant(Instant.ofEpochMilli(now), ZoneId.systemDefault());
     String body = formatter.format(current);
     Context context = new Context();
     // Skip the second group

--- a/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestRegexExtractorInterceptorMillisSerializer.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestRegexExtractorInterceptorMillisSerializer.java
@@ -22,6 +22,7 @@ import org.apache.flume.Context;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import org.junit.Test;
 
@@ -66,8 +67,7 @@ public class TestRegexExtractorInterceptorMillisSerializer {
 
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
     long time = (System.currentTimeMillis() / 1000L) * 1000L;
-    LocalDateTime current = Instant.ofEpochMilli(time).atOffset(UTC)
-              .toLocalDateTime();
+    LocalDateTime current = LocalDateTime.ofInstant(Instant.ofEpochMilli(time), ZoneId.systemDefault());
     Assert.assertEquals(String.valueOf(time),
         fixture.serialize(formatter.format(current)));
   }


### PR DESCRIPTION
While #431 migrated `RegexExtractorInterceptorMillisSerializer` correctly from Joda to Java time, it introduced a small bug in the tests, which assume that all dates are in `UTC`.

The original extractor interpreted them instead in the local timezone.