### PR TITLE
Apply concurrency setting on PR jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,12 @@ on:
 # Remove all permissions by default. They will be added at a job level.
 permissions: {}
 
+concurrency:
+  # One group per PR, or per ref for branch pushes.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel in-progress runs for PRs only, so release branch builds always complete.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,12 @@ on:
 # Remove all permissions by default. They will be added at a job level.
 permissions: {}
 
+concurrency:
+  # One group per PR, or per ref for branch pushes.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel in-progress runs for PRs only, so release branch builds always complete.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Applies a concurrency settings on PR jobs, so pushing a new commit to a PR cancels the previous jobs.