### PR TITLE
Don't leak exception details in `HTTPSource` responses

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
@@ -234,16 +234,13 @@ public class HTTPSource extends SslContextAwareAbstractSource implements
       } catch (HTTPBadRequestException ex) {
         LOG.warn("Received bad request from client. ", ex);
         sourceCounter.incrementEventReadFail();
-        response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                "Bad request from client. "
-                + ex.getMessage());
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Bad request from client.");
         return;
       } catch (Exception ex) {
         LOG.warn("Deserializer threw unexpected exception. ", ex);
         sourceCounter.incrementEventReadFail();
         response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                "Deserializer threw unexpected exception. "
-                + ex.getMessage());
+                "Deserializer threw unexpected exception.");
         return;
       }
       sourceCounter.incrementAppendBatchReceivedCount();
@@ -256,15 +253,13 @@ public class HTTPSource extends SslContextAwareAbstractSource implements
                 + "capacity or make sure the sinks perform faster.", ex);
         sourceCounter.incrementChannelWriteFail();
         response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
-                "Error appending event to channel. Channel might be full."
-                + ex.getMessage());
+                "Error appending event to channel. Channel might be full.");
         return;
       } catch (Exception ex) {
         LOG.warn("Unexpected error appending event to channel. ", ex);
         sourceCounter.incrementGenericProcessingFail();
         response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                "Unexpected error while appending event to channel. "
-                + ex.getMessage());
+                "Unexpected error while appending event to channel.");
         return;
       }
       response.setCharacterEncoding(request.getCharacterEncoding());


### PR DESCRIPTION
`HTTPSource` appended `ex.getMessage()` to its HTTP error responses, which can disclose internal implementation details to clients. The exceptions are already logged server-side, so return a generic message per status code and keep the detail in the logs only.

Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>