### PR TITLE
Migrate logging API from SLF4J to Log4j 2.x

### DIFF
--- a/flume-ng-auth/pom.xml
+++ b/flume-ng-auth/pom.xml
@@ -51,7 +51,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/flume-ng-auth/pom.xml
+++ b/flume-ng-auth/pom.xml
@@ -45,8 +45,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/flume-ng-auth/pom.xml
+++ b/flume-ng-auth/pom.xml
@@ -56,12 +56,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <optional>true</optional>
@@ -77,6 +71,7 @@
       <artifactId>hadoop-minikdc</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <!-- add this to satisfy the dependency requirement of apacheds-jdbm1 in minikdc-->
       <groupId>org.apache.directory.jdbm</groupId>

--- a/flume-ng-auth/src/main/java/org/apache/flume/auth/KerberosAuthenticator.java
+++ b/flume-ng-auth/src/main/java/org/apache/flume/auth/KerberosAuthenticator.java
@@ -33,8 +33,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A kerberos authenticator, which authenticates using the supplied principal
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 class KerberosAuthenticator implements FlumeAuthenticator {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KerberosAuthenticator.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private volatile UserGroupInformation ugi;
     private volatile KerberosUser prevUser;
@@ -146,7 +146,7 @@ class KerberosAuthenticator implements FlumeAuthenticator {
                 curUser = null;
             }
         } catch (IOException e) {
-            LOG.warn("User unexpectedly had no active login. Continuing with " + "authentication", e);
+            logger.warn("User unexpectedly had no active login. Continuing with " + "authentication", e);
         }
 
         /*
@@ -158,13 +158,13 @@ class KerberosAuthenticator implements FlumeAuthenticator {
         try {
             if (ugi != null) {
                 if (curUser != null && curUser.getUserName().equals(ugi.getUserName())) {
-                    LOG.debug("Using existing principal login: {}", ugi);
+                    logger.debug("Using existing principal login: {}", ugi);
                 } else {
-                    LOG.info("Attempting kerberos Re-login as principal ({}) ", new Object[] {ugi.getUserName()});
+                    logger.info("Attempting kerberos Re-login as principal ({}) ", new Object[] {ugi.getUserName()});
                     ugi.reloginFromKeytab();
                 }
             } else {
-                LOG.info(
+                logger.info(
                         "Attempting kerberos login as principal ({}) from keytab " + "file ({})",
                         new Object[] {resolvedPrincipal, keytab});
                 UserGroupInformation.loginUserFromKeytab(resolvedPrincipal, keytab);
@@ -187,7 +187,7 @@ class KerberosAuthenticator implements FlumeAuthenticator {
         if (ugi != null) {
             // dump login information
             AuthenticationMethod authMethod = ugi.getAuthenticationMethod();
-            LOG.info("\n{} \nUser: {} \nAuth method: {} \nKeytab: {} \n", new Object[] {
+            logger.info("\n{} \nUser: {} \nAuth method: {} \nKeytab: {} \n", new Object[] {
                 authMethod.equals(AuthenticationMethod.PROXY) ? "Proxy as: " : "Logged as: ",
                 ugi.getUserName(),
                 authMethod,
@@ -213,7 +213,7 @@ class KerberosAuthenticator implements FlumeAuthenticator {
                         try {
                             ugi.checkTGTAndReloginFromKeytab();
                         } catch (IOException e) {
-                            LOG.warn(
+                            logger.warn(
                                     "Error occured during checkTGTAndReloginFromKeytab() for user " + ugi.getUserName(),
                                     e);
                         }

--- a/flume-ng-channels/flume-file-channel/pom.xml
+++ b/flume-ng-channels/flume-file-channel/pom.xml
@@ -53,8 +53,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/flume-ng-channels/flume-file-channel/pom.xml
+++ b/flume-ng-channels/flume-file-channel/pom.xml
@@ -98,12 +98,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <scope>compile</scope>

--- a/flume-ng-channels/flume-file-channel/pom.xml
+++ b/flume-ng-channels/flume-file-channel/pom.xml
@@ -87,13 +87,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-jcl</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/CheckpointRebuilder.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/CheckpointRebuilder.java
@@ -32,8 +32,8 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class CheckpointRebuilder {
 
@@ -45,7 +45,7 @@ public class CheckpointRebuilder {
     private final SetMultimap<Long, ComparableFlumeEventPointer> uncommittedTakes = HashMultimap.create();
     private final boolean fsyncPerTransaction;
 
-    private static Logger LOG = LoggerFactory.getLogger(CheckpointRebuilder.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public CheckpointRebuilder(List<File> logFiles, FlumeEventQueue queue, boolean fsyncPerTransaction)
             throws IOException {
@@ -55,13 +55,13 @@ public class CheckpointRebuilder {
     }
 
     public boolean rebuild() throws IOException, Exception {
-        LOG.info("Attempting to fast replay the log files.");
+        logger.info("Attempting to fast replay the log files.");
         List<LogFile.SequentialReader> logReaders = Lists.newArrayList();
         for (File logFile : logFiles) {
             try {
                 logReaders.add(LogFileFactory.getSequentialReader(logFile, null, fsyncPerTransaction));
             } catch (EOFException e) {
-                LOG.warn("Ignoring " + logFile + " due to EOF", e);
+                logger.warn("Ignoring " + logFile + " due to EOF", e);
             }
         }
         long transactionIDSeed = 0;
@@ -120,7 +120,7 @@ public class CheckpointRebuilder {
                 }
             }
         } catch (Exception e) {
-            LOG.warn("Error while generating checkpoint using fast generation logic", e);
+            logger.warn("Error while generating checkpoint using fast generation logic", e);
             return false;
         } finally {
             TransactionIDOracle.setSeed(transactionIDSeed);
@@ -135,7 +135,7 @@ public class CheckpointRebuilder {
             queue.addTail(put.pointer);
             count++;
         }
-        LOG.info("Replayed {} events using fast replay logic.", count);
+        logger.info("Replayed {} events using fast replay logic.", count);
         return true;
     }
 
@@ -155,7 +155,7 @@ public class CheckpointRebuilder {
                 }
             }
         } catch (Exception e) {
-            LOG.warn("Error while generating checkpoint using fast generation logic", e);
+            logger.warn("Error while generating checkpoint using fast generation logic", e);
         } finally {
             for (LogFile.MetaDataWriter metaDataWriter : metaDataWriters) {
                 metaDataWriter.close();
@@ -228,7 +228,7 @@ public class CheckpointRebuilder {
         int capacity = Integer.parseInt(cli.getOptionValue("t"));
         File checkpointFile = new File(checkpointDir, "checkpoint");
         if (checkpointFile.exists()) {
-            LOG.error("Cannot execute fast replay", new IllegalStateException("Checkpoint exists" + checkpointFile));
+            logger.error("Cannot execute fast replay", new IllegalStateException("Checkpoint exists" + checkpointFile));
         } else {
             EventQueueBackingStore backingStore = EventQueueBackingStoreFactory.get(
                     checkpointFile, capacity, "channel", new FileChannelCounter("Main"));
@@ -241,7 +241,7 @@ public class CheckpointRebuilder {
             if (rebuilder.rebuild()) {
                 rebuilder.writeCheckpoint();
             } else {
-                LOG.error("Could not rebuild the checkpoint due to errors.");
+                logger.error("Could not rebuild the checkpoint due to errors.");
             }
         }
     }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/EventQueueBackingStoreFactory.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/EventQueueBackingStoreFactory.java
@@ -21,11 +21,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 class EventQueueBackingStoreFactory {
-    private static final Logger LOG = LoggerFactory.getLogger(EventQueueBackingStoreFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private EventQueueBackingStoreFactory() {}
 
@@ -60,7 +60,7 @@ class EventQueueBackingStoreFactory {
                 // delete everything in the checkpoint directory and force
                 // a full replay.
                 if (!checkpointExists || checkpointFile.length() == 0) {
-                    LOG.warn("MetaData file for checkpoint "
+                    logger.warn("MetaData file for checkpoint "
                             + " exists but checkpoint does not. Checkpoint = " + checkpointFile
                             + ", metaDataFile = " + metaDataFile);
                     throw new BadCheckpointException("The last checkpoint was not completed correctly, "
@@ -90,7 +90,7 @@ class EventQueueBackingStoreFactory {
                 }
                 return new EventQueueBackingStoreFileV2(checkpointFile, capacity, name, counter);
             }
-            LOG.error("Found version " + Integer.toHexString(version) + " in " + checkpointFile);
+            logger.error("Found version " + Integer.toHexString(version) + " in " + checkpointFile);
             throw new BadCheckpointException(
                     "Checkpoint file exists with " + Serialization.VERSION_3 + " but no metadata file found.");
         } finally {
@@ -98,7 +98,7 @@ class EventQueueBackingStoreFactory {
                 try {
                     checkpointFileHandle.close();
                 } catch (IOException e) {
-                    LOG.warn("Unable to close " + checkpointFile, e);
+                    logger.warn("Unable to close " + checkpointFile, e);
                 }
             }
         }
@@ -113,7 +113,7 @@ class EventQueueBackingStoreFactory {
             boolean compressBackup,
             FileChannelCounter counter)
             throws Exception {
-        LOG.info("Attempting upgrade of " + checkpointFile + " for " + name);
+        logger.info("Attempting upgrade of " + checkpointFile + " for " + name);
         EventQueueBackingStoreFileV2 backingStoreV2 =
                 new EventQueueBackingStoreFileV2(checkpointFile, capacity, name, counter);
         String backupName = checkpointFile.getName() + "-backup-" + System.currentTimeMillis();

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/EventQueueBackingStoreFile.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/EventQueueBackingStoreFile.java
@@ -38,11 +38,11 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 abstract class EventQueueBackingStoreFile extends EventQueueBackingStore {
-    private static final Logger LOG = LoggerFactory.getLogger(EventQueueBackingStoreFile.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final int MAX_ALLOC_BUFFER_SIZE = 2 * 1024 * 1024; // 2MB
     protected static final int HEADER_SIZE = 1029;
     protected static final int INDEX_VERSION = 0;
@@ -94,7 +94,7 @@ abstract class EventQueueBackingStoreFile extends EventQueueBackingStore {
             checkpointFileHandle.seek(INDEX_VERSION * Serialization.SIZE_OF_LONG);
             checkpointFileHandle.writeLong(getVersion());
             checkpointFileHandle.getChannel().force(true);
-            LOG.info("Preallocated " + checkpointFile + " to " + checkpointFileHandle.length() + " for capacity "
+            logger.info("Preallocated " + checkpointFile + " to " + checkpointFileHandle.length() + " for capacity "
                     + capacity);
         }
         if (checkpointFile.length() != totalBytes) {
@@ -187,7 +187,7 @@ abstract class EventQueueBackingStoreFile extends EventQueueBackingStore {
                         + "this directory: "
                         + backupDirectory.toString() + " as backup?");
         if (!backupFile.createNewFile()) {
-            LOG.error("Could not create backup file. Backup of checkpoint will "
+            logger.error("Could not create backup file. Backup of checkpoint will "
                     + "not be used during replay even if checkpoint is bad.");
         }
     }
@@ -225,7 +225,7 @@ abstract class EventQueueBackingStoreFile extends EventQueueBackingStore {
 
     @Override
     void beginCheckpoint() throws IOException {
-        LOG.info("Start checkpoint for " + checkpointFile + ", elements to sync = " + overwriteMap.size());
+        logger.info("Start checkpoint for " + checkpointFile + ", elements to sync = " + overwriteMap.size());
 
         if (shouldBackup) {
             int permits = backupCompletedSema.drainPermits();
@@ -250,7 +250,7 @@ abstract class EventQueueBackingStoreFile extends EventQueueBackingStore {
     void checkpoint() throws IOException {
 
         setLogWriteOrderID(WriteOrderOracle.next());
-        LOG.info("Updating checkpoint metadata: logWriteOrderID: "
+        logger.info("Updating checkpoint metadata: logWriteOrderID: "
                 + getLogWriteOrderID() + ", queueSize: " + getSize() + ", queueHead: "
                 + getHead());
         elementsBuffer.put(INDEX_WRITE_ORDER_ID, getLogWriteOrderID());
@@ -286,7 +286,7 @@ abstract class EventQueueBackingStoreFile extends EventQueueBackingStore {
                 checkpointBackUpExecutor,
                 "Expected the checkpoint backup exector to be non-null, "
                         + "but it is null. Checkpoint will not be backed up.");
-        LOG.info("Attempting to back up checkpoint.");
+        logger.info("Attempting to back up checkpoint.");
         checkpointBackUpExecutor.submit(new Runnable() {
 
             @Override
@@ -297,12 +297,12 @@ abstract class EventQueueBackingStoreFile extends EventQueueBackingStore {
                 } catch (Throwable throwable) {
                     fileChannelCounter.incrementCheckpointBackupWriteErrorCount();
                     error = true;
-                    LOG.error("Backing up of checkpoint directory failed.", throwable);
+                    logger.error("Backing up of checkpoint directory failed.", throwable);
                 } finally {
                     backupCompletedSema.release();
                 }
                 if (!error) {
-                    LOG.info("Checkpoint backup completed.");
+                    logger.info("Checkpoint backup completed.");
                 }
             }
         });
@@ -314,7 +314,7 @@ abstract class EventQueueBackingStoreFile extends EventQueueBackingStore {
         try {
             checkpointFileHandle.close();
         } catch (IOException e) {
-            LOG.info("Error closing " + checkpointFile, e);
+            logger.info("Error closing " + checkpointFile, e);
         }
         if (checkpointBackUpExecutor != null && !checkpointBackUpExecutor.isShutdown()) {
             checkpointBackUpExecutor.shutdown();
@@ -322,7 +322,7 @@ abstract class EventQueueBackingStoreFile extends EventQueueBackingStore {
                 // Wait till the executor dies.
                 while (!checkpointBackUpExecutor.awaitTermination(1, TimeUnit.SECONDS)) {}
             } catch (InterruptedException ex) {
-                LOG.warn("Interrupted while waiting for checkpoint backup to " + "complete");
+                logger.warn("Interrupted while waiting for checkpoint backup to " + "complete");
             }
         }
     }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/EventQueueBackingStoreFileV3.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/EventQueueBackingStoreFileV3.java
@@ -27,11 +27,11 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
 import org.apache.flume.channel.file.proto.ProtosFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 final class EventQueueBackingStoreFileV3 extends EventQueueBackingStoreFile {
-    private static final Logger LOG = LoggerFactory.getLogger(EventQueueBackingStoreFileV3.class);
+    private static final Logger logger = LogManager.getLogger();
     private final File metaDataFile;
 
     EventQueueBackingStoreFileV3(File checkpointFile, int capacity, String name, FileChannelCounter counter)
@@ -51,11 +51,11 @@ final class EventQueueBackingStoreFileV3 extends EventQueueBackingStoreFile {
         super(capacity, name, counter, checkpointFile, checkpointBackupDir, backupCheckpoint, compressBackup);
         Preconditions.checkArgument(capacity > 0, "capacity must be greater than 0 " + capacity);
         metaDataFile = Serialization.getMetaDataFile(checkpointFile);
-        LOG.info("Starting up with " + checkpointFile + " and " + metaDataFile);
+        logger.info("Starting up with " + checkpointFile + " and " + metaDataFile);
         if (metaDataFile.exists()) {
             FileInputStream inputStream = new FileInputStream(metaDataFile);
             try {
-                LOG.info("Reading checkpoint metadata from " + metaDataFile);
+                logger.info("Reading checkpoint metadata from " + metaDataFile);
                 ProtosFactory.Checkpoint checkpoint = ProtosFactory.Checkpoint.parseDelimitedFrom(inputStream);
                 if (checkpoint == null) {
                     throw new BadCheckpointException(
@@ -71,7 +71,7 @@ final class EventQueueBackingStoreFileV3 extends EventQueueBackingStoreFile {
                     String msg = "Checkpoint and Meta files have differing " + "logWriteOrderIDs "
                             + getCheckpointLogWriteOrderID() + ", and "
                             + logWriteOrderID;
-                    LOG.warn(msg);
+                    logger.warn(msg);
                     throw new BadCheckpointException(msg);
                 }
                 WriteOrderOracle.setSeed(logWriteOrderID);
@@ -93,7 +93,7 @@ final class EventQueueBackingStoreFileV3 extends EventQueueBackingStoreFile {
                 try {
                     inputStream.close();
                 } catch (IOException e) {
-                    LOG.warn("Unable to close " + metaDataFile, e);
+                    logger.warn("Unable to close " + metaDataFile, e);
                 }
             }
         } else {
@@ -115,7 +115,7 @@ final class EventQueueBackingStoreFileV3 extends EventQueueBackingStoreFile {
                 try {
                     outputStream.close();
                 } catch (IOException e) {
-                    LOG.warn("Unable to close " + metaDataFile, e);
+                    logger.warn("Unable to close " + metaDataFile, e);
                 }
             }
         }
@@ -154,7 +154,7 @@ final class EventQueueBackingStoreFileV3 extends EventQueueBackingStoreFile {
             try {
                 outputStream.close();
             } catch (IOException e) {
-                LOG.warn("Unable to close " + metaDataFile, e);
+                logger.warn("Unable to close " + metaDataFile, e);
             }
         }
     }
@@ -189,7 +189,7 @@ final class EventQueueBackingStoreFileV3 extends EventQueueBackingStoreFile {
             try {
                 outputStream.close();
             } catch (IOException e) {
-                LOG.warn("Unable to close " + metaDataFile, e);
+                logger.warn("Unable to close " + metaDataFile, e);
             }
         }
         RandomAccessFile checkpointFileHandle = new RandomAccessFile(checkpointFile, "rw");
@@ -201,7 +201,7 @@ final class EventQueueBackingStoreFileV3 extends EventQueueBackingStoreFile {
             try {
                 checkpointFileHandle.close();
             } catch (IOException e) {
-                LOG.warn("Unable to close " + checkpointFile, e);
+                logger.warn("Unable to close " + checkpointFile, e);
             }
         }
     }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FileChannel.java
@@ -44,8 +44,8 @@ import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
 import org.apache.flume.conf.TransactionCapacitySupported;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.exception.ChannelFullException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
 @Disposable
 public class FileChannel extends BasicChannelSemantics implements TransactionCapacitySupported {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FileChannel.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private Integer capacity = 0;
     private int keepAlive;
@@ -162,7 +162,7 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
         capacity = context.getInteger(FileChannelConfiguration.CAPACITY, FileChannelConfiguration.DEFAULT_CAPACITY);
         if (capacity <= 0) {
             capacity = FileChannelConfiguration.DEFAULT_CAPACITY;
-            LOG.warn("Invalid capacity specified, initializing channel to " + "default capacity of {}", capacity);
+            logger.warn("Invalid capacity specified, initializing channel to " + "default capacity of {}", capacity);
         }
 
         keepAlive =
@@ -172,7 +172,7 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
 
         if (transactionCapacity <= 0) {
             transactionCapacity = FileChannelConfiguration.DEFAULT_TRANSACTION_CAPACITY;
-            LOG.warn(
+            logger.warn(
                     "Invalid transaction capacity specified, " + "initializing channel to default " + "capacity of {}",
                     transactionCapacity);
         }
@@ -184,7 +184,7 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
         checkpointInterval = context.getLong(
                 FileChannelConfiguration.CHECKPOINT_INTERVAL, FileChannelConfiguration.DEFAULT_CHECKPOINT_INTERVAL);
         if (checkpointInterval <= 0) {
-            LOG.warn("Checkpoint interval is invalid: " + checkpointInterval
+            logger.warn("Checkpoint interval is invalid: " + checkpointInterval
                     + ", using default: "
                     + FileChannelConfiguration.DEFAULT_CHECKPOINT_INTERVAL);
 
@@ -259,7 +259,7 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
 
     @Override
     public synchronized void start() {
-        LOG.info("Starting {}...", this);
+        logger.info("Starting {}...", this);
         channelCounter.start();
         try {
             Builder builder = createLogBuilder();
@@ -271,12 +271,12 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
             Preconditions.checkState(
                     queueRemaining.tryAcquire(depth),
                     "Unable to acquire " + depth + " permits " + channelNameDescriptor);
-            LOG.info("Queue Size after replay: " + depth + " " + channelNameDescriptor);
+            logger.info("Queue Size after replay: " + depth + " " + channelNameDescriptor);
         } catch (Throwable t) {
             setOpen(false);
             channelCounter.setUnhealthy(1);
             startupError = t;
-            LOG.error("Failed to start the file channel " + channelNameDescriptor, t);
+            logger.error("Failed to start the file channel " + channelNameDescriptor, t);
             if (t instanceof Error) {
                 throw (Error) t;
             }
@@ -315,7 +315,7 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
 
     @Override
     public synchronized void stop() {
-        LOG.info("Stopping {}...", this);
+        logger.info("Stopping {}...", this);
         startupError = null;
         int size = getDepth();
         close();
@@ -375,7 +375,7 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
             try {
                 log.close();
             } catch (Exception e) {
-                LOG.error("Error while trying to close the log.", e);
+                logger.error("Error while trying to close the log.", e);
                 Throwables.propagate(e);
             }
             log = null;
@@ -556,7 +556,7 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
                             channelCounter.incrementEventTakeErrorCount();
                             throw new ChannelException("Take failed due to IO error " + channelNameDescriptor, e);
                         } catch (NoopRecordException e) {
-                            LOG.warn(
+                            logger.warn(
                                     "Corrupt record replaced by File Channel Integrity "
                                             + "tool found. Will retrieve next event",
                                     e);
@@ -566,7 +566,7 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
                             if (fsyncPerTransaction) {
                                 throw new ChannelException(ex);
                             }
-                            LOG.warn(
+                            logger.warn(
                                     "Corrupt record found. Event will be " + "skipped, and next event will be read.",
                                     ex);
                             takeList.remove(ptr);
@@ -598,7 +598,7 @@ public class FileChannel extends BasicChannelSemantics implements TransactionCap
                                 msg.append("cannot be added. Those messages will be consumed ");
                                 msg.append("despite this transaction failing. Please report.");
                                 msg.append(channelNameDescriptor);
-                                LOG.error(msg.toString());
+                                logger.error(msg.toString());
                                 Preconditions.checkState(false, msg.toString());
                             }
                         }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FlumeEventQueue.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/FlumeEventQueue.java
@@ -26,6 +26,7 @@ import java.io.RandomAccessFile;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
+import java.nio.channels.FileChannel;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Collection;
@@ -34,10 +35,10 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Queue of events in the channel. This queue stores only
@@ -49,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * the head position.
  */
 final class FlumeEventQueue {
-    private static final Logger LOG = LoggerFactory.getLogger(FlumeEventQueue.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final int EMPTY = 0;
     private final EventQueueBackingStore backingStore;
     private final String channelNameDescriptor;
@@ -80,7 +81,7 @@ final class FlumeEventQueue {
             inflightPuts = new InflightEventWrapper(inflightPutsFile);
             inflightTakes = new InflightEventWrapper(inflightTakesFile);
         } catch (Exception e) {
-            LOG.error("Could not read checkpoint.", e);
+            logger.error("Could not read checkpoint.", e);
             throw e;
         }
         if (queueSetDBDir.isDirectory()) {
@@ -106,7 +107,7 @@ final class FlumeEventQueue {
         for (int i = 0; i < backingStore.getSize(); i++) {
             queueSet.add(get(i));
         }
-        LOG.info("QueueSet population inserting " + backingStore.getSize() + " took "
+        logger.info("QueueSet population inserting " + backingStore.getSize() + " took "
                 + (System.currentTimeMillis() - start));
     }
 
@@ -127,7 +128,7 @@ final class FlumeEventQueue {
                 && !inflightTakes.syncRequired()
                 && !force) { // No need to check inflight puts, since that would
             // cause elements.syncRequired() to return true.
-            LOG.debug("Checkpoint not required");
+            logger.debug("Checkpoint not required");
             return false;
         }
         backingStore.beginCheckpoint();
@@ -170,7 +171,7 @@ final class FlumeEventQueue {
         // in such a way that these takes cannot go back in. If this if returns true,
         // there is a buuuuuuuug!
         if (backingStore.getSize() == backingStore.getCapacity()) {
-            LOG.error("Could not reinsert to queue, events which were taken but "
+            logger.error("Could not reinsert to queue, events which were taken but "
                     + "not committed. Please report this issue.");
             return false;
         }
@@ -381,14 +382,14 @@ final class FlumeEventQueue {
                 db.close();
             }
         } catch (Exception ex) {
-            LOG.warn("Error closing db", ex);
+            logger.warn("Error closing db", ex);
         }
         try {
             backingStore.close();
             inflightPuts.close();
             inflightTakes.close();
         } catch (IOException e) {
-            LOG.warn("Error closing backing store", e);
+            logger.warn("Error closing backing store", e);
         }
     }
 
@@ -399,7 +400,7 @@ final class FlumeEventQueue {
     synchronized void replayComplete() {
         String msg = "Search Count = " + searchCount + ", Search Time = " + searchTime + ", Copy Count = " + copyCount
                 + ", Copy Time = " + copyTime;
-        LOG.info(msg);
+        logger.info(msg);
         if (db != null) {
             db.close();
         }
@@ -427,7 +428,7 @@ final class FlumeEventQueue {
         // Both these are volatile for safe publication, they are never accessed by
         // more than 1 thread at a time.
         private volatile RandomAccessFile file;
-        private volatile java.nio.channels.FileChannel fileChannel;
+        private volatile FileChannel fileChannel;
         private final MessageDigest digest;
         private final File inflightEventsFile;
         private volatile boolean syncRequired = false;
@@ -513,7 +514,7 @@ final class FlumeEventQueue {
                     Set<Long> pointers = inflightEvents.get(txnID);
                     longBuffer.put(txnID);
                     longBuffer.put((long) pointers.size());
-                    LOG.debug("Number of events inserted into "
+                    logger.debug("Number of events inserted into "
                             + "inflights file: " + String.valueOf(pointers.size())
                             + " file: " + inflightEventsFile.getCanonicalPath());
                     long[] written = ArrayUtils.toPrimitive(pointers.toArray(new Long[0]));
@@ -526,7 +527,7 @@ final class FlumeEventQueue {
                 fileChannel.force(true);
                 syncRequired = false;
             } catch (IOException ex) {
-                LOG.error("Error while writing checkpoint to disk.", ex);
+                logger.error("Error while writing checkpoint to disk.", ex);
                 throw ex;
             }
         }
@@ -568,7 +569,7 @@ final class FlumeEventQueue {
                     }
                 }
             } catch (BufferUnderflowException ex) {
-                LOG.debug("Reached end of inflights buffer. Long buffer position ="
+                logger.debug("Reached end of inflights buffer. Long buffer position ="
                         + String.valueOf(longBuffer.position()));
             }
             return inflights;

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/Log.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/Log.java
@@ -54,8 +54,8 @@ import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.channel.file.encryption.KeyProvider;
 import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Stores FlumeEvents on disk and pointers to the events in a in memory queue.
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Unstable
 public class Log {
     public static final String PREFIX = "log-";
-    private static final Logger LOGGER = LoggerFactory.getLogger(Log.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final int MIN_NUM_LOGS = 2;
     public static final String FILE_LOCK = "in_use.lock";
     public static final String QUEUE_SET = "queueset";
@@ -361,7 +361,7 @@ public class Log {
             throw e;
         }
         if (encryptionKeyProvider != null && encryptionKeyAlias != null && encryptionCipherProvider != null) {
-            LOGGER.info("Encryption is enabled with encryptionKeyProvider = " + encryptionKeyProvider
+            logger.info("Encryption is enabled with encryptionKeyProvider = " + encryptionKeyProvider
                     + ", encryptionKeyAlias = " + encryptionKeyAlias
                     + ", encryptionCipherProvider = " + encryptionCipherProvider);
             this.encryptionKeyProvider = encryptionKeyProvider;
@@ -369,7 +369,7 @@ public class Log {
             this.encryptionCipherProvider = encryptionCipherProvider;
             this.encryptionKey = encryptionKeyProvider.getKey(encryptionKeyAlias);
         } else if (encryptionKeyProvider == null && encryptionKeyAlias == null && encryptionCipherProvider == null) {
-            LOGGER.info("Encryption is not enabled");
+            logger.info("Encryption is not enabled");
         } else {
             throw new IllegalArgumentException(
                     "Encryption configuration must all " + "null or all not null: encryptionKeyProvider = "
@@ -418,7 +418,7 @@ public class Log {
              *
              * Also store up the list of files so we can replay them later.
              */
-            LOGGER.info("Replay started");
+            logger.info("Replay started");
             nextFileID.set(0);
             List<File> dataFiles = Lists.newArrayList();
             for (File logDir : logDirs) {
@@ -432,7 +432,7 @@ public class Log {
                                     new File(logDir, PREFIX + id), encryptionKeyProvider, fsyncPerTransaction));
                 }
             }
-            LOGGER.info("Found NextFileID " + nextFileID + ", from " + dataFiles);
+            logger.info("Found NextFileID " + nextFileID + ", from " + dataFiles);
 
             /*
              * sort the data files by file id so we can replay them by file id
@@ -448,10 +448,10 @@ public class Log {
             File checkpointFile = new File(checkpointDir, "checkpoint");
             if (shouldFastReplay) {
                 if (checkpointFile.exists()) {
-                    LOGGER.debug("Disabling fast full replay because checkpoint " + "exists: " + checkpointFile);
+                    logger.debug("Disabling fast full replay because checkpoint " + "exists: " + checkpointFile);
                     shouldFastReplay = false;
                 } else {
-                    LOGGER.debug("Not disabling fast full replay because checkpoint " + " does not exist: "
+                    logger.debug("Not disabling fast full replay because checkpoint " + " does not exist: "
                             + checkpointFile);
                 }
             }
@@ -471,7 +471,7 @@ public class Log {
                         this.useDualCheckpoints,
                         this.compressBackupCheckpoint);
                 queue = new FlumeEventQueue(backingStore, inflightTakesFile, inflightPutsFile, queueSetDir);
-                LOGGER.info("Last Checkpoint " + new Date(checkpointFile.lastModified()) + ", queue depth = "
+                logger.info("Last Checkpoint " + new Date(checkpointFile.lastModified()) + ", queue depth = "
                         + queue.getSize());
 
                 /*
@@ -487,7 +487,7 @@ public class Log {
             } catch (BadCheckpointException ex) {
                 backupRestored = false;
                 if (useDualCheckpoints) {
-                    LOGGER.warn(
+                    logger.warn(
                             "Checkpoint may not have completed successfully. "
                                     + "Restoring checkpoint and starting up.",
                             ex);
@@ -496,7 +496,7 @@ public class Log {
                     }
                 }
                 if (!backupRestored) {
-                    LOGGER.warn(
+                    logger.warn(
                             "Checkpoint may not have completed successfully. "
                                     + "Forcing full replay, this may take a while.",
                             ex);
@@ -525,7 +525,7 @@ public class Log {
             }
 
             for (int index = 0; index < logDirs.length; index++) {
-                LOGGER.info("Rolling " + logDirs[index]);
+                logger.info("Rolling " + logDirs[index]);
                 roll(index);
             }
 
@@ -536,7 +536,7 @@ public class Log {
 
             open = true;
         } catch (Exception ex) {
-            LOGGER.error("Failed to initialize Log on " + channelNameDescriptor, ex);
+            logger.error("Failed to initialize Log on " + channelNameDescriptor, ex);
             if (ex instanceof IOException) {
                 throw (IOException) ex;
             }
@@ -553,14 +553,14 @@ public class Log {
         CheckpointRebuilder rebuilder = new CheckpointRebuilder(dataFiles, queue, fsyncPerTransaction);
         if (useFastReplay && rebuilder.rebuild()) {
             didFastReplay = true;
-            LOGGER.info("Fast replay successful.");
+            logger.info("Fast replay successful.");
         } else {
             ReplayHandler replayHandler = new ReplayHandler(queue, encryptionKeyProvider, fsyncPerTransaction);
             if (useLogReplayV1) {
-                LOGGER.info("Replaying logs with v1 replay logic");
+                logger.info("Replaying logs with v1 replay logic");
                 replayHandler.replayLogv1(dataFiles);
             } else {
-                LOGGER.info("Replaying logs with v2 replay logic");
+                logger.info("Replaying logs with v2 replay logic");
                 replayHandler.replayLog(dataFiles);
             }
             readCount = replayHandler.getReadCount();
@@ -748,8 +748,8 @@ public class Log {
     void rollback(long transactionID) throws IOException {
         Preconditions.checkState(open, "Log is closed");
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Rolling back " + transactionID);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Rolling back " + transactionID);
         }
         Rollback rollback = new Rollback(transactionID, WriteOrderOracle.next());
         ByteBuffer buffer = TransactionEventRecord.toByteBuffer(rollback);
@@ -843,7 +843,7 @@ public class Log {
                     writeCheckpoint(true); // do this before acquiring exclusive lock
                 }
             } catch (Exception err) {
-                LOGGER.warn(
+                logger.warn(
                         "Failed creating checkpoint on close of channel " + channelNameDescriptor
                                 + "Replay will take longer next time channel is started.",
                         err);
@@ -869,20 +869,20 @@ public class Log {
             try {
                 unlock(checkpointDir);
             } catch (IOException ex) {
-                LOGGER.warn("Error unlocking " + checkpointDir, ex);
+                logger.warn("Error unlocking " + checkpointDir, ex);
             }
             if (useDualCheckpoints) {
                 try {
                     unlock(backupCheckpointDir);
                 } catch (IOException ex) {
-                    LOGGER.warn("Error unlocking " + checkpointDir, ex);
+                    logger.warn("Error unlocking " + checkpointDir, ex);
                 }
             }
             for (File logDir : logDirs) {
                 try {
                     unlock(logDir);
                 } catch (IOException ex) {
-                    LOGGER.warn("Error unlocking " + logDir, ex);
+                    logger.warn("Error unlocking " + logDir, ex);
                 }
             }
         } finally {
@@ -893,12 +893,12 @@ public class Log {
     void shutdownWorker() {
         String msg = "Attempting to shutdown background worker.";
         System.out.println(msg);
-        LOGGER.info(msg);
+        logger.info(msg);
         workerExecutor.shutdown();
         try {
             workerExecutor.awaitTermination(10, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            LOGGER.error("Interrupted while waiting for worker to die.");
+            logger.error("Interrupted while waiting for worker to die.");
         }
     }
 
@@ -999,7 +999,7 @@ public class Log {
             // the possibility of multiple writes waiting on lock
             if (oldLogFile == null || buffer == null || oldLogFile.isRollRequired(buffer)) {
                 try {
-                    LOGGER.info("Roll start " + logDirs[index]);
+                    logger.info("Roll start " + logDirs[index]);
                     int fileID = nextFileID.incrementAndGet();
                     File file = new File(logDirs[index], PREFIX + fileID);
                     LogFile.Writer writer = LogFileFactory.getWriter(
@@ -1021,7 +1021,7 @@ public class Log {
                         oldLogFile.close();
                     }
                 } finally {
-                    LOGGER.info("Roll end");
+                    logger.info("Roll end");
                 }
             }
         } finally {
@@ -1079,7 +1079,7 @@ public class Log {
                         writer.close();
                     }
                     logFileRefCountsAll.remove(logFileID);
-                    LOGGER.info("Updated checkpoint for file: " + logFile + " position: " + logWriter.position()
+                    logger.info("Updated checkpoint for file: " + logFile + " position: " + logWriter.position()
                             + " logWriteOrderID: " + logWriteOrderID);
                 }
 
@@ -1099,7 +1099,7 @@ public class Log {
                         writer.close();
                     }
 
-                    LOGGER.debug("Updated checkpoint for file: " + file + "logWriteOrderID " + logWriteOrderID);
+                    logger.debug("Updated checkpoint for file: " + file + "logWriteOrderID " + logWriteOrderID);
                     idIterator.remove();
                 }
                 Preconditions.checkState(
@@ -1133,14 +1133,14 @@ public class Log {
         // checkpoint will become the backup at that time,
         // and thus these files are no longer needed).
         for (File fileToDelete : pendingDeletes) {
-            LOGGER.info("Removing old file: " + fileToDelete);
+            logger.info("Removing old file: " + fileToDelete);
             FileUtils.deleteQuietly(fileToDelete);
         }
         pendingDeletes.clear();
         // we will find the smallest fileID currently in use and
         // won't delete any files with an id larger than the min
         int minFileID = fileIDs.first();
-        LOGGER.debug("Files currently in use: " + fileIDs);
+        logger.debug("Files currently in use: " + fileIDs);
         for (File logDir : logDirs) {
             List<File> logs = LogUtils.getLogs(logDir);
             // sort oldset to newest
@@ -1178,12 +1178,12 @@ public class Log {
         FileLock lock = tryLock(dir);
         if (lock == null) {
             String msg = "Cannot lock " + dir + ". The directory is already locked. " + channelNameDescriptor;
-            LOGGER.info(msg);
+            logger.info(msg);
             throw new IOException(msg);
         }
         FileLock secondLock = tryLock(dir);
         if (secondLock != null) {
-            LOGGER.warn("Directory " + dir + " does not support locking");
+            logger.warn("Directory " + dir + " does not support locking");
             secondLock.release();
             secondLock.channel().close();
         }
@@ -1209,7 +1209,7 @@ public class Log {
             file.close();
             return null;
         } catch (IOException e) {
-            LOGGER.error("Cannot create lock on " + lockF, e);
+            logger.error("Cannot create lock on " + lockF, e);
             file.close();
             throw e;
         }
@@ -1232,7 +1232,7 @@ public class Log {
     }
 
     static class BackgroundWorker implements Runnable {
-        private static final Logger LOG = LoggerFactory.getLogger(BackgroundWorker.class);
+        private static final Logger logger = LogManager.getLogger();
         private final Log log;
 
         public BackgroundWorker(Log log) {
@@ -1247,10 +1247,10 @@ public class Log {
                 }
             } catch (IOException e) {
                 log.channelCounter.incrementCheckpointWriteErrorCount();
-                LOG.error("Error doing checkpoint", e);
+                logger.error("Error doing checkpoint", e);
             } catch (Throwable e) {
                 log.channelCounter.incrementCheckpointWriteErrorCount();
-                LOG.error("General error in checkpoint worker", e);
+                logger.error("General error in checkpoint worker", e);
             }
         }
     }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/LogFile.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/LogFile.java
@@ -40,14 +40,14 @@ import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.channel.file.encryption.CipherProvider;
 import org.apache.flume.channel.file.encryption.KeyProvider;
 import org.apache.flume.tools.DirectMemoryUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public abstract class LogFile {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LogFile.class);
+    private static final Logger logger = LogManager.getLogger();
 
     /**
      * This class preallocates the data files 1MB at time to avoid
@@ -126,7 +126,7 @@ public abstract class LogFile {
             try {
                 writeFileHandle.close();
             } catch (IOException e) {
-                LOG.warn("Unable to close " + file, e);
+                logger.warn("Unable to close " + file, e);
             }
         }
     }
@@ -198,7 +198,7 @@ public abstract class LogFile {
             this.fsyncPerTransaction = fsyncPerTransaction;
             this.fsyncInterval = fsyncInterval;
             if (!fsyncPerTransaction) {
-                LOG.info("Sync interval = " + fsyncInterval);
+                logger.info("Sync interval = " + fsyncInterval);
                 syncExecutor = Executors.newSingleThreadScheduledExecutor();
                 syncExecutor.scheduleWithFixedDelay(
                         new Runnable() {
@@ -207,7 +207,7 @@ public abstract class LogFile {
                                 try {
                                     sync();
                                 } catch (Throwable ex) {
-                                    LOG.error(
+                                    logger.error(
                                             "Data file, " + getFile().toString() + " could not "
                                                     + "be synced to disk due to an error.",
                                             ex);
@@ -221,7 +221,7 @@ public abstract class LogFile {
                 syncExecutor = null;
             }
             usableSpace = new CachedFSUsableSpace(file, usableSpaceRefreshInterval);
-            LOG.info("Opened " + file);
+            logger.info("Opened " + file);
             open = true;
         }
 
@@ -342,8 +342,8 @@ public abstract class LogFile {
          */
         synchronized void sync() throws IOException {
             if (!fsyncPerTransaction && !dirty) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("No events written to file, " + getFile().toString() + " in last " + fsyncInterval
+                if (logger.isDebugEnabled()) {
+                    logger.debug("No events written to file, " + getFile().toString() + " in last " + fsyncInterval
                             + " or since last commit.");
                 }
                 return;
@@ -382,16 +382,16 @@ public abstract class LogFile {
                     }
                 }
                 if (writeFileChannel.isOpen()) {
-                    LOG.info("Closing " + file);
+                    logger.info("Closing " + file);
                     try {
                         writeFileChannel.force(true);
                     } catch (IOException e) {
-                        LOG.warn("Unable to flush to disk " + file, e);
+                        logger.warn("Unable to flush to disk " + file, e);
                     }
                     try {
                         writeFileHandle.close();
                     } catch (IOException e) {
-                        LOG.warn("Unable to close " + file, e);
+                        logger.warn("Unable to close " + file, e);
                     }
                 }
             }
@@ -400,7 +400,7 @@ public abstract class LogFile {
         protected void preallocate(int size) throws IOException {
             long position = position();
             if (position + size > getFileChannel().size()) {
-                LOG.debug("Preallocating at position " + position);
+                logger.debug("Preallocating at position " + position);
                 synchronized (FILL) {
                     FILL.position(0);
                     getFileChannel().write(FILL, position);
@@ -435,7 +435,7 @@ public abstract class LogFile {
                     byteRead == OP_RECORD || byteRead == OP_NOOP,
                     "Expected to read a record but the byte read indicates EOF");
             fileHandle.seek(offset);
-            LOG.info("Marking event as " + OP_NOOP + " at " + offset + " for file " + file.toString());
+            logger.info("Marking event as " + OP_NOOP + " at " + offset + " for file " + file.toString());
             fileHandle.writeByte(OP_NOOP);
         }
 
@@ -444,7 +444,7 @@ public abstract class LogFile {
                 fileHandle.getFD().sync();
                 fileHandle.close();
             } catch (IOException e) {
-                LOG.error("Could not close file handle to file " + fileHandle.toString(), e);
+                logger.error("Could not close file handle to file " + fileHandle.toString(), e);
             }
         }
     }
@@ -514,7 +514,7 @@ public abstract class LogFile {
         synchronized void close() {
             if (open) {
                 open = false;
-                LOG.info("Closing RandomReader " + file);
+                logger.info("Closing RandomReader " + file);
                 List<RandomAccessFile> fileHandles = Lists.newArrayList();
                 while (readFileHandles.drainTo(fileHandles) > 0) {
                     for (RandomAccessFile fileHandle : fileHandles) {
@@ -522,7 +522,7 @@ public abstract class LogFile {
                             try {
                                 fileHandle.close();
                             } catch (IOException e) {
-                                LOG.warn("Unable to close fileHandle for " + file, e);
+                                logger.warn("Unable to close fileHandle for " + file, e);
                             }
                         }
                     }
@@ -553,7 +553,7 @@ public abstract class LogFile {
             }
             int remaining = readFileHandles.remainingCapacity();
             if (remaining > 0) {
-                LOG.info("Opening " + file + " for read, remaining number of file "
+                logger.info("Opening " + file + " for read, remaining number of file "
                         + "handles available for reads of this file is " + remaining);
                 return open();
             }
@@ -565,7 +565,7 @@ public abstract class LogFile {
                 try {
                     fileHandle.close();
                 } catch (IOException e) {
-                    LOG.warn("Unable to close " + file, e);
+                    logger.warn("Unable to close " + file, e);
                 }
             }
         }
@@ -644,9 +644,9 @@ public abstract class LogFile {
                     position = backupCheckpointPosition;
                 }
                 fileChannel.position(position);
-                LOG.info("fast-forward to checkpoint position: " + position);
+                logger.info("fast-forward to checkpoint position: " + position);
             } else {
-                LOG.info("Checkpoint for file(" + file.getAbsolutePath() + ") "
+                logger.info("Checkpoint for file(" + file.getAbsolutePath() + ") "
                         + "is: " + lastCheckpointWriteOrderID + ", which is beyond the "
                         + "requested checkpoint time: " + checkpointWriteOrderID
                         + " and position " + lastCheckpointPosition);
@@ -658,7 +658,7 @@ public abstract class LogFile {
             try {
                 long position = fileChannel.position();
                 if (position > FileChannelConfiguration.DEFAULT_MAX_FILE_SIZE) {
-                    LOG.info("File position exceeds the threshold: "
+                    logger.info("File position exceeds the threshold: "
                             + FileChannelConfiguration.DEFAULT_MAX_FILE_SIZE
                             + ", position: " + position);
                 }
@@ -669,16 +669,16 @@ public abstract class LogFile {
                     if (operation == OP_RECORD) {
                         break;
                     } else if (operation == OP_EOF) {
-                        LOG.info("Encountered EOF at " + offset + " in " + file);
+                        logger.info("Encountered EOF at " + offset + " in " + file);
                         return null;
                     } else if (operation == OP_NOOP) {
-                        LOG.info("No op event found in file: " + file.toString() + " at " + offset
+                        logger.info("No op event found in file: " + file.toString() + " at " + offset
                                 + ". Skipping event.");
                         skipRecord(fileHandle, offset + 1);
                         offset = (int) fileHandle.getFilePointer();
                         continue;
                     } else {
-                        LOG.error("Encountered non op-record at " + offset + " " + Integer.toHexString(operation)
+                        logger.error("Encountered non op-record at " + offset + " " + Integer.toHexString(operation)
                                 + " in " + file);
                         return null;
                     }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/LogFileFactory.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/LogFileFactory.java
@@ -24,12 +24,12 @@ import java.io.RandomAccessFile;
 import java.security.Key;
 import javax.annotation.Nullable;
 import org.apache.flume.channel.file.encryption.KeyProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @SuppressWarnings("deprecation")
 class LogFileFactory {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LogFileFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private LogFileFactory() {}
 
@@ -51,7 +51,7 @@ class LogFileFactory {
                 try {
                     logFile.close();
                 } catch (IOException e) {
-                    LOGGER.warn("Unable to close " + file, e);
+                    logger.warn("Unable to close " + file, e);
                 }
             }
         }
@@ -102,7 +102,7 @@ class LogFileFactory {
                 try {
                     logFile.close();
                 } catch (IOException e) {
-                    LOGGER.warn("Unable to close " + file, e);
+                    logger.warn("Unable to close " + file, e);
                 }
             }
         }
@@ -174,7 +174,7 @@ class LogFileFactory {
                 try {
                     logFile.close();
                 } catch (IOException e) {
-                    LOGGER.warn("Unable to close " + file, e);
+                    logger.warn("Unable to close " + file, e);
                 }
             }
         }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/LogFileV2.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/LogFileV2.java
@@ -20,8 +20,8 @@ import java.io.EOFException;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Represents a single data file on disk. Has methods to write,
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 @Deprecated
 class LogFileV2 extends LogFile {
-    protected static final Logger LOGGER = LoggerFactory.getLogger(LogFileV2.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static final long OFFSET_CHECKPOINT = 2 * Serialization.SIZE_OF_INT;
 
@@ -56,7 +56,7 @@ class LogFileV2 extends LogFile {
                 }
                 setLastCheckpointOffset(writeFileHandle.readLong());
                 setLastCheckpointWriteOrderID(writeFileHandle.readLong());
-                LOGGER.info("File: " + file.getCanonicalPath() + " was last checkpointed "
+                logger.info("File: " + file.getCanonicalPath() + " was last checkpointed "
                         + "at position: " + getLastCheckpointOffset()
                         + ", logWriteOrderID: " + getLastCheckpointWriteOrderID());
                 error = false;
@@ -79,7 +79,7 @@ class LogFileV2 extends LogFile {
             writeFileHandle.writeLong(currentPosition);
             writeFileHandle.writeLong(logWriteOrderID);
             writeFileHandle.getChannel().force(true);
-            LOGGER.info("Noted checkpoint for file: " + getFile() + ", id: "
+            logger.info("Noted checkpoint for file: " + getFile() + ", id: "
                     + getLogFileID() + ", checkpoint position: " + currentPosition
                     + ", logWriteOrderID: " + logWriteOrderID);
         }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/LogFileV3.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/LogFileV3.java
@@ -36,8 +36,8 @@ import org.apache.flume.channel.file.encryption.CipherProviderFactory;
 import org.apache.flume.channel.file.encryption.DecryptionFailureException;
 import org.apache.flume.channel.file.encryption.KeyProvider;
 import org.apache.flume.channel.file.proto.ProtosFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Represents a single data file on disk. Has methods to write,
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public class LogFileV3 extends LogFile {
-    protected static final Logger LOGGER = LoggerFactory.getLogger(LogFileV3.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private LogFileV3() {}
 
@@ -118,7 +118,7 @@ public class LogFileV3 extends LogFile {
                 try {
                     inputStream.close();
                 } catch (IOException e) {
-                    LOGGER.warn("Unable to close " + metaDataFile, e);
+                    logger.warn("Unable to close " + metaDataFile, e);
                 }
             }
         }
@@ -162,7 +162,7 @@ public class LogFileV3 extends LogFile {
                 try {
                     outputStream.close();
                 } catch (IOException e) {
-                    LOGGER.warn("Unable to close " + tmp, e);
+                    logger.warn("Unable to close " + tmp, e);
                 }
             }
         }
@@ -257,7 +257,7 @@ public class LogFileV3 extends LogFile {
                 try {
                     inputStream.close();
                 } catch (IOException e) {
-                    LOGGER.warn("Unable to close " + metaDataFile, e);
+                    logger.warn("Unable to close " + metaDataFile, e);
                 }
             }
         }
@@ -346,7 +346,7 @@ public class LogFileV3 extends LogFile {
                 try {
                     inputStream.close();
                 } catch (IOException e) {
-                    LOGGER.warn("Unable to close " + metaDataFile, e);
+                    logger.warn("Unable to close " + metaDataFile, e);
                 }
             }
         }
@@ -367,7 +367,7 @@ public class LogFileV3 extends LogFile {
                 }
                 event = TransactionEventRecord.fromByteArray(buffer);
             } catch (CorruptEventException ex) {
-                LOGGER.warn("Corrupt file found. File id: log-" + this.getLogFileID(), ex);
+                logger.warn("Corrupt file found. File id: log-" + this.getLogFileID(), ex);
                 // Return null so that replay handler thinks all events in this file
                 // have been taken.
                 if (!fsyncPerTransaction) {
@@ -376,7 +376,7 @@ public class LogFileV3 extends LogFile {
                 throw ex;
             } catch (DecryptionFailureException ex) {
                 if (!fsyncPerTransaction) {
-                    LOGGER.warn("Could not decrypt even read from channel. Skipping " + "event.", ex);
+                    logger.warn("Could not decrypt even read from channel. Skipping " + "event.", ex);
                     return null;
                 }
                 throw ex;

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/ReplayHandler.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/ReplayHandler.java
@@ -35,14 +35,14 @@ import javax.annotation.Nullable;
 import org.apache.commons.collections.MultiMap;
 import org.apache.commons.collections.map.MultiValueMap;
 import org.apache.flume.channel.file.encryption.KeyProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Processes a set of data logs, replaying said logs into the queue.
  */
 class ReplayHandler {
-    private static final Logger LOG = LoggerFactory.getLogger(ReplayHandler.class);
+    private static final Logger logger = LogManager.getLogger();
     private final FlumeEventQueue queue;
     private final long lastCheckpoint;
     private final Map<Integer, LogFile.SequentialReader> readers;
@@ -127,9 +127,9 @@ class ReplayHandler {
         }
 
         SetMultimap<Long, Long> inflightTakes = queue.deserializeInflightTakes();
-        LOG.info("Starting replay of " + logs);
+        logger.info("Starting replay of " + logs);
         for (File log : logs) {
-            LOG.info("Replaying " + log);
+            logger.info("Replaying " + log);
             LogFile.SequentialReader reader = null;
             try {
                 reader = LogFileFactory.getSequentialReader(log, encryptionKeyProvider, fsyncPerTransaction);
@@ -189,14 +189,14 @@ class ReplayHandler {
                         skipCount++;
                     }
                 }
-                LOG.info("Replayed " + count + " from " + log);
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("read: " + readCount + ", put: " + putCount + ", take: "
+                logger.info("Replayed " + count + " from " + log);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("read: " + readCount + ", put: " + putCount + ", take: "
                             + takeCount + ", rollback: " + rollbackCount + ", commit: "
                             + commitCount + ", skipp: " + skipCount);
                 }
             } catch (EOFException e) {
-                LOG.warn("Hit EOF on " + log);
+                logger.warn("Hit EOF on " + log);
             } finally {
                 total += count;
                 count = 0;
@@ -220,15 +220,15 @@ class ReplayHandler {
         int pendingTakesSize = pendingTakes.size();
         if (pendingTakesSize > 0) {
             String msg = "Pending takes " + pendingTakesSize + " exist after the end of replay";
-            if (LOG.isDebugEnabled()) {
+            if (logger.isDebugEnabled()) {
                 for (Long pointer : pendingTakes) {
-                    LOG.debug("Pending take " + FlumeEventPointer.fromLong(pointer));
+                    logger.debug("Pending take " + FlumeEventPointer.fromLong(pointer));
                 }
             } else {
-                LOG.error(msg + ". Duplicate messages will exist in destination.");
+                logger.error(msg + ". Duplicate messages will exist in destination.");
             }
         }
-        LOG.info("Replayed " + total);
+        logger.info("Replayed " + total);
     }
     /**
      * Replay logs in order records were written
@@ -240,7 +240,7 @@ class ReplayHandler {
         MultiMap transactionMap = new MultiValueMap();
         // seed both with the highest known sequence of either the tnxid or woid
         long transactionIDSeed = lastCheckpoint, writeOrderIDSeed = lastCheckpoint;
-        LOG.info("Starting replay of " + logs);
+        logger.info("Starting replay of " + logs);
         // Load the inflight puts into the transaction map to see if they were
         // committed in one of the logs.
         SetMultimap<Long, Long> inflightPuts = queue.deserializeInflightPuts();
@@ -253,7 +253,7 @@ class ReplayHandler {
         SetMultimap<Long, Long> inflightTakes = queue.deserializeInflightTakes();
         try {
             for (File log : logs) {
-                LOG.info("Replaying " + log);
+                logger.info("Replaying " + log);
                 try {
                     LogFile.SequentialReader reader =
                             LogFileFactory.getSequentialReader(log, encryptionKeyProvider, fsyncPerTransaction);
@@ -270,7 +270,7 @@ class ReplayHandler {
                         logRecordBuffer.add(logRecord);
                     }
                 } catch (EOFException e) {
-                    LOG.warn("Ignoring " + log + " due to EOF", e);
+                    logger.warn("Ignoring " + log + " due to EOF", e);
                 }
             }
             LogRecord entry = null;
@@ -287,7 +287,7 @@ class ReplayHandler {
                 writeOrderIDSeed = Math.max(writeOrderIDSeed, record.getLogWriteOrderID());
                 readCount++;
                 if (readCount % 10000 == 0 && readCount > 0) {
-                    LOG.info("read: " + readCount + ", put: " + putCount + ", take: "
+                    logger.info("read: " + readCount + ", put: " + putCount + ", take: "
                             + takeCount + ", rollback: " + rollbackCount + ", commit: "
                             + commitCount + ", skip: " + skipCount + ", eventCount:" + count);
                 }
@@ -333,7 +333,7 @@ class ReplayHandler {
                     skipCount++;
                 }
             }
-            LOG.info("read: " + readCount + ", put: " + putCount + ", take: "
+            logger.info("read: " + readCount + ", put: " + putCount + ", take: "
                     + takeCount + ", rollback: " + rollbackCount + ", commit: "
                     + commitCount + ", skip: " + skipCount + ", eventCount:" + count);
             queue.replayComplete();
@@ -360,7 +360,7 @@ class ReplayHandler {
         count += uncommittedTakes;
         int pendingTakesSize = pendingTakes.size();
         if (pendingTakesSize > 0) {
-            LOG.info("Pending takes " + pendingTakesSize + " exist after the"
+            logger.info("Pending takes " + pendingTakesSize + " exist after the"
                     + " end of replay. Duplicate messages will exist in"
                     + " destination.");
         }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/Serialization.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/Serialization.java
@@ -30,8 +30,8 @@ import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.xerial.snappy.SnappyInputStream;
 import org.xerial.snappy.SnappyOutputStream;
 
@@ -53,7 +53,7 @@ public class Serialization {
     // 64 K buffer to copy and compress files.
     private static final int FILE_BUFFER_SIZE = 64 * 1024;
 
-    public static final Logger LOG = LoggerFactory.getLogger(Serialization.class);
+    private static final Logger logger = LogManager.getLogger();
 
     static File getMetaDataTempFile(File metaDataFile) {
         String metaDataFileName = metaDataFile.getName() + METADATA_TMP_FILENAME;
@@ -99,18 +99,18 @@ public class Serialization {
         }
         for (File file : files) {
             if (excludes.contains(file.getName())) {
-                LOG.info("Skipping " + file.getName() + " because it is in excludes " + "set");
+                logger.info("Skipping " + file.getName() + " because it is in excludes " + "set");
                 continue;
             }
             if (!FileUtils.deleteQuietly(file)) {
-                LOG.info(builder.toString());
-                LOG.error("Error while attempting to delete: " + file.getAbsolutePath());
+                logger.info(builder.toString());
+                logger.error("Error while attempting to delete: " + file.getAbsolutePath());
                 return false;
             }
             builder.append(", ").append(file.getName());
         }
         builder.append(".");
-        LOG.info(builder.toString());
+        logger.info(builder.toString());
         return true;
     }
 
@@ -148,7 +148,7 @@ public class Serialization {
                     total == from.length(), "The size of the origin file and destination file are not equal.");
             return true;
         } catch (Exception ex) {
-            LOG.error("Error while attempting to copy " + from.toString() + " to " + to.toString() + ".", ex);
+            logger.error("Error while attempting to copy " + from.toString() + " to " + to.toString() + ".", ex);
             Throwables.propagate(ex);
         } finally {
             Throwable th = null;
@@ -157,7 +157,7 @@ public class Serialization {
                     in.close();
                 }
             } catch (Throwable ex) {
-                LOG.error("Error while closing input file.", ex);
+                logger.error("Error while closing input file.", ex);
                 th = ex;
             }
             try {
@@ -165,7 +165,7 @@ public class Serialization {
                     out.close();
                 }
             } catch (IOException ex) {
-                LOG.error("Error while closing output file.", ex);
+                logger.error("Error while closing output file.", ex);
                 Throwables.propagate(ex);
             }
             if (th != null) {
@@ -209,7 +209,7 @@ public class Serialization {
             out.getFD().sync();
             return true;
         } catch (Exception ex) {
-            LOG.error(
+            logger.error(
                     "Error while attempting to compress " + uncompressed.toString() + " to " + compressed.toString()
                             + ".",
                     ex);
@@ -221,7 +221,7 @@ public class Serialization {
                     in.close();
                 }
             } catch (Throwable ex) {
-                LOG.error("Error while closing input file.", ex);
+                logger.error("Error while closing input file.", ex);
                 th = ex;
             }
             try {
@@ -229,7 +229,7 @@ public class Serialization {
                     snappyOut.close();
                 }
             } catch (IOException ex) {
-                LOG.error("Error while closing output file.", ex);
+                logger.error("Error while closing output file.", ex);
                 Throwables.propagate(ex);
             }
             if (th != null) {
@@ -274,7 +274,7 @@ public class Serialization {
             out.getFD().sync();
             return true;
         } catch (Exception ex) {
-            LOG.error(
+            logger.error(
                     "Error while attempting to compress " + compressed.toString() + " to " + decompressed.toString()
                             + ".",
                     ex);
@@ -286,7 +286,7 @@ public class Serialization {
                     in.close();
                 }
             } catch (Throwable ex) {
-                LOG.error("Error while closing input file.", ex);
+                logger.error("Error while closing input file.", ex);
                 th = ex;
             }
             try {
@@ -294,7 +294,7 @@ public class Serialization {
                     snappyIn.close();
                 }
             } catch (IOException ex) {
-                LOG.error("Error while closing output file.", ex);
+                logger.error("Error while closing output file.", ex);
                 Throwables.propagate(ex);
             }
             if (th != null) {

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/TransactionEventRecord.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/TransactionEventRecord.java
@@ -33,8 +33,8 @@ import java.nio.ByteBuffer;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.channel.file.proto.ProtosFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Base class for records in data file: Put, Take, Rollback, Commit
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public abstract class TransactionEventRecord implements Writable {
-    private static final Logger LOG = LoggerFactory.getLogger(TransactionEventRecord.class);
+    private static final Logger logger = LogManager.getLogger();
     private final long transactionID;
     private long logWriteOrderID;
 
@@ -130,7 +130,7 @@ public abstract class TransactionEventRecord implements Writable {
                 try {
                     dataOutput.close();
                 } catch (IOException e) {
-                    LOG.warn("Error closing byte array output stream", e);
+                    logger.warn("Error closing byte array output stream", e);
                 }
             }
         }
@@ -172,7 +172,7 @@ public abstract class TransactionEventRecord implements Writable {
                 try {
                     byteOutput.close();
                 } catch (IOException e) {
-                    LOG.warn("Error closing byte array output stream", e);
+                    logger.warn("Error closing byte array output stream", e);
                 }
             }
         }
@@ -198,7 +198,7 @@ public abstract class TransactionEventRecord implements Writable {
             try {
                 in.close();
             } catch (IOException e) {
-                LOG.warn("Error closing byte array input stream", e);
+                logger.warn("Error closing byte array input stream", e);
             }
         }
     }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/encryption/AESCTRNoPaddingProvider.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/encryption/AESCTRNoPaddingProvider.java
@@ -24,11 +24,11 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class AESCTRNoPaddingProvider extends CipherProvider {
-    private static final Logger LOG = LoggerFactory.getLogger(AESCTRNoPaddingProvider.class);
+    private static final Logger logger = LogManager.getLogger();
     static final String TYPE = "AES/CTR/NoPadding";
 
     public Encryptor.Builder<AESCTRNoPaddingEncryptor> newEncryptorBuilder() {
@@ -107,7 +107,7 @@ public class AESCTRNoPaddingProvider extends CipherProvider {
             return cipher.doFinal(input);
         } catch (Exception e) {
             String msg = "Unable to encrypt or decrypt data " + TYPE + " input.length " + input.length;
-            LOG.error(msg, e);
+            logger.error(msg, e);
             throw new DecryptionFailureException(msg, e);
         }
     }
@@ -132,7 +132,7 @@ public class AESCTRNoPaddingProvider extends CipherProvider {
                     msg += "; Unable to find specified algorithm?";
                 }
             }
-            LOG.error(msg, e);
+            logger.error(msg, e);
             throw Throwables.propagate(e);
         }
     }

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/encryption/CipherProviderFactory.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/encryption/CipherProviderFactory.java
@@ -20,11 +20,11 @@ import com.google.common.base.Preconditions;
 import java.security.Key;
 import java.util.Locale;
 import org.apache.flume.FlumeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class CipherProviderFactory {
-    private static final Logger logger = LoggerFactory.getLogger(CipherProviderFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static CipherProvider.Encryptor getEncrypter(String cipherProviderType, Key key) {
         if (cipherProviderType == null) {

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/encryption/JCEFileKeyProvider.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/encryption/JCEFileKeyProvider.java
@@ -29,11 +29,11 @@ import java.security.Key;
 import java.security.KeyStore;
 import java.util.Map;
 import org.apache.flume.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class JCEFileKeyProvider extends KeyProvider {
-    private static final Logger logger = LoggerFactory.getLogger(JCEFileKeyProvider.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private Map<String, File> aliasPasswordFileMap;
     private KeyStore ks;

--- a/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/encryption/KeyProviderFactory.java
+++ b/flume-ng-channels/flume-file-channel/src/main/java/org/apache/flume/channel/file/encryption/KeyProviderFactory.java
@@ -20,11 +20,11 @@ import com.google.common.base.Preconditions;
 import java.util.Locale;
 import org.apache.flume.Context;
 import org.apache.flume.FlumeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class KeyProviderFactory {
-    private static final Logger logger = LoggerFactory.getLogger(KeyProviderFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     public static KeyProvider getInstance(String keyProviderType, Context context) {

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestCheckpointRebuilder.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestCheckpointRebuilder.java
@@ -27,12 +27,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestCheckpointRebuilder extends TestFileChannelBase {
-
-    protected static final Logger LOG = LoggerFactory.getLogger(TestCheckpointRebuilder.class);
 
     @Before
     public void setup() throws Exception {

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannel.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannel.java
@@ -56,16 +56,16 @@ import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.exception.ChannelException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestFileChannel extends TestFileChannelBase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TestFileChannel.class);
+    private static final Logger logger = LogManager.getLogger();
     public static final String TEST_KEY = "test_key";
 
     @Before
@@ -342,7 +342,7 @@ public class TestFileChannel extends TestFileChannelBase {
         Assert.assertNotNull(putmsg);
         String takemsg = result.iterator().next();
         Assert.assertNotNull(takemsg);
-        LOG.info("Got: put " + putmsg + ", take " + takemsg);
+        logger.info("Got: put " + putmsg + ", take " + takemsg);
         channel.stop();
         channel = createFileChannel(overrides);
         // now when we replay, the transaction the put will be ordered
@@ -372,9 +372,9 @@ public class TestFileChannel extends TestFileChannelBase {
                         } else {
                             expected.addAll(putEvents(channel, Integer.toString(id), 5, 5));
                         }
-                        LOG.info("Completed some puts " + expected.size());
+                        logger.info("Completed some puts " + expected.size());
                     } catch (Exception e) {
-                        LOG.error("Error doing puts", e);
+                        logger.error("Error doing puts", e);
                         errors.add(e);
                     } finally {
                         producerStopLatch.countDown();
@@ -398,12 +398,12 @@ public class TestFileChannel extends TestFileChannelBase {
                             }
                         }
                         if (actual.isEmpty()) {
-                            LOG.error("Found nothing!");
+                            logger.error("Found nothing!");
                         } else {
-                            LOG.info("Completed some takes " + actual.size());
+                            logger.info("Completed some takes " + actual.size());
                         }
                     } catch (Exception e) {
-                        LOG.error("Error doing takes", e);
+                        logger.error("Error doing takes", e);
                         errors.add(e);
                     } finally {
                         consumerStopLatch.countDown();

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelFormatRegression.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelFormatRegression.java
@@ -29,11 +29,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestFileChannelFormatRegression extends TestFileChannelBase {
-    protected static final Logger LOG = LoggerFactory.getLogger(TestFileChannelFormatRegression.class);
 
     @Before
     public void setup() throws Exception {

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelRestart.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelRestart.java
@@ -49,11 +49,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestFileChannelRestart extends TestFileChannelBase {
-    protected static final Logger LOG = LoggerFactory.getLogger(TestFileChannelRestart.class);
 
     @Before
     public void setup() throws Exception {

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelRollback.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelRollback.java
@@ -26,15 +26,15 @@ import java.util.Set;
 import org.apache.flume.Transaction;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.sink.LoggerSink;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestFileChannelRollback extends TestFileChannelBase {
-    protected static final Logger LOG = LoggerFactory.getLogger(TestFileChannelRollback.class);
+    private static final Logger logger = LogManager.getLogger();
 
     @Before
     public void setup() throws Exception {
@@ -121,7 +121,7 @@ public class TestFileChannelRollback extends TestFileChannelBase {
         }
         Assert.assertEquals(numEvents - 1, runner.getCount());
         for (Exception ex : runner.getErrors()) {
-            LOG.warn("Sink had error", ex);
+            logger.warn("Sink had error", ex);
         }
         Assert.assertEquals(Collections.EMPTY_LIST, runner.getErrors());
 

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestIntegration.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestIntegration.java
@@ -29,16 +29,16 @@ import org.apache.flume.Context;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.sink.NullSink;
 import org.apache.flume.source.SequenceGeneratorSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestIntegration {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TestIntegration.class);
+    private static final Logger logger = LogManager.getLogger();
     private FileChannel channel;
     private File baseDir;
     private File checkpointDir;
@@ -116,17 +116,17 @@ public class TestIntegration {
         for (int i = 0; i < dataDirs.length; i++) {
             logs.addAll(LogUtils.getLogs(dataDirs[i]));
         }
-        LOG.info("Total Number of Logs = " + logs.size());
+        logger.info("Total Number of Logs = " + logs.size());
         for (File logFile : logs) {
-            LOG.info("LogFile = " + logFile);
+            logger.info("LogFile = " + logFile);
         }
-        LOG.info("Source processed " + sinkRunner.getCount());
-        LOG.info("Sink processed " + sourceRunner.getCount());
+        logger.info("Source processed " + sinkRunner.getCount());
+        logger.info("Sink processed " + sourceRunner.getCount());
         for (Exception ex : sourceRunner.getErrors()) {
-            LOG.warn("Source had error", ex);
+            logger.warn("Source had error", ex);
         }
         for (Exception ex : sinkRunner.getErrors()) {
-            LOG.warn("Sink had error", ex);
+            logger.warn("Sink had error", ex);
         }
         Assert.assertEquals(sinkRunner.getCount(), sinkRunner.getCount());
         Assert.assertEquals(Collections.EMPTY_LIST, sinkRunner.getErrors());

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestLog.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestLog.java
@@ -27,15 +27,15 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.flume.channel.file.instrumentation.FileChannelCounter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestLog {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestLog.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final long MAX_FILE_SIZE = 1000;
     private static final int CAPACITY = 10000;
     private Log log;
@@ -199,10 +199,10 @@ public class TestLog {
         try {
             doTestMinimumRequiredSpaceTooSmallForPut();
         } catch (IOException e) {
-            LOGGER.info("Error during test, retrying", e);
+            logger.info("Error during test, retrying", e);
             doTestMinimumRequiredSpaceTooSmallForPut();
         } catch (AssertionError e) {
-            LOGGER.info("Test failed, let's be sure it failed for good reason", e);
+            logger.info("Test failed, let's be sure it failed for good reason", e);
             doTestMinimumRequiredSpaceTooSmallForPut();
         }
     }

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/encryption/TestFileChannelEncryption.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/encryption/TestFileChannelEncryption.java
@@ -40,15 +40,15 @@ import org.apache.flume.channel.file.FileChannelConfiguration;
 import org.apache.flume.channel.file.TestFileChannelBase;
 import org.apache.flume.channel.file.TestUtils;
 import org.apache.flume.exception.ChannelException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestFileChannelEncryption extends TestFileChannelBase {
-    protected static final Logger LOGGER = LoggerFactory.getLogger(TestFileChannelEncryption.class);
+    private static final Logger logger = LogManager.getLogger();
     private File keyStoreFile;
     private File keyStorePasswordFile;
     private Map<String, File> keyAliasPassword;
@@ -117,7 +117,7 @@ public class TestFileChannelEncryption extends TestFileChannelBase {
                         out.addAll(takeEvents(channel, 10));
                     } catch (Throwable t) {
                         error.set(true);
-                        LOGGER.error("Error in take thread", t);
+                        logger.error("Error in take thread", t);
                     } finally {
                         stopLatch.countDown();
                     }
@@ -153,7 +153,7 @@ public class TestFileChannelEncryption extends TestFileChannelBase {
                         in.addAll(putEvents(channel, "thread-produce", 10, 10000, true));
                     } catch (Throwable t) {
                         error.set(true);
-                        LOGGER.error("Error in put thread", t);
+                        logger.error("Error in put thread", t);
                     } finally {
                         stopLatch.countDown();
                     }

--- a/flume-ng-channels/flume-spillable-memory-channel/pom.xml
+++ b/flume-ng-channels/flume-spillable-memory-channel/pom.xml
@@ -103,12 +103,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/flume-ng-channels/flume-spillable-memory-channel/pom.xml
+++ b/flume-ng-channels/flume-spillable-memory-channel/pom.xml
@@ -99,7 +99,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/flume-ng-channels/flume-spillable-memory-channel/pom.xml
+++ b/flume-ng-channels/flume-spillable-memory-channel/pom.xml
@@ -58,8 +58,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/flume-ng-channels/flume-spillable-memory-channel/src/main/java/org/apache/flume/channel/SpillableMemoryChannel.java
+++ b/flume-ng-channels/flume-spillable-memory-channel/src/main/java/org/apache/flume/channel/SpillableMemoryChannel.java
@@ -33,8 +33,8 @@ import org.apache.flume.exception.ChannelException;
 import org.apache.flume.exception.ChannelFullException;
 import org.apache.flume.instrumentation.ChannelCounter;
 import org.apache.flume.lifecycle.LifecycleState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -86,7 +86,7 @@ public class SpillableMemoryChannel extends FileChannel {
      */
     public static final String AVG_EVENT_SIZE = "avgEventSize";
 
-    private static Logger LOGGER = LoggerFactory.getLogger(SpillableMemoryChannel.class);
+    private static final Logger logger = LogManager.getLogger();
     public static final int defaultMemoryCapacity = 10000;
     public static final int defaultOverflowCapacity = 100000000;
 
@@ -345,7 +345,7 @@ public class SpillableMemoryChannel extends FileChannel {
         protected Event doTake() throws InterruptedException {
             channelCounter.incrementEventTakeAttemptCount();
             if (!totalStored.tryAcquire(overflowTimeout, TimeUnit.SECONDS)) {
-                LOGGER.debug("Take is backing off as channel is empty.");
+                logger.debug("Take is backing off as channel is empty.");
                 return null;
             }
             boolean takeSuceeded = false;
@@ -365,7 +365,7 @@ public class SpillableMemoryChannel extends FileChannel {
 
                     if (useOverflow) {
                         if (drainOrderTop > 0) {
-                            LOGGER.debug("Take is switching to primary");
+                            logger.debug("Take is switching to primary");
                             return null; // takes should now occur from primary channel
                         }
 
@@ -374,7 +374,7 @@ public class SpillableMemoryChannel extends FileChannel {
                         drainOrder.takeOverflow(1);
                     } else {
                         if (drainOrderTop < 0) {
-                            LOGGER.debug("Take is switching to overflow");
+                            logger.debug("Take is switching to overflow");
                             return null; // takes should now occur from overflow channel
                         }
 
@@ -406,13 +406,13 @@ public class SpillableMemoryChannel extends FileChannel {
         protected void doCommit() throws InterruptedException {
             if (putCalled) {
                 putCommit();
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Put Committed. Drain Order Queue state : " + drainOrder.dump());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Put Committed. Drain Order Queue state : " + drainOrder.dump());
                 }
             } else if (takeCalled) {
                 takeCommit();
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Take Committed. Drain Order Queue state : " + drainOrder.dump());
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Take Committed. Drain Order Queue state : " + drainOrder.dump());
                 }
             }
         }
@@ -432,7 +432,7 @@ public class SpillableMemoryChannel extends FileChannel {
 
                 if (overflowActivated && memoryPercentFree >= overflowDeactivationThreshold) {
                     overflowActivated = false;
-                    LOGGER.info("Overflow Deactivated");
+                    logger.info("Overflow Deactivated");
                 }
                 channelCounter.setChannelSize(getTotalStored());
             }
@@ -537,7 +537,7 @@ public class SpillableMemoryChannel extends FileChannel {
 
         @Override
         protected void doRollback() {
-            LOGGER.debug("Rollback() of " + (takeCalled ? " Take Tx" : (putCalled ? " Put Tx" : "Empty Tx")));
+            logger.debug("Rollback() of " + (takeCalled ? " Take Tx" : (putCalled ? " Put Tx" : "Empty Tx")));
 
             if (putCalled) {
                 if (overflowPutTx != null) {
@@ -615,7 +615,7 @@ public class SpillableMemoryChannel extends FileChannel {
 
         } catch (NumberFormatException e) {
             newMemoryCapacity = defaultMemoryCapacity;
-            LOGGER.warn(
+            logger.warn(
                     "Invalid " + MEMORY_CAPACITY + " specified, initializing " + getName()
                             + " channel to default value of {}",
                     defaultMemoryCapacity);
@@ -631,7 +631,7 @@ public class SpillableMemoryChannel extends FileChannel {
             Integer newOverflowTimeout = context.getInteger(OVERFLOW_TIMEOUT, defaultOverflowTimeout);
             overflowTimeout = (newOverflowTimeout != null) ? newOverflowTimeout : defaultOverflowTimeout;
         } catch (NumberFormatException e) {
-            LOGGER.warn(
+            logger.warn(
                     "Incorrect value for " + getName() + "'s " + OVERFLOW_TIMEOUT + " setting. Using default value {}",
                     defaultOverflowTimeout);
             overflowTimeout = defaultOverflowTimeout;
@@ -642,7 +642,7 @@ public class SpillableMemoryChannel extends FileChannel {
             overflowDeactivationThreshold =
                     (newThreshold != null) ? newThreshold / 100.0 : defaultOverflowDeactivationThreshold / 100.0;
         } catch (NumberFormatException e) {
-            LOGGER.warn(
+            logger.warn(
                     "Incorrect value for " + getName() + "'s " + OVERFLOW_DEACTIVATION_THRESHOLD
                             + ". Using default value {} %",
                     defaultOverflowDeactivationThreshold);
@@ -654,7 +654,7 @@ public class SpillableMemoryChannel extends FileChannel {
             byteCapacityBufferPercentage =
                     context.getInteger(BYTE_CAPACITY_BUFFER_PERCENTAGE, defaultByteCapacityBufferPercentage);
         } catch (NumberFormatException e) {
-            LOGGER.warn("Error parsing " + BYTE_CAPACITY_BUFFER_PERCENTAGE + " for "
+            logger.warn("Error parsing " + BYTE_CAPACITY_BUFFER_PERCENTAGE + " for "
                     + getName() + ". Using default="
                     + defaultByteCapacityBufferPercentage + ". " + e.getMessage());
             byteCapacityBufferPercentage = defaultByteCapacityBufferPercentage;
@@ -663,7 +663,7 @@ public class SpillableMemoryChannel extends FileChannel {
         try {
             avgEventSize = context.getInteger(AVG_EVENT_SIZE, defaultAvgEventSize);
         } catch (NumberFormatException e) {
-            LOGGER.warn("Error parsing " + AVG_EVENT_SIZE + " for " + getName()
+            logger.warn("Error parsing " + AVG_EVENT_SIZE + " for " + getName()
                     + ". Using default = " + defaultAvgEventSize + ". "
                     + e.getMessage());
             avgEventSize = defaultAvgEventSize;
@@ -677,7 +677,7 @@ public class SpillableMemoryChannel extends FileChannel {
                 byteCapacity = Integer.MAX_VALUE;
             }
         } catch (NumberFormatException e) {
-            LOGGER.warn("Error parsing " + BYTE_CAPACITY + " setting for " + getName()
+            logger.warn("Error parsing " + BYTE_CAPACITY + " setting for " + getName()
                     + ". Using default = " + defaultByteCapacity + ". "
                     + e.getMessage());
             byteCapacity = (int) ((defaultByteCapacity * (1 - byteCapacityBufferPercentage * .01)) / avgEventSize);
@@ -694,7 +694,7 @@ public class SpillableMemoryChannel extends FileChannel {
                 try {
                     if (!bytesRemaining.tryAcquire(
                             lastByteCapacity - byteCapacity, overflowTimeout, TimeUnit.SECONDS)) {
-                        LOGGER.warn("Couldn't acquire permits to downsize the byte capacity, "
+                        logger.warn("Couldn't acquire permits to downsize the byte capacity, "
                                 + "resizing has been aborted");
                     } else {
                         lastByteCapacity = byteCapacity;
@@ -710,7 +710,7 @@ public class SpillableMemoryChannel extends FileChannel {
             overflowCapacity = context.getInteger(OVERFLOW_CAPACITY, defaultOverflowCapacity);
             // Determine if File channel needs to be disabled
             if (memoryCapacity < 1 && overflowCapacity < 1) {
-                LOGGER.warn("For channel " + getName() + OVERFLOW_CAPACITY + " cannot be set to 0 if "
+                logger.warn("For channel " + getName() + OVERFLOW_CAPACITY + " cannot be set to 0 if "
                         + MEMORY_CAPACITY + " is also 0. " + "Using default value "
                         + OVERFLOW_CAPACITY + " = " + defaultOverflowCapacity);
                 overflowCapacity = defaultOverflowCapacity;
@@ -737,7 +737,7 @@ public class SpillableMemoryChannel extends FileChannel {
         if (memoryCapacity > newMemoryCapacity) {
             int diff = memoryCapacity - newMemoryCapacity;
             if (!memQueRemaining.tryAcquire(diff, overflowTimeout, TimeUnit.SECONDS)) {
-                LOGGER.warn("Memory buffer currently contains more events than the new size. "
+                logger.warn("Memory buffer currently contains more events than the new size. "
                         + "Downsizing has been aborted.");
                 return;
             }

--- a/flume-ng-configfilters/flume-ng-external-process-config-filter/pom.xml
+++ b/flume-ng-configfilters/flume-ng-external-process-config-filter/pom.xml
@@ -33,8 +33,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.flume</groupId>

--- a/flume-ng-configfilters/flume-ng-external-process-config-filter/src/main/java/org/apache/flume/configfilter/ExternalProcessConfigFilter.java
+++ b/flume-ng-configfilters/flume-ng-external-process-config-filter/src/main/java/org/apache/flume/configfilter/ExternalProcessConfigFilter.java
@@ -23,12 +23,12 @@ import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Scanner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ExternalProcessConfigFilter extends AbstractConfigFilter {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExternalProcessConfigFilter.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static final String COMMAND_KEY = "command";
     private static final String CHARSET_KEY = "charset";
@@ -42,7 +42,7 @@ public class ExternalProcessConfigFilter extends AbstractConfigFilter {
         try {
             return execCommand(key);
         } catch (InterruptedException | IllegalStateException | IOException ex) {
-            LOGGER.error("Error while reading value for key {}: ", key, ex);
+            logger.error("Error while reading value for key {}: ", key, ex);
         }
         return null;
     }
@@ -90,10 +90,10 @@ public class ExternalProcessConfigFilter extends AbstractConfigFilter {
             if (scanner.hasNextLine()) {
                 result = scanner.nextLine();
                 if (scanner.hasNextLine()) {
-                    LOGGER.warn("External process has more than one line of output. " + "Only the first line is used.");
+                    logger.warn("External process has more than one line of output. " + "Only the first line is used.");
                 }
             } else {
-                LOGGER.warn("External process has not produced any output.");
+                logger.warn("External process has not produced any output.");
             }
 
             return result;

--- a/flume-ng-configuration/pom.xml
+++ b/flume-ng-configuration/pom.xml
@@ -36,8 +36,8 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/flume-ng-configuration/pom.xml
+++ b/flume-ng-configuration/pom.xml
@@ -53,12 +53,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/flume-ng-configuration/pom.xml
+++ b/flume-ng-configuration/pom.xml
@@ -48,7 +48,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/flume-ng-configuration/src/main/java/org/apache/flume/conf/ConfigFilterFactory.java
+++ b/flume-ng-configuration/src/main/java/org/apache/flume/conf/ConfigFilterFactory.java
@@ -21,17 +21,17 @@ import java.util.Locale;
 import org.apache.flume.FlumeException;
 import org.apache.flume.conf.configfilter.ConfigFilterType;
 import org.apache.flume.configfilter.ConfigFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ConfigFilterFactory {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigFilterFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static ConfigFilter create(String name, String type) throws FlumeException {
         Preconditions.checkNotNull(name, "name");
         Preconditions.checkNotNull(type, "type");
-        LOGGER.info("Creating instance of configfilter {}, type {}", name, type);
+        logger.info("Creating instance of configfilter {}, type {}", name, type);
         Class<? extends ConfigFilter> aClass = getClass(type);
         try {
             ConfigFilter configFilter = aClass.newInstance();
@@ -49,7 +49,7 @@ public class ConfigFilterFactory {
         try {
             srcType = ConfigFilterType.valueOf(type.toUpperCase(Locale.ENGLISH));
         } catch (IllegalArgumentException ex) {
-            LOGGER.debug("Configfilter type {} is a custom type", type);
+            logger.debug("Configfilter type {} is a custom type", type);
         }
         if (srcType != ConfigFilterType.OTHER) {
             classname = srcType.getClassName();

--- a/flume-ng-configuration/src/main/java/org/apache/flume/conf/FlumeConfiguration.java
+++ b/flume-ng-configuration/src/main/java/org/apache/flume/conf/FlumeConfiguration.java
@@ -67,8 +67,8 @@ import org.apache.flume.conf.sink.SinkType;
 import org.apache.flume.conf.source.SourceConfiguration;
 import org.apache.flume.conf.source.SourceType;
 import org.apache.flume.configfilter.ConfigFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -85,7 +85,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FlumeConfiguration {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FlumeConfiguration.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final Map<String, AgentConfiguration> agentConfigMap;
     private final LinkedList<FlumeConfigurationError> errors;
@@ -103,7 +103,7 @@ public class FlumeConfiguration {
         // Construct the in-memory component hierarchy
         for (Entry entry : properties.entrySet()) {
             if (!addRawProperty(entry.getKey().toString(), entry.getValue().toString())) {
-                LOGGER.warn("Configuration property ignored: {} = {}", entry.getKey(), entry.getValue());
+                logger.warn("Configuration property ignored: {} = {}", entry.getKey(), entry.getValue());
             }
         }
         // Now iterate thru the agentContext and create agent configs and add them
@@ -122,7 +122,7 @@ public class FlumeConfiguration {
         // Construct the in-memory component hierarchy
         for (Entry<String, String> entry : properties.entrySet()) {
             if (!addRawProperty(entry.getKey(), entry.getValue())) {
-                LOGGER.warn("Configuration property ignored: {} = {}", entry.getKey(), entry.getValue());
+                logger.warn("Configuration property ignored: {} = {}", entry.getKey(), entry.getValue());
             }
         }
         // Now iterate thru the agentContext and create agent configs and add them
@@ -150,16 +150,16 @@ public class FlumeConfiguration {
             AgentConfiguration aconf = next.getValue();
 
             if (!aconf.isValid()) {
-                LOGGER.warn("Agent configuration invalid for agent '{}'. It will be removed.", agentName);
+                logger.warn("Agent configuration invalid for agent '{}'. It will be removed.", agentName);
                 addError(agentName, AGENT_CONFIGURATION_INVALID, ERROR);
                 it.remove();
             }
-            LOGGER.debug("Channels:{}\n", aconf.channels);
-            LOGGER.debug("Sinks {}\n", aconf.sinks);
-            LOGGER.debug("Sources {}\n", aconf.sources);
+            logger.debug("Channels:{}\n", aconf.channels);
+            logger.debug("Sinks {}\n", aconf.sinks);
+            logger.debug("Sources {}\n", aconf.sources);
         }
 
-        LOGGER.info(
+        logger.info(
                 "Post-validation flume configuration contains configuration for agents: {}", agentConfigMap.keySet());
     }
 
@@ -340,9 +340,9 @@ public class FlumeConfiguration {
          * @return true if the configuration is valid, false otherwise
          */
         private boolean isValid() {
-            LOGGER.debug("Starting validation of configuration for agent: {}", agentName);
-            if (LOGGER.isDebugEnabled() && LogPrivacyUtil.allowLogPrintConfig()) {
-                LOGGER.debug("Initial configuration: {}", getPrevalidationConfig());
+            logger.debug("Starting validation of configuration for agent: {}", agentName);
+            if (logger.isDebugEnabled() && LogPrivacyUtil.allowLogPrintConfig()) {
+                logger.debug("Initial configuration: {}", getPrevalidationConfig());
             }
 
             configFilterSet = validateConfigFilterSet();
@@ -351,7 +351,7 @@ public class FlumeConfiguration {
 
             // Make sure that at least one channel is specified
             if (channels == null || channels.trim().isEmpty()) {
-                LOGGER.warn(
+                logger.warn(
                         "Agent configuration for '{}' does not contain any channels. Marking it as invalid.",
                         agentName);
                 addError(CONFIG_CHANNELS, PROPERTY_VALUE_NULL, ERROR);
@@ -362,7 +362,7 @@ public class FlumeConfiguration {
 
             channelSet = validateChannels(channelSet);
             if (channelSet.isEmpty()) {
-                LOGGER.warn(
+                logger.warn(
                         "Agent configuration for '{}' does not contain any valid channels. " + "Marking it as invalid.",
                         agentName);
                 addError(CONFIG_CHANNELS, PROPERTY_VALUE_NULL, ERROR);
@@ -375,7 +375,7 @@ public class FlumeConfiguration {
 
             // If no sources or sinks are present, then this is invalid
             if (sourceSet.isEmpty() && sinkSet.isEmpty()) {
-                LOGGER.warn("Agent configuration for '{}' has no sources or sinks. Will be marked invalid.", agentName);
+                logger.warn("Agent configuration for '{}' has no sources or sinks. Will be marked invalid.", agentName);
                 addError(CONFIG_SOURCES, PROPERTY_VALUE_NULL, ERROR);
                 addError(CONFIG_SINKS, PROPERTY_VALUE_NULL, ERROR);
                 return false;
@@ -389,9 +389,9 @@ public class FlumeConfiguration {
             sinks = getSpaceDelimitedList(sinkSet);
             sinkgroups = getSpaceDelimitedList(sinkgroupSet);
 
-            if (LOGGER.isDebugEnabled() && LogPrivacyUtil.allowLogPrintConfig()) {
-                LOGGER.debug("Post validation configuration for {}", agentName);
-                LOGGER.debug(getPostvalidationConfig());
+            if (logger.isDebugEnabled() && LogPrivacyUtil.allowLogPrintConfig()) {
+                logger.debug("Post validation configuration for {}", agentName);
+                logger.debug(getPostvalidationConfig());
             }
 
             return true;
@@ -429,7 +429,7 @@ public class FlumeConfiguration {
                         configFilterPatternCache.put(configFilter.getName(), createConfigFilterPattern(configFilter));
                     }
                 } catch (Exception e) {
-                    LOGGER.error("Error while creating config filter {}", name, e);
+                    logger.error("Error while creating config filter {}", name, e);
                 }
             }
         }
@@ -461,7 +461,7 @@ public class FlumeConfiguration {
                     String filteredValue = currentValue;
                     while (matcher.find()) {
                         String key = matcher.group("key");
-                        LOGGER.debug("Replacing {} from config filter {}", key, configFilter.getName());
+                        logger.debug("Replacing {} from config filter {}", key, configFilter.getName());
                         String filtered = configFilter.filter(key);
                         if (filtered == null) {
                             continue;
@@ -472,7 +472,7 @@ public class FlumeConfiguration {
                     c.put(contextKey, filteredValue);
                 } catch (Exception e) {
                     e.printStackTrace();
-                    LOGGER.error(
+                    logger.error(
                             "Error while matching and filtering configFilter: {} and key: {}",
                             new Object[] {configFilter.getName(), contextKey, e});
                 }
@@ -561,7 +561,7 @@ public class FlumeConfiguration {
                     try {
                         conf = (ChannelConfiguration)
                                 ComponentConfigurationFactory.create(channelName, config, ComponentType.CHANNEL);
-                        LOGGER.debug("Created channel {}", channelName);
+                        logger.debug("Created channel {}", channelName);
                         if (conf != null) {
                             conf.configure(channelContext);
                         }
@@ -579,7 +579,7 @@ public class FlumeConfiguration {
                         // thrown
                         if (conf != null) errorList.addAll(conf.getErrors());
                         iter.remove();
-                        LOGGER.warn(
+                        logger.warn(
                                 "Could not configure channel {} due to: {}",
                                 new Object[] {channelName, e.getMessage(), e});
                     }
@@ -598,7 +598,7 @@ public class FlumeConfiguration {
 
         private Set<String> validateConfigFilterSet() {
             if (configFilters == null || configFilters.isEmpty()) {
-                LOGGER.warn("Agent configuration for '{}' has no configfilters.", agentName);
+                logger.warn("Agent configuration for '{}' has no configfilters.", agentName);
                 return new HashSet<>();
             }
             Set<String> configFilterSet = new HashSet<>(Arrays.asList(configFilters.split("\\s+")));
@@ -632,7 +632,7 @@ public class FlumeConfiguration {
                     try {
                         conf = (ConfigFilterConfiguration) ComponentConfigurationFactory.create(
                                 configFilterName, config, ComponentType.CONFIG_FILTER);
-                        LOGGER.debug("Created configfilter {}", configFilterName);
+                        logger.debug("Created configfilter {}", configFilterName);
                         if (conf != null) {
                             conf.configure(configFilterContext);
                         }
@@ -648,14 +648,14 @@ public class FlumeConfiguration {
                     } catch (ConfigurationException e) {
                         if (conf != null) errorList.addAll(conf.getErrors());
                         iter.remove();
-                        LOGGER.warn(
+                        logger.warn(
                                 "Could not configure configfilter {} due to: {}",
                                 new Object[] {configFilterName, e.getMessage(), e});
                     }
                 } else {
                     iter.remove();
                     addError(configFilterName, CONFIG_ERROR, ERROR);
-                    LOGGER.warn("Configuration empty for: {}. Removed.", configFilterName);
+                    logger.warn("Configuration empty for: {}. Removed.", configFilterName);
                 }
             }
 
@@ -671,7 +671,7 @@ public class FlumeConfiguration {
         private Set<String> validateSources(Set<String> channelSet) {
             // Arrays.split() call will throw NPE if the sources string is empty
             if (sources == null || sources.isEmpty()) {
-                LOGGER.warn("Agent configuration for '{}' has no sources.", agentName);
+                logger.warn("Agent configuration for '{}' has no sources.", agentName);
                 addError(CONFIG_SOURCES, PROPERTY_VALUE_NULL, WARNING);
                 return new HashSet<String>();
             }
@@ -742,14 +742,14 @@ public class FlumeConfiguration {
                     } catch (ConfigurationException e) {
                         if (srcConf != null) errorList.addAll(srcConf.getErrors());
                         iter.remove();
-                        LOGGER.warn(
+                        logger.warn(
                                 "Could not configure source  {} due to: {}",
                                 new Object[] {sourceName, e.getMessage(), e});
                     }
                 } else {
                     iter.remove();
                     addError(sourceName, CONFIG_ERROR, ERROR);
-                    LOGGER.warn("Configuration empty for: {}.Removed.", sourceName);
+                    logger.warn("Configuration empty for: {}.Removed.", sourceName);
                 }
             }
 
@@ -770,7 +770,7 @@ public class FlumeConfiguration {
             Set<String> sinkSet;
             SinkConfiguration sinkConf = null;
             if (sinks == null || sinks.isEmpty()) {
-                LOGGER.warn("Agent configuration for '{}' has no sinks.", agentName);
+                logger.warn("Agent configuration for '{}' has no sinks.", agentName);
                 addError(CONFIG_SINKS, PROPERTY_VALUE_NULL, WARNING);
                 return new HashSet<String>();
             } else {
@@ -801,7 +801,7 @@ public class FlumeConfiguration {
                 Context sinkContext = sinkContextMap.get(sinkName.trim());
                 if (sinkContext == null) {
                     iter.remove();
-                    LOGGER.warn("no context for sink{}", sinkName);
+                    logger.warn("no context for sink{}", sinkName);
                     addError(sinkName, CONFIG_ERROR, ERROR);
                 } else {
                     String config = null;
@@ -819,7 +819,7 @@ public class FlumeConfiguration {
                         configSpecified = true;
                     }
                     try {
-                        LOGGER.debug("Creating sink: {} using {}", sinkName, config);
+                        logger.debug("Creating sink: {} using {}", sinkName, config);
 
                         sinkConf = (SinkConfiguration)
                                 ComponentConfigurationFactory.create(sinkName, config, ComponentType.SINK);
@@ -839,7 +839,7 @@ public class FlumeConfiguration {
                     } catch (ConfigurationException e) {
                         iter.remove();
                         if (sinkConf != null) errorList.addAll(sinkConf.getErrors());
-                        LOGGER.warn(
+                        logger.warn(
                                 "Could not configure sink  {} due to: {}", new Object[] {sinkName, e.getMessage(), e});
                     }
                 }
@@ -897,14 +897,14 @@ public class FlumeConfiguration {
                     } catch (ConfigurationException e) {
                         iter.remove();
                         addError(sinkgroupName, CONFIG_ERROR, ERROR);
-                        LOGGER.warn(
+                        logger.warn(
                                 "Could not configure sink group {} due to: {}",
                                 new Object[] {sinkgroupName, e.getMessage(), e});
                     }
                 } else {
                     iter.remove();
                     addError(sinkgroupName, CONFIG_ERROR, ERROR);
-                    LOGGER.warn("Configuration error for: {}.Removed.", sinkgroupName);
+                    logger.warn("Configuration error for: {}.Removed.", sinkgroupName);
                 }
             }
 
@@ -932,7 +932,7 @@ public class FlumeConfiguration {
             while (sinkIt.hasNext()) {
                 String curSink = sinkIt.next();
                 if (usedSinks.containsKey(curSink)) {
-                    LOGGER.warn(
+                    logger.warn(
                             "Agent configuration for '{}' sinkgroup '{}' sink '{}' in use by another group: "
                                     + "'{}', sink not added",
                             new Object[] {agentName, groupConf.getComponentName(), curSink, usedSinks.get(curSink)});
@@ -940,7 +940,7 @@ public class FlumeConfiguration {
                     sinkIt.remove();
                     continue;
                 } else if (!sinkSet.contains(curSink)) {
-                    LOGGER.warn(
+                    logger.warn(
                             "Agent configuration for '{}' sinkgroup '{}' sink not found: '{}', " + " sink not added",
                             new Object[] {agentName, groupConf.getComponentName(), curSink});
                     addError(curSink, INVALID_PROPERTY, ERROR);
@@ -1036,7 +1036,7 @@ public class FlumeConfiguration {
                     configFilters = value;
                     return true;
                 } else {
-                    LOGGER.warn("Duplicate configfilter list specified for agent: {}", agentName);
+                    logger.warn("Duplicate configfilter list specified for agent: {}", agentName);
                     addError(CONFIG_CONFIGFILTERS, DUPLICATE_PROPERTY, ERROR);
                     return false;
                 }
@@ -1047,7 +1047,7 @@ public class FlumeConfiguration {
                     sources = value;
                     return true;
                 } else {
-                    LOGGER.warn("Duplicate source list specified for agent: {}", agentName);
+                    logger.warn("Duplicate source list specified for agent: {}", agentName);
                     addError(CONFIG_SOURCES, DUPLICATE_PROPERTY, ERROR);
                     return false;
                 }
@@ -1057,10 +1057,10 @@ public class FlumeConfiguration {
             if (CONFIG_SINKS.equals(key)) {
                 if (sinks == null) {
                     sinks = value;
-                    LOGGER.info("Added sinks: {} Agent: {}", sinks, agentName);
+                    logger.info("Added sinks: {} Agent: {}", sinks, agentName);
                     return true;
                 } else {
-                    LOGGER.warn("Duplicate sink list specfied for agent: {}", agentName);
+                    logger.warn("Duplicate sink list specfied for agent: {}", agentName);
                     addError(CONFIG_SINKS, DUPLICATE_PROPERTY, ERROR);
                     return false;
                 }
@@ -1073,7 +1073,7 @@ public class FlumeConfiguration {
 
                     return true;
                 } else {
-                    LOGGER.warn("Duplicate channel list specified for agent: {}", agentName);
+                    logger.warn("Duplicate channel list specified for agent: {}", agentName);
                     addError(CONFIG_CHANNELS, DUPLICATE_PROPERTY, ERROR);
                     return false;
                 }
@@ -1086,7 +1086,7 @@ public class FlumeConfiguration {
 
                     return true;
                 } else {
-                    LOGGER.warn("Duplicate sinkgroup list specfied for agent: {}", agentName);
+                    logger.warn("Duplicate sinkgroup list specfied for agent: {}", agentName);
                     addError(CONFIG_SINKGROUPS, DUPLICATE_PROPERTY, ERROR);
                     return false;
                 }
@@ -1100,7 +1100,7 @@ public class FlumeConfiguration {
                 return true;
             }
 
-            LOGGER.warn("Invalid property specified: {}", key);
+            logger.warn("Invalid property specified: {}", key);
             addError(key, INVALID_PROPERTY, ERROR);
             return false;
         }
@@ -1131,11 +1131,11 @@ public class FlumeConfiguration {
             ComponentNameAndConfigKey parsed = parseConfigKey(key, configPrefix);
             if (parsed != null) {
                 String name = parsed.getComponentName().trim();
-                LOGGER.info("Processing:{}", name);
+                logger.info("Processing:{}", name);
                 Context context = contextMap.get(name);
 
                 if (context == null) {
-                    LOGGER.debug("Created context for {}: {}", name, parsed.getConfigKey());
+                    logger.debug("Created context for {}: {}", name, parsed.getConfigKey());
                     context = new Context();
                     contextMap.put(name, context);
                 }

--- a/flume-ng-configuration/src/main/java/org/apache/flume/conf/LogPrivacyUtil.java
+++ b/flume-ng-configuration/src/main/java/org/apache/flume/conf/LogPrivacyUtil.java
@@ -16,8 +16,8 @@
  */
 package org.apache.flume.conf;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utility class to help any Flume component determine whether logging potentially sensitive
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * InterfaceStability.Evolving
  */
 public class LogPrivacyUtil {
-    private static final Logger logger = LoggerFactory.getLogger(LogPrivacyUtil.class);
+    private static final Logger logger = LogManager.getLogger();
     /**
      * system property name to enable logging of potentially sensitive user data
      */

--- a/flume-ng-core/pom.xml
+++ b/flume-ng-core/pom.xml
@@ -107,7 +107,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/flume-ng-core/pom.xml
+++ b/flume-ng-core/pom.xml
@@ -107,12 +107,6 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/flume-ng-core/pom.xml
+++ b/flume-ng-core/pom.xml
@@ -62,8 +62,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/flume-ng-core/src/main/java/org/apache/flume/SinkRunner.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/SinkRunner.java
@@ -19,8 +19,8 @@ package org.apache.flume;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.flume.lifecycle.LifecycleAware;
 import org.apache.flume.lifecycle.LifecycleState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SinkRunner implements LifecycleAware {
 
-    private static final Logger logger = LoggerFactory.getLogger(SinkRunner.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final long backoffSleepIncrement = 1000;
     private static final long maxBackoffSleep = 5000;
 

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/ChannelProcessor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/ChannelProcessor.java
@@ -33,8 +33,8 @@ import org.apache.flume.exception.ChannelException;
 import org.apache.flume.interceptor.Interceptor;
 import org.apache.flume.interceptor.InterceptorBuilderFactory;
 import org.apache.flume.interceptor.InterceptorChain;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A channel processor exposes operations to put {@link Event}s into
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ChannelProcessor implements Configurable {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ChannelProcessor.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final ChannelSelector selector;
     private final InterceptorChain interceptorChain;
@@ -96,7 +96,7 @@ public class ChannelProcessor implements Configurable {
             Context interceptorContext = new Context(interceptorContexts.getSubProperties(interceptorName + "."));
             String type = interceptorContext.getString("type");
             if (type == null) {
-                LOG.error("Type not specified for interceptor " + interceptorName);
+                logger.error("Type not specified for interceptor " + interceptorName);
                 throw new FlumeException("Interceptor.Type not specified for " + interceptorName);
             }
             try {
@@ -104,13 +104,13 @@ public class ChannelProcessor implements Configurable {
                 builder.configure(interceptorContext);
                 interceptors.add(builder.build());
             } catch (ClassNotFoundException e) {
-                LOG.error("Builder class not found. Exception follows.", e);
+                logger.error("Builder class not found. Exception follows.", e);
                 throw new FlumeException("Interceptor.Builder not found.", e);
             } catch (InstantiationException e) {
-                LOG.error("Could not instantiate Builder. Exception follows.", e);
+                logger.error("Could not instantiate Builder. Exception follows.", e);
                 throw new FlumeException("Interceptor.Builder not constructable.", e);
             } catch (IllegalAccessException e) {
-                LOG.error("Unable to access Builder. Exception follows.", e);
+                logger.error("Unable to access Builder. Exception follows.", e);
                 throw new FlumeException("Unable to access Interceptor.Builder.", e);
             }
         }
@@ -185,7 +185,7 @@ public class ChannelProcessor implements Configurable {
             } catch (Throwable t) {
                 tx.rollback();
                 if (t instanceof Error) {
-                    LOG.error("Error while writing to required channel: " + reqChannel, t);
+                    logger.error("Error while writing to required channel: " + reqChannel, t);
                     throw (Error) t;
                 } else if (t instanceof ChannelException) {
                     throw (ChannelException) t;
@@ -215,7 +215,7 @@ public class ChannelProcessor implements Configurable {
                 tx.commit();
             } catch (Throwable t) {
                 tx.rollback();
-                LOG.error("Unable to put batch on optional channel: " + optChannel, t);
+                logger.error("Unable to put batch on optional channel: " + optChannel, t);
                 if (t instanceof Error) {
                     throw (Error) t;
                 }
@@ -260,7 +260,7 @@ public class ChannelProcessor implements Configurable {
             } catch (Throwable t) {
                 tx.rollback();
                 if (t instanceof Error) {
-                    LOG.error("Error while writing to required channel: " + reqChannel, t);
+                    logger.error("Error while writing to required channel: " + reqChannel, t);
                     throw (Error) t;
                 } else if (t instanceof ChannelException) {
                     throw (ChannelException) t;
@@ -287,7 +287,7 @@ public class ChannelProcessor implements Configurable {
                 tx.commit();
             } catch (Throwable t) {
                 tx.rollback();
-                LOG.error("Unable to put event on optional channel: " + optChannel, t);
+                logger.error("Unable to put event on optional channel: " + optChannel, t);
                 if (t instanceof Error) {
                     throw (Error) t;
                 }

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/ChannelSelectorFactory.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/ChannelSelectorFactory.java
@@ -27,12 +27,12 @@ import org.apache.flume.conf.BasicConfigurationConstants;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.conf.channel.ChannelSelectorConfiguration;
 import org.apache.flume.conf.channel.ChannelSelectorType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class ChannelSelectorFactory {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ChannelSelectorFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static ChannelSelector create(List<Channel> channels, Map<String, String> config) {
 
@@ -69,7 +69,7 @@ public class ChannelSelectorFactory {
         try {
             selectorType = ChannelSelectorType.valueOf(type.toUpperCase(Locale.ENGLISH));
         } catch (IllegalArgumentException ex) {
-            LOGGER.debug("Selector type {} is a custom type", type);
+            logger.debug("Selector type {} is a custom type", type);
         }
 
         if (!selectorType.equals(ChannelSelectorType.OTHER)) {

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/ChannelUtils.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/ChannelUtils.java
@@ -25,8 +25,8 @@ import org.apache.flume.Channel;
 import org.apache.flume.Event;
 import org.apache.flume.Transaction;
 import org.apache.flume.exception.ChannelException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ChannelUtils {
 
-    private static final Logger logger = LoggerFactory.getLogger(ChannelUtils.class);
+    private static final Logger logger = LogManager.getLogger();
 
     /**
      * <p>

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/DefaultChannelFactory.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/DefaultChannelFactory.java
@@ -22,12 +22,12 @@ import org.apache.flume.Channel;
 import org.apache.flume.ChannelFactory;
 import org.apache.flume.FlumeException;
 import org.apache.flume.conf.channel.ChannelType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DefaultChannelFactory implements ChannelFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultChannelFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     @Override
     public Channel create(String name, String type) throws FlumeException {

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
@@ -31,8 +31,8 @@ import org.apache.flume.conf.TransactionCapacitySupported;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.exception.ChannelFullException;
 import org.apache.flume.instrumentation.ChannelCounter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Stable
 @Recyclable
 public class MemoryChannel extends BasicChannelSemantics implements TransactionCapacitySupported {
-    private static Logger LOGGER = LoggerFactory.getLogger(MemoryChannel.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final Integer defaultCapacity = 100;
     private static final Integer defaultTransCapacity = 100;
     private static final double byteCapacitySlotSize = 100;
@@ -225,27 +225,27 @@ public class MemoryChannel extends BasicChannelSemantics implements TransactionC
             capacity = context.getInteger("capacity", defaultCapacity);
         } catch (NumberFormatException e) {
             capacity = defaultCapacity;
-            LOGGER.warn(
+            logger.warn(
                     "Invalid capacity specified, initializing channel to " + "default capacity of {}", defaultCapacity);
         }
 
         if (capacity <= 0) {
             capacity = defaultCapacity;
-            LOGGER.warn(
+            logger.warn(
                     "Invalid capacity specified, initializing channel to " + "default capacity of {}", defaultCapacity);
         }
         try {
             transCapacity = context.getInteger("transactionCapacity", defaultTransCapacity);
         } catch (NumberFormatException e) {
             transCapacity = defaultTransCapacity;
-            LOGGER.warn(
+            logger.warn(
                     "Invalid transation capacity specified, initializing channel" + " to default capacity of {}",
                     defaultTransCapacity);
         }
 
         if (transCapacity <= 0) {
             transCapacity = defaultTransCapacity;
-            LOGGER.warn(
+            logger.warn(
                     "Invalid transation capacity specified, initializing channel" + " to default capacity of {}",
                     defaultTransCapacity);
         }
@@ -303,7 +303,7 @@ public class MemoryChannel extends BasicChannelSemantics implements TransactionC
             } else {
                 try {
                     if (!bytesRemaining.tryAcquire(lastByteCapacity - byteCapacity, keepAlive, TimeUnit.SECONDS)) {
-                        LOGGER.warn(
+                        logger.warn(
                                 "Couldn't acquire permits to downsize the byte capacity, resizing has been aborted");
                     } else {
                         lastByteCapacity = byteCapacity;
@@ -329,7 +329,7 @@ public class MemoryChannel extends BasicChannelSemantics implements TransactionC
             return;
         } else if (oldCapacity > capacity) {
             if (!queueRemaining.tryAcquire(oldCapacity - capacity, keepAlive, TimeUnit.SECONDS)) {
-                LOGGER.warn("Couldn't acquire permits to downsize the queue, resizing has been aborted");
+                logger.warn("Couldn't acquire permits to downsize the queue, resizing has been aborted");
             } else {
                 synchronized (queueLock) {
                     LinkedBlockingDeque<Event> newQueue = new LinkedBlockingDeque<Event>(capacity);

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MultiplexingChannelSelector.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MultiplexingChannelSelector.java
@@ -24,8 +24,6 @@ import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.FlumeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MultiplexingChannelSelector extends AbstractChannelSelector {
 
@@ -34,9 +32,6 @@ public class MultiplexingChannelSelector extends AbstractChannelSelector {
     public static final String CONFIG_PREFIX_MAPPING = "mapping.";
     public static final String CONFIG_DEFAULT_CHANNEL = "default";
     public static final String CONFIG_PREFIX_OPTIONAL = "optional";
-
-    @SuppressWarnings("unused")
-    private static final Logger LOG = LoggerFactory.getLogger(MultiplexingChannelSelector.class);
 
     private static final List<Channel> EMPTY_LIST = Collections.emptyList();
 

--- a/flume-ng-core/src/main/java/org/apache/flume/event/EventHelper.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/event/EventHelper.java
@@ -20,8 +20,8 @@ import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 import org.apache.commons.io.HexDump;
 import org.apache.flume.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class EventHelper {
 
@@ -29,7 +29,7 @@ public class EventHelper {
     private static final String EOL = System.getProperty("line.separator", "\n");
     private static final int DEFAULT_MAX_BYTES = 16;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EventHelper.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static String dumpEvent(Event event) {
         return dumpEvent(event, DEFAULT_MAX_BYTES);
@@ -54,8 +54,8 @@ public class EventHelper {
                 }
                 buffer.append(hexDump);
             } catch (Exception e) {
-                if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info("Exception while dumping event", e);
+                if (logger.isInfoEnabled()) {
+                    logger.info("Exception while dumping event", e);
                 }
                 buffer.append("...Exception while dumping: ").append(e.getMessage());
             }

--- a/flume-ng-core/src/main/java/org/apache/flume/formatter/output/PathManagerFactory.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/formatter/output/PathManagerFactory.java
@@ -20,14 +20,14 @@ import com.google.common.base.Preconditions;
 import java.util.Locale;
 import org.apache.flume.Context;
 import org.apache.flume.FlumeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Create PathManager instances.
  */
 public class PathManagerFactory {
-    private static final Logger logger = LoggerFactory.getLogger(PathManagerFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static PathManager getInstance(String managerType, Context context) {
 

--- a/flume-ng-core/src/main/java/org/apache/flume/instrumentation/util/JMXPollUtil.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/instrumentation/util/JMXPollUtil.java
@@ -26,15 +26,15 @@ import javax.management.AttributeList;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanServer;
 import javax.management.ObjectInstance;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  *
  */
 public class JMXPollUtil {
 
-    private static Logger LOG = LoggerFactory.getLogger(JMXPollUtil.class);
+    private static final Logger logger = LogManager.getLogger();
     private static MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
 
     public static Map<String, Map<String, String>> getAllMBeans() {
@@ -43,7 +43,7 @@ public class JMXPollUtil {
         try {
             queryMBeans = mbeanServer.queryMBeans(null, null);
         } catch (Exception ex) {
-            LOG.error("Could not get Mbeans for monitoring", ex);
+            logger.error("Could not get Mbeans for monitoring", ex);
             Throwables.propagate(ex);
         }
         for (ObjectInstance obj : queryMBeans) {
@@ -72,7 +72,7 @@ public class JMXPollUtil {
                 }
                 mbeanMap.put(component, attrMap);
             } catch (Exception e) {
-                LOG.error("Unable to poll JMX for metrics.", e);
+                logger.error("Unable to poll JMX for metrics.", e);
             }
         }
         return mbeanMap;

--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/HostInterceptor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/HostInterceptor.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Simple Interceptor class that sets the host name or IP on all events
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HostInterceptor implements Interceptor {
 
-    private static final Logger logger = LoggerFactory.getLogger(HostInterceptor.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final boolean preserveExisting;
     private final String header;

--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/InterceptorType.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/InterceptorType.java
@@ -17,13 +17,13 @@
 package org.apache.flume.interceptor;
 
 public enum InterceptorType {
-    TIMESTAMP(org.apache.flume.interceptor.TimestampInterceptor.Builder.class),
-    HOST(org.apache.flume.interceptor.HostInterceptor.Builder.class),
-    STATIC(org.apache.flume.interceptor.StaticInterceptor.Builder.class),
-    REGEX_FILTER(org.apache.flume.interceptor.RegexFilteringInterceptor.Builder.class),
-    REGEX_EXTRACTOR(org.apache.flume.interceptor.RegexExtractorInterceptor.Builder.class),
-    REMOVE_HEADER(org.apache.flume.interceptor.RemoveHeaderInterceptor.Builder.class),
-    SEARCH_REPLACE(org.apache.flume.interceptor.SearchAndReplaceInterceptor.Builder.class);
+    TIMESTAMP(TimestampInterceptor.Builder.class),
+    HOST(HostInterceptor.Builder.class),
+    STATIC(StaticInterceptor.Builder.class),
+    REGEX_FILTER(RegexFilteringInterceptor.Builder.class),
+    REGEX_EXTRACTOR(RegexExtractorInterceptor.Builder.class),
+    REMOVE_HEADER(RemoveHeaderInterceptor.Builder.class),
+    SEARCH_REPLACE(SearchAndReplaceInterceptor.Builder.class);
 
     private final Class<? extends Interceptor.Builder> builderClass;
 

--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/RegexExtractorInterceptor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/RegexExtractorInterceptor.java
@@ -27,8 +27,8 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Interceptor that extracts matches using a specified regular expression and
@@ -99,7 +99,7 @@ public class RegexExtractorInterceptor implements Interceptor {
     static final String REGEX = "regex";
     static final String SERIALIZERS = "serializers";
 
-    private static final Logger logger = LoggerFactory.getLogger(RegexExtractorInterceptor.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final Pattern regex;
     private final List<NameAndSerializer> serializers;

--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/RegexFilteringInterceptor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/RegexFilteringInterceptor.java
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Interceptor that filters events selectively based on a configured regular
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RegexFilteringInterceptor implements Interceptor {
 
-    private static final Logger logger = LoggerFactory.getLogger(RegexFilteringInterceptor.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final Pattern regex;
     private final boolean excludeEvents;

--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/RemoveHeaderInterceptor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/RemoveHeaderInterceptor.java
@@ -28,8 +28,8 @@ import java.util.regex.Pattern;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.conf.LogPrivacyUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This interceptor manipulates Flume event headers, by removing one or many
@@ -54,7 +54,7 @@ public class RemoveHeaderInterceptor implements Interceptor {
     static final String LIST_SEPARATOR = "fromListSeparator";
     static final String LIST_SEPARATOR_DEFAULT = "\\s*,\\s*";
     static final String MATCH_REGEX = "matching";
-    private static final Logger LOG = LoggerFactory.getLogger(RemoveHeaderInterceptor.class);
+    private static final Logger logger = LogManager.getLogger();
     private final String withName;
     private final Set<String> fromList;
     private final Pattern matchRegex;
@@ -107,7 +107,7 @@ public class RemoveHeaderInterceptor implements Interceptor {
             final Map<String, String> headers = event.getHeaders();
             // If withName matches, removing it directly
             if (withName != null && headers.remove(withName) != null) {
-                LOG.trace("Removed header \"{}\" for event: {}", withName, event);
+                logger.trace("Removed header \"{}\" for event: {}", withName, event);
             }
             // Also, we need to go through the list
             if (fromList != null || matchRegex != null) {
@@ -127,11 +127,11 @@ public class RemoveHeaderInterceptor implements Interceptor {
                     }
                 }
                 if (!removedHeaders.isEmpty() && LogPrivacyUtil.allowLogRawData()) {
-                    LOG.trace("Removed headers \"{}\" for event: {}", removedHeaders, event);
+                    logger.trace("Removed headers \"{}\" for event: {}", removedHeaders, event);
                 }
             }
         } catch (final Exception e) {
-            LOG.error("Failed to process event " + event, e);
+            logger.error("Failed to process event " + event, e);
         }
         return event;
     }
@@ -150,8 +150,8 @@ public class RemoveHeaderInterceptor implements Interceptor {
          */
         @Override
         public Interceptor build() {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(
+            if (logger.isDebugEnabled()) {
+                logger.debug(
                         "Creating RemoveHeaderInterceptor with: withName={}, fromList={}, "
                                 + "listSeparator={}, matchRegex={}",
                         new String[] {withName, fromList, listSeparator, String.valueOf(matchRegex)});

--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/SearchAndReplaceInterceptor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/SearchAndReplaceInterceptor.java
@@ -25,8 +25,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -45,8 +43,6 @@ import org.slf4j.LoggerFactory;
  * including backtracking and grouping.
  */
 public class SearchAndReplaceInterceptor implements Interceptor {
-
-    private static final Logger logger = LoggerFactory.getLogger(SearchAndReplaceInterceptor.class);
 
     private final Pattern searchPattern;
     private final String replaceString;

--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/StaticInterceptor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/StaticInterceptor.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.Map;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Interceptor class that appends a static, pre-configured header to all events.
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StaticInterceptor implements Interceptor {
 
-    private static final Logger logger = LoggerFactory.getLogger(StaticInterceptor.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final boolean preserveExisting;
     private final String key;

--- a/flume-ng-core/src/main/java/org/apache/flume/lifecycle/LifecycleController.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/lifecycle/LifecycleController.java
@@ -17,12 +17,12 @@
 package org.apache.flume.lifecycle;
 
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class LifecycleController {
 
-    private static final Logger logger = LoggerFactory.getLogger(LifecycleController.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final long shortestSleepDuration = 50;
     private static final int maxNumberOfChecks = 5;
 

--- a/flume-ng-core/src/main/java/org/apache/flume/lifecycle/LifecycleSupervisor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/lifecycle/LifecycleSupervisor.java
@@ -26,12 +26,12 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.flume.FlumeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class LifecycleSupervisor implements LifecycleAware {
 
-    private static final Logger logger = LoggerFactory.getLogger(LifecycleSupervisor.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private Map<LifecycleAware, Supervisoree> supervisedProcesses;
     private Map<LifecycleAware, ScheduledFuture<?>> monitorFutures;

--- a/flume-ng-core/src/main/java/org/apache/flume/serialization/BodyTextEventSerializer.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/serialization/BodyTextEventSerializer.java
@@ -20,16 +20,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class simply writes the body of the event to the output stream
  * and appends a newline after each event.
  */
 public class BodyTextEventSerializer implements EventSerializer {
-
-    private static final Logger logger = LoggerFactory.getLogger(BodyTextEventSerializer.class);
 
     // for legacy reasons, by default, append a newline to each event written out
     private final String APPEND_NEWLINE = "appendNewline";

--- a/flume-ng-core/src/main/java/org/apache/flume/serialization/EventDeserializerFactory.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/serialization/EventDeserializerFactory.java
@@ -22,14 +22,14 @@ import org.apache.flume.Context;
 import org.apache.flume.FlumeException;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @InterfaceAudience.Private
 @InterfaceStability.Stable
 public class EventDeserializerFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(EventDeserializerFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static EventDeserializer getInstance(String deserializerType, Context context, ResettableInputStream in) {
 

--- a/flume-ng-core/src/main/java/org/apache/flume/serialization/EventSerializerFactory.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/serialization/EventSerializerFactory.java
@@ -23,14 +23,14 @@ import org.apache.flume.Context;
 import org.apache.flume.FlumeException;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @InterfaceAudience.Private
 @InterfaceStability.Stable
 public class EventSerializerFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(EventSerializerFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static EventSerializer getInstance(String serializerType, Context context, OutputStream out) {
 

--- a/flume-ng-core/src/main/java/org/apache/flume/serialization/HeaderAndBodyTextEventSerializer.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/serialization/HeaderAndBodyTextEventSerializer.java
@@ -20,16 +20,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class simply writes the body of the event to the output stream
  * and appends a newline after each event.
  */
 public class HeaderAndBodyTextEventSerializer implements EventSerializer {
-
-    private static final Logger logger = LoggerFactory.getLogger(HeaderAndBodyTextEventSerializer.class);
 
     // for legacy reasons, by default, append a newline to each event written out
     private final String APPEND_NEWLINE = "appendNewline";

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/AbstractRpcSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/AbstractRpcSink.java
@@ -40,8 +40,8 @@ import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.instrumentation.SinkCounter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This sink provides the basic RPC functionality for Flume. This sink takes
@@ -139,7 +139,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractRpcSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractRpcSink.class);
+    private static final Logger logger = LogManager.getLogger();
     private String hostname;
     private Integer port;
     private RpcClient client;

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/DefaultSinkFactory.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/DefaultSinkFactory.java
@@ -22,12 +22,12 @@ import org.apache.flume.FlumeException;
 import org.apache.flume.Sink;
 import org.apache.flume.SinkFactory;
 import org.apache.flume.conf.sink.SinkType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DefaultSinkFactory implements SinkFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultSinkFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     @Override
     public Sink create(String name, String type) throws FlumeException {

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/FailoverSinkProcessor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/FailoverSinkProcessor.java
@@ -28,8 +28,8 @@ import org.apache.flume.Context;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Sink;
 import org.apache.flume.Sink.Status;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * FailoverSinkProcessor maintains a prioritized list of sinks,
@@ -106,7 +106,7 @@ public class FailoverSinkProcessor extends AbstractSinkProcessor {
         }
     }
 
-    private static final Logger logger = LoggerFactory.getLogger(FailoverSinkProcessor.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static final String PRIORITY_PREFIX = "priority.";
     private static final String MAX_PENALTY_PREFIX = "maxpenalty";

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/LoadBalancingSinkProcessor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/LoadBalancingSinkProcessor.java
@@ -29,8 +29,8 @@ import org.apache.flume.lifecycle.LifecycleAware;
 import org.apache.flume.util.OrderSelector;
 import org.apache.flume.util.RandomOrderSelector;
 import org.apache.flume.util.RoundRobinOrderSelector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>Provides the ability to load-balance flow over multiple sinks.</p>
@@ -85,7 +85,7 @@ public class LoadBalancingSinkProcessor extends AbstractSinkProcessor {
     public static final String SELECTOR_NAME_ROUND_ROBIN_BACKOFF = "ROUND_ROBIN_BACKOFF";
     public static final String SELECTOR_NAME_RANDOM_BACKOFF = "RANDOM_BACKOFF";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoadBalancingSinkProcessor.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private SinkSelector selector;
 
@@ -120,7 +120,7 @@ public class LoadBalancingSinkProcessor extends AbstractSinkProcessor {
         selector.setSinks(getSinks());
         selector.configure(new Context(context.getSubProperties(CONFIG_SELECTOR_PREFIX)));
 
-        LOGGER.debug("Sink selector: " + selector + " initialized");
+        logger.debug("Sink selector: " + selector + " initialized");
     }
 
     @Override
@@ -149,7 +149,7 @@ public class LoadBalancingSinkProcessor extends AbstractSinkProcessor {
                 break;
             } catch (Exception ex) {
                 selector.informSinkFailed(sink);
-                LOGGER.warn("Sink failed to consume event. " + "Attempting next sink if available.", ex);
+                logger.warn("Sink failed to consume event. " + "Attempting next sink if available.", ex);
             }
         }
 

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/LoggerSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/LoggerSink.java
@@ -24,8 +24,8 @@ import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Transaction;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.event.EventHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LoggerSink extends AbstractSink implements Configurable {
 
-    private static final Logger logger = LoggerFactory.getLogger(LoggerSink.class);
+    private static final Logger logger = LogManager.getLogger();
 
     // Default Max bytes to dump
     public static final int DEFAULT_MAX_BYTE_DUMP = 16;

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/NullSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/NullSink.java
@@ -26,8 +26,8 @@ import org.apache.flume.Sink;
 import org.apache.flume.Transaction;
 import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NullSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
-    private static final Logger logger = LoggerFactory.getLogger(NullSink.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static final int DFLT_BATCH_SIZE = 100;
     private static final int DFLT_LOG_EVERY_N_EVENTS = 10000;

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/RollingFileSink.java
@@ -38,12 +38,12 @@ import org.apache.flume.formatter.output.PathManagerFactory;
 import org.apache.flume.instrumentation.SinkCounter;
 import org.apache.flume.serialization.EventSerializer;
 import org.apache.flume.serialization.EventSerializerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class RollingFileSink extends AbstractSink implements Configurable, BatchSizeSupported {
 
-    private static final Logger logger = LoggerFactory.getLogger(RollingFileSink.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final long defaultRollInterval = 30;
     private static final int defaultBatchSize = 100;
 

--- a/flume-ng-core/src/main/java/org/apache/flume/sink/SinkProcessorFactory.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/sink/SinkProcessorFactory.java
@@ -27,11 +27,11 @@ import org.apache.flume.SinkProcessor;
 import org.apache.flume.conf.ComponentConfiguration;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.conf.sink.SinkProcessorType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class SinkProcessorFactory {
-    private static final Logger logger = LoggerFactory.getLogger(SinkProcessorFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static final String TYPE = "type";
 

--- a/flume-ng-core/src/main/java/org/apache/flume/source/BasicSourceSemantics.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/BasicSourceSemantics.java
@@ -26,8 +26,8 @@ import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.channel.ChannelProcessor;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.lifecycle.LifecycleState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Alternative to AbstractSource, which:
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
 public abstract class BasicSourceSemantics implements Source, Configurable {
-    private static final Logger logger = LoggerFactory.getLogger(BasicSourceSemantics.class);
+    private static final Logger logger = LogManager.getLogger();
     private Exception exception;
     private ChannelProcessor channelProcessor;
     private String name;

--- a/flume-ng-core/src/main/java/org/apache/flume/source/DefaultSourceFactory.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/DefaultSourceFactory.java
@@ -22,12 +22,12 @@ import org.apache.flume.FlumeException;
 import org.apache.flume.Source;
 import org.apache.flume.SourceFactory;
 import org.apache.flume.conf.source.SourceType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DefaultSourceFactory implements SourceFactory {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultSourceFactory.class);
+    private static final Logger logger = LogManager.getLogger();
 
     @Override
     public Source create(String name, String type) throws FlumeException {

--- a/flume-ng-core/src/main/java/org/apache/flume/source/ExecSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/ExecSource.java
@@ -41,8 +41,8 @@ import org.apache.flume.conf.BatchSizeSupported;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.instrumentation.SourceCounter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -143,7 +143,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExecSource extends AbstractSource implements EventDrivenSource, Configurable, BatchSizeSupported {
 
-    private static final Logger logger = LoggerFactory.getLogger(ExecSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private String shell;
     private String command;

--- a/flume-ng-core/src/main/java/org/apache/flume/source/NetcatSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/NetcatSource.java
@@ -43,8 +43,8 @@ import org.apache.flume.conf.Configurable;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.exception.ChannelException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -100,7 +100,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NetcatSource extends AbstractSource implements Configurable, EventDrivenSource {
 
-    private static final Logger logger = LoggerFactory.getLogger(NetcatSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private String hostName;
     private int port;

--- a/flume-ng-core/src/main/java/org/apache/flume/source/PollableSourceRunner.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/PollableSourceRunner.java
@@ -24,8 +24,8 @@ import org.apache.flume.Source;
 import org.apache.flume.SourceRunner;
 import org.apache.flume.channel.ChannelProcessor;
 import org.apache.flume.lifecycle.LifecycleState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PollableSourceRunner extends SourceRunner {
 
-    private static final Logger logger = LoggerFactory.getLogger(PollableSourceRunner.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private AtomicBoolean shouldStop;
 

--- a/flume-ng-core/src/main/java/org/apache/flume/source/SequenceGeneratorSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/SequenceGeneratorSource.java
@@ -28,12 +28,12 @@ import org.apache.flume.conf.Configurable;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.instrumentation.SourceCounter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class SequenceGeneratorSource extends AbstractPollableSource implements Configurable, BatchSizeSupported {
 
-    private static final Logger logger = LoggerFactory.getLogger(SequenceGeneratorSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private int batchSize;
     private SourceCounter sourceCounter;

--- a/flume-ng-core/src/main/java/org/apache/flume/source/StressSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/StressSource.java
@@ -29,8 +29,8 @@ import org.apache.flume.conf.Configurable;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.source.shaded.guava.RateLimiter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * StressSource is an internal load-generating source implementation
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StressSource extends AbstractPollableSource implements Configurable, BatchSizeSupported {
 
-    private static final Logger logger = LoggerFactory.getLogger(StressSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private CounterGroup counterGroup;
     private byte[] buffer;

--- a/flume-ng-core/src/main/java/org/apache/flume/tools/DirectMemoryUtils.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/tools/DirectMemoryUtils.java
@@ -106,7 +106,8 @@ public class DirectMemoryUtils {
                 return (Long) result;
             }
         } catch (Exception e) {
-            logger.info("Unable to get maxDirectMemory from VM: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            logger.info(
+                    "Unable to get maxDirectMemory from VM: " + e.getClass().getSimpleName() + ": " + e.getMessage());
         }
         // default according to VM.maxDirectMemory()
         return Runtime.getRuntime().maxMemory();

--- a/flume-ng-core/src/main/java/org/apache/flume/tools/DirectMemoryUtils.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/tools/DirectMemoryUtils.java
@@ -25,12 +25,12 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DirectMemoryUtils {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DirectMemoryUtils.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final String MAX_DIRECT_MEMORY_PARAM = "-XX:MaxDirectMemorySize=";
     private static final long DEFAULT_SIZE = getDefaultDirectMemorySize();
     private static final AtomicInteger allocated = new AtomicInteger(0);
@@ -39,7 +39,7 @@ public class DirectMemoryUtils {
         Preconditions.checkArgument(size > 0, "Size must be greater than zero");
         long maxDirectMemory = getDirectMemorySize();
         long allocatedCurrently = allocated.get();
-        LOG.info("Direct Memory Allocation: " + " Allocation = "
+        logger.info("Direct Memory Allocation: " + " Allocation = "
                 + size + ", Allocated = "
                 + allocatedCurrently + ", MaxDirectMemorySize = "
                 + maxDirectMemory + ", Remaining = "
@@ -49,7 +49,7 @@ public class DirectMemoryUtils {
             allocated.addAndGet(size);
             return result;
         } catch (OutOfMemoryError error) {
-            LOG.error(
+            logger.error(
                     "Error allocating " + size + ", you likely want" + " to increase " + MAX_DIRECT_MEMORY_PARAM,
                     error);
             throw error;
@@ -66,7 +66,7 @@ public class DirectMemoryUtils {
         cleanMethod.invoke(cleaner);
         allocated.getAndAdd(-buffer.capacity());
         long maxDirectMemory = getDirectMemorySize();
-        LOG.info("Direct Memory Deallocation: " + ", Allocated = "
+        logger.info("Direct Memory Deallocation: " + ", Allocated = "
                 + allocated.get() + ", MaxDirectMemorySize = "
                 + maxDirectMemory + ", Remaining = "
                 + Math.max(0, (maxDirectMemory - allocated.get())));
@@ -106,7 +106,7 @@ public class DirectMemoryUtils {
                 return (Long) result;
             }
         } catch (Exception e) {
-            LOG.info("Unable to get maxDirectMemory from VM: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            logger.info("Unable to get maxDirectMemory from VM: " + e.getClass().getSimpleName() + ": " + e.getMessage());
         }
         // default according to VM.maxDirectMemory()
         return Runtime.getRuntime().maxMemory();

--- a/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestCensoringInterceptor.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestCensoringInterceptor.java
@@ -31,12 +31,8 @@ import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.event.EventBuilder;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestCensoringInterceptor {
-
-    Logger logger = LoggerFactory.getLogger(TestCensoringInterceptor.class);
 
     @Test
     public void testCensor() {

--- a/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestSearchAndReplaceInterceptor.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestSearchAndReplaceInterceptor.java
@@ -22,13 +22,13 @@ import com.google.common.base.Charsets;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.event.EventBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestSearchAndReplaceInterceptor {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestSearchAndReplaceInterceptor.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private void testSearchReplace(Context context, String input, String output) throws Exception {
         Interceptor.Builder builder = InterceptorBuilderFactory.newInstance(InterceptorType.SEARCH_REPLACE.toString());

--- a/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/sink/TestRollingFileSink.java
@@ -33,17 +33,17 @@ import org.apache.flume.event.SimpleEvent;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.instrumentation.SinkCounter;
 import org.apache.flume.util.Whitebox;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestRollingFileSink {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestRollingFileSink.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private File tmpDir;
     private RollingFileSink sink;

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestNetcatSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestNetcatSource.java
@@ -41,14 +41,14 @@ import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.lifecycle.LifecycleController;
 import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestNetcatSource {
-    private static final Logger logger = LoggerFactory.getLogger(TestNetcatSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static int getFreePort() {
         try (ServerSocket socket = new ServerSocket(0)) {

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestPollableSourceRunner.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestPollableSourceRunner.java
@@ -31,14 +31,14 @@ import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestPollableSourceRunner {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestPollableSourceRunner.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private PollableSourceRunner sourceRunner;
 

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestSequenceGeneratorSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestSequenceGeneratorSource.java
@@ -45,7 +45,7 @@ public class TestSequenceGeneratorSource {
     }
 
     @Test
-    public void testLifecycle() throws org.apache.flume.EventDeliveryException {
+    public void testLifecycle() throws EventDeliveryException {
         final int DOPROCESS_LOOPS = 5;
         Context context = new Context();
         Configurables.configure(source, context);

--- a/flume-ng-core/src/test/java/org/apache/flume/tools/TestVersionInfo.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/tools/TestVersionInfo.java
@@ -18,13 +18,13 @@ package org.apache.flume.tools;
 
 import static org.junit.Assert.*;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestVersionInfo {
 
-    private static final Logger logger = LoggerFactory.getLogger(TestVersionInfo.class);
+    private static final Logger logger = LogManager.getLogger();
 
     /**
      *  Make sure that Unknown is expected when no version info

--- a/flume-ng-dist/pom.xml
+++ b/flume-ng-dist/pom.xml
@@ -207,10 +207,6 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/flume-ng-dist/pom.xml
+++ b/flume-ng-dist/pom.xml
@@ -205,7 +205,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
   </dependencies>
 

--- a/flume-ng-instrumentation/flume-ganglia-monitor/src/main/java/org/apache/flume/instrumentation/ganglia/GangliaServer.java
+++ b/flume-ng-instrumentation/flume-ganglia-monitor/src/main/java/org/apache/flume/instrumentation/ganglia/GangliaServer.java
@@ -34,8 +34,8 @@ import org.apache.flume.api.HostInfo;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.instrumentation.MonitorService;
 import org.apache.flume.instrumentation.util.JMXPollUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A Ganglia server that polls JMX based at a configured frequency (defaults to
@@ -59,7 +59,7 @@ public class GangliaServer implements MonitorService {
      * from Hadoop. All hail the yellow elephant!
      */
 
-    private static final Logger logger = LoggerFactory.getLogger(GangliaServer.class);
+    private static final Logger logger = LogManager.getLogger();
     public static final int BUFFER_SIZE = 1500; // as per libgmond.c
     protected byte[] buffer = new byte[BUFFER_SIZE];
     protected int offset;

--- a/flume-ng-instrumentation/flume-http-monitor/src/main/java/org/apache/flume/instrumentation/http/HTTPMetricsServer.java
+++ b/flume-ng-instrumentation/flume-http-monitor/src/main/java/org/apache/flume/instrumentation/http/HTTPMetricsServer.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import org.apache.flume.Context;
 import org.apache.flume.instrumentation.MonitorService;
 import org.apache.flume.instrumentation.util.JMXPollUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -33,8 +35,6 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.Callback;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A Monitor service implementation that runs a web server on a configurable
@@ -50,7 +50,7 @@ public class HTTPMetricsServer implements MonitorService {
 
     private Server jettyServer;
     private int port;
-    private static Logger LOG = LoggerFactory.getLogger(HTTPMetricsServer.class);
+    private static final Logger logger = LogManager.getLogger();
     private static int DEFAULT_PORT = 41414;
     public static String CONFIG_PORT = "port";
 
@@ -76,7 +76,7 @@ public class HTTPMetricsServer implements MonitorService {
                 Thread.sleep(500);
             }
         } catch (Exception ex) {
-            LOG.error("Error starting Jetty. JSON Metrics may not be available.", ex);
+            logger.error("Error starting Jetty. JSON Metrics may not be available.", ex);
         }
     }
 
@@ -86,7 +86,7 @@ public class HTTPMetricsServer implements MonitorService {
             jettyServer.stop();
             jettyServer.join();
         } catch (Exception ex) {
-            LOG.error("Error stopping Jetty. JSON Metrics may not be available.", ex);
+            logger.error("Error stopping Jetty. JSON Metrics may not be available.", ex);
         }
     }
 

--- a/flume-ng-instrumentation/flume-prometheus-monitor/src/main/java/org/apache/flume/instrumentation/prometheus/PrometheusHTTPMetricsServer.java
+++ b/flume-ng-instrumentation/flume-prometheus-monitor/src/main/java/org/apache/flume/instrumentation/prometheus/PrometheusHTTPMetricsServer.java
@@ -38,14 +38,14 @@ import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import org.apache.flume.instrumentation.http.HTTPMetricsServer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A Monitor service implementation that runs a web server on a configurable
@@ -57,7 +57,7 @@ public class PrometheusHTTPMetricsServer extends HTTPMetricsServer {
 
     private static final String PROM_DEFAULT_PREFIX = "Flume_";
     private Server jettyServer;
-    private static Logger LOG = LoggerFactory.getLogger(PrometheusHTTPMetricsServer.class);
+    private static final Logger logger = LogManager.getLogger();
     private static MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
 
     private FlumePrometheusCollector metricsCollector;
@@ -91,7 +91,7 @@ public class PrometheusHTTPMetricsServer extends HTTPMetricsServer {
                 Thread.sleep(500);
             }
         } catch (Exception ex) {
-            LOG.error("Error starting Jetty. Prometheus Metrics may not be available.", ex);
+            logger.error("Error starting Jetty. Prometheus Metrics may not be available.", ex);
         }
     }
 
@@ -120,12 +120,12 @@ public class PrometheusHTTPMetricsServer extends HTTPMetricsServer {
                         }
 
                     } catch (Exception e) {
-                        LOG.error("Unable to poll JMX for metrics.", e);
+                        logger.error("Unable to poll JMX for metrics.", e);
                     }
                 }
 
             } catch (Exception ex) {
-                LOG.error("Could not get Mbeans for monitoring", ex);
+                logger.error("Could not get Mbeans for monitoring", ex);
                 Throwables.propagate(ex);
             }
         }
@@ -224,7 +224,7 @@ public class PrometheusHTTPMetricsServer extends HTTPMetricsServer {
                                 .set(value);
                     }
                 } catch (Exception e) {
-                    LOG.warn("Metric {} could not be monitored", metricKey, e);
+                    logger.warn("Metric {} could not be monitored", metricKey, e);
                 }
             }
         }
@@ -263,7 +263,7 @@ public class PrometheusHTTPMetricsServer extends HTTPMetricsServer {
             jettyServer.stop();
             jettyServer.join();
         } catch (Exception ex) {
-            LOG.error("Error stopping Jetty. Prometheus Metrics may not be available.", ex);
+            logger.error("Error stopping Jetty. Prometheus Metrics may not be available.", ex);
         }
     }
 }

--- a/flume-ng-node/pom.xml
+++ b/flume-ng-node/pom.xml
@@ -93,12 +93,6 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/flume-ng-node/pom.xml
+++ b/flume-ng-node/pom.xml
@@ -81,14 +81,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/flume-ng-node/pom.xml
+++ b/flume-ng-node/pom.xml
@@ -93,7 +93,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/flume-ng-node/src/main/java/org/apache/flume/node/AbstractConfigurationProvider.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/AbstractConfigurationProvider.java
@@ -64,13 +64,13 @@ import org.apache.flume.sink.DefaultSinkFactory;
 import org.apache.flume.sink.DefaultSinkProcessor;
 import org.apache.flume.sink.SinkGroup;
 import org.apache.flume.source.DefaultSourceFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @SuppressFBWarnings("REC_CATCH_EXCEPTION")
 public abstract class AbstractConfigurationProvider implements ConfigurationProvider {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractConfigurationProvider.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final String agentName;
     private final SourceFactory sourceFactory;
@@ -107,7 +107,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                 for (String channelName : channelNames) {
                     ChannelComponent channelComponent = channelComponentMap.get(channelName);
                     if (channelComponent.components.isEmpty()) {
-                        LOGGER.warn(String.format(
+                        logger.warn(String.format(
                                 "Channel %s has no components connected" + " and has been removed.", channelName));
                         channelComponentMap.remove(channelName);
                         Map<String, Channel> nameChannelMap = channelCache.get(channelComponent.channel.getClass());
@@ -115,7 +115,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                             nameChannelMap.remove(channelName);
                         }
                     } else {
-                        LOGGER.info(String.format(
+                        logger.info(String.format(
                                 "Channel %s connected to %s", channelName, channelComponent.components.toString()));
                         conf.addChannel(channelName, channelComponent.channel);
                     }
@@ -127,14 +127,14 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                     conf.addSinkRunner(entry.getKey(), entry.getValue());
                 }
             } catch (InstantiationException ex) {
-                LOGGER.error("Failed to instantiate component", ex);
+                logger.error("Failed to instantiate component", ex);
             } finally {
                 channelComponentMap.clear();
                 sourceRunnerMap.clear();
                 sinkRunnerMap.clear();
             }
         } else {
-            LOGGER.warn("No configuration found for this host:{}", getAgentName());
+            logger.warn("No configuration found for this host:{}", getAgentName());
         }
         return conf;
     }
@@ -145,7 +145,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
 
     private void loadChannels(AgentConfiguration agentConf, Map<String, ChannelComponent> channelComponentMap)
             throws InstantiationException {
-        LOGGER.info("Creating channels");
+        logger.info("Creating channels");
 
         /*
          * Some channels will be reused across re-configurations. To handle this,
@@ -175,11 +175,11 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                 try {
                     Configurables.configure(channel, comp);
                     channelComponentMap.put(comp.getComponentName(), new ChannelComponent(channel));
-                    LOGGER.info("Created channel " + chName);
+                    logger.info("Created channel " + chName);
                 } catch (Exception e) {
                     String msg = String.format(
                             "Channel %s has been removed due to an " + "error during configuration", chName);
-                    LOGGER.error(msg, e);
+                    logger.error(msg, e);
                 }
             }
         }
@@ -195,11 +195,11 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                 try {
                     Configurables.configure(channel, context);
                     channelComponentMap.put(chName, new ChannelComponent(channel));
-                    LOGGER.info("Created channel " + chName);
+                    logger.info("Created channel " + chName);
                 } catch (Exception e) {
                     String msg = String.format(
                             "Channel %s has been removed due to an " + "error during configuration", chName);
-                    LOGGER.error(msg, e);
+                    logger.error(msg, e);
                 }
             }
         }
@@ -211,7 +211,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
             if (channelMap != null) {
                 for (String channelName : channelsNotReused.get(channelKlass)) {
                     if (channelMap.remove(channelName) != null) {
-                        LOGGER.info("Removed {} of type {}", channelName, channelKlass);
+                        logger.info("Removed {} of type {}", channelName, channelKlass);
                     }
                 }
                 if (channelMap.isEmpty()) {
@@ -292,7 +292,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                 } catch (Exception e) {
                     String msg = String.format(
                             "Source %s has been removed due to an " + "error during configuration", sourceName);
-                    LOGGER.error(msg, e);
+                    logger.error(msg, e);
                 }
             }
         }
@@ -334,7 +334,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                 } catch (Exception e) {
                     String msg = String.format(
                             "Source %s has been removed due to an " + "error during configuration", sourceName);
-                    LOGGER.error(msg, e);
+                    logger.error(msg, e);
                 }
             }
         }
@@ -414,7 +414,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                 } catch (Exception e) {
                     String msg = String.format(
                             "Sink %s has been removed due to an " + "error during configuration", sinkName);
-                    LOGGER.error(msg, e);
+                    logger.error(msg, e);
                 }
             }
         }
@@ -442,7 +442,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                 } catch (Exception e) {
                     String msg = String.format(
                             "Sink %s has been removed due to an " + "error during configuration", sinkName);
-                    LOGGER.error(msg, e);
+                    logger.error(msg, e);
                 }
             }
         }
@@ -484,7 +484,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                 } catch (Exception e) {
                     String msg = String.format(
                             "SinkGroup %s has been removed due to " + "an error during configuration", groupName);
-                    LOGGER.error(msg, e);
+                    logger.error(msg, e);
                 }
             }
         }
@@ -501,7 +501,7 @@ public abstract class AbstractConfigurationProvider implements ConfigurationProv
                 } catch (Exception e) {
                     String msg = String.format(
                             "SinkGroup %s has been removed due to " + "an error during configuration", entry.getKey());
-                    LOGGER.error(msg, e);
+                    logger.error(msg, e);
                 }
             }
         }

--- a/flume-ng-node/src/main/java/org/apache/flume/node/Application.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/Application.java
@@ -59,12 +59,12 @@ import org.apache.flume.node.net.BasicAuthorizationProvider;
 import org.apache.flume.sink.AbstractSingleSinkProcessor;
 import org.apache.flume.sink.AbstractSinkProcessor;
 import org.apache.flume.util.SSLUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class Application {
 
-    private static final Logger logger = LoggerFactory.getLogger(Application.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static final String CONF_MONITOR_CLASS = "flume.monitoring.type";
     public static final String CONF_MONITOR_PREFIX = "flume.monitoring.";

--- a/flume-ng-node/src/main/java/org/apache/flume/node/FileConfigurationSource.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/FileConfigurationSource.java
@@ -25,12 +25,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.flume.CounterGroup;
 import org.apache.flume.conf.ConfigurationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class FileConfigurationSource implements ConfigurationSource {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FileConfigurationSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final Path path;
     private final URI uri;
@@ -46,7 +46,7 @@ public class FileConfigurationSource implements ConfigurationSource {
             this.lastChange = path.toFile().lastModified();
             data = Files.readAllBytes(this.path);
         } catch (IOException ioe) {
-            LOGGER.error("Unable to read {}: {}", path.toString(), ioe.getMessage());
+            logger.error("Unable to read {}: {}", path.toString(), ioe.getMessage());
             throw new ConfigurationException("Unable to read file " + path.toString(), ioe);
         }
     }
@@ -72,14 +72,14 @@ public class FileConfigurationSource implements ConfigurationSource {
 
     @Override
     public boolean isModified() {
-        LOGGER.debug("Checking file:{} for changes", path.toString());
+        logger.debug("Checking file:{} for changes", path.toString());
 
         counterGroup.incrementAndGet("file.checks");
 
         long lastModified = path.toFile().lastModified();
 
         if (lastModified > lastChange) {
-            LOGGER.info("Reloading configuration file:{}", path.toString());
+            logger.info("Reloading configuration file:{}", path.toString());
 
             counterGroup.incrementAndGet("file.loads");
 
@@ -89,14 +89,14 @@ public class FileConfigurationSource implements ConfigurationSource {
                 data = Files.readAllBytes(path);
                 return true;
             } catch (Exception e) {
-                LOGGER.error("Failed to load configuration data. Exception follows.", e);
+                logger.error("Failed to load configuration data. Exception follows.", e);
             } catch (NoClassDefFoundError e) {
-                LOGGER.error(
+                logger.error(
                         "Failed to start agent because dependencies were not found in classpath." + "Error follows.",
                         e);
             } catch (Throwable t) {
                 // caught because the caller does not handle or log Throwables
-                LOGGER.error("Unhandled error", t);
+                logger.error("Unhandled error", t);
             }
         }
         return false;

--- a/flume-ng-node/src/main/java/org/apache/flume/node/HttpConfigurationSource.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/HttpConfigurationSource.java
@@ -27,12 +27,12 @@ import org.apache.flume.CounterGroup;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.node.net.AuthorizationProvider;
 import org.apache.flume.node.net.UrlConnectionFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class HttpConfigurationSource implements ConfigurationSource {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HttpConfigurationSource.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final int NOT_MODIFIED = 304;
     private static final int NOT_AUTHORIZED = 401;
     private static final int NOT_FOUND = 404;
@@ -75,17 +75,17 @@ public class HttpConfigurationSource implements ConfigurationSource {
 
     @Override
     public boolean isModified() {
-        LOGGER.debug("Checking {} for changes", uri);
+        logger.debug("Checking {} for changes", uri);
 
         counterGroup.incrementAndGet("uri.checks");
         try {
-            LOGGER.info("Reloading configuration from:{}", uri);
+            logger.info("Reloading configuration from:{}", uri);
             if (readInputStream()) {
                 counterGroup.incrementAndGet("uri.loads");
                 return true;
             }
         } catch (ConfigurationException ex) {
-            LOGGER.error("Unable to access configuration due to {}: ", ex.getMessage());
+            logger.error("Unable to access configuration due to {}: ", ex.getMessage());
         }
         return false;
     }
@@ -99,20 +99,20 @@ public class HttpConfigurationSource implements ConfigurationSource {
                 int code = connection.getResponseCode();
                 switch (code) {
                     case NOT_MODIFIED: {
-                        LOGGER.debug("Configuration Not Modified");
+                        logger.debug("Configuration Not Modified");
                         return false;
                     }
                     case OK: {
                         try (InputStream is = connection.getInputStream()) {
                             lastModified = connection.getLastModified();
-                            LOGGER.debug("Content was modified for {}. lastModified: {}", uri.toString(), lastModified);
+                            logger.debug("Content was modified for {}. lastModified: {}", uri.toString(), lastModified);
                             data = IOUtils.toByteArray(is);
                             return true;
                         } catch (final IOException e) {
                             try (InputStream es = connection.getErrorStream()) {
-                                LOGGER.info("Error accessing configuration at {}: {}", uri, readStream(es));
+                                logger.info("Error accessing configuration at {}: {}", uri, readStream(es));
                             } catch (final IOException ioe) {
-                                LOGGER.error("Error accessing configuration at {}: {}", uri, e.getMessage());
+                                logger.error("Error accessing configuration at {}: {}", uri, e.getMessage());
                             }
                             throw new ConfigurationException("Unable to access " + uri.toString(), e);
                         }
@@ -125,9 +125,9 @@ public class HttpConfigurationSource implements ConfigurationSource {
                     }
                     default: {
                         if (code < 0) {
-                            LOGGER.info("Invalid response code returned");
+                            logger.info("Invalid response code returned");
                         } else {
-                            LOGGER.info("Unexpected response code returned {}", code);
+                            logger.info("Unexpected response code returned {}", code);
                         }
                         return false;
                     }
@@ -136,7 +136,7 @@ public class HttpConfigurationSource implements ConfigurationSource {
                 connection.disconnect();
             }
         } catch (IOException e) {
-            LOGGER.warn("Error accessing {}: {}", uri.toString(), e.getMessage());
+            logger.warn("Error accessing {}: {}", uri.toString(), e.getMessage());
             throw new ConfigurationException("Unable to access " + uri.toString(), e);
         }
     }

--- a/flume-ng-node/src/main/java/org/apache/flume/node/MapResolver.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/MapResolver.java
@@ -29,8 +29,8 @@ import org.apache.commons.text.StringSubstitutor;
 import org.apache.commons.text.lookup.DefaultStringLookup;
 import org.apache.commons.text.lookup.StringLookup;
 import org.apache.commons.text.lookup.StringLookupFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Resolves replaceable tokens to create a Map.
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 final class MapResolver {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MapResolver.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final String DEFAULT_LOOKUPS = "lookups.properties";
     private static final String CUSTOM_LOOKUPS_KEY = "lookups";
     private static final String PROPS_IMPL_KEY = "propertiesImplementation";
@@ -87,7 +87,7 @@ final class MapResolver {
                                 DefaultStringLookup.valueOf(lookupEnum).getStringLookup();
                         map.put(key.toLowerCase(Locale.ROOT), stringLookup);
                     } catch (IllegalArgumentException ex) {
-                        LOGGER.warn("{} is not a DefaultStringLookup enum value, ignoring", key);
+                        logger.warn("{} is not a DefaultStringLookup enum value, ignoring", key);
                     }
                 } else {
                     try {
@@ -96,10 +96,10 @@ final class MapResolver {
                             StringLookup stringLookup = (StringLookup) clazz.newInstance();
                             map.put(k.toString().toLowerCase(Locale.ROOT), stringLookup);
                         } else {
-                            LOGGER.warn("{} is not a StringLookup, ignoring", v);
+                            logger.warn("{} is not a StringLookup, ignoring", v);
                         }
                     } catch (Exception ex) {
-                        LOGGER.warn("Unable to load {} due to {}, ignoring", v, ex.getMessage());
+                        logger.warn("Unable to load {} due to {}, ignoring", v, ex.getMessage());
                     }
                 }
             });
@@ -146,7 +146,7 @@ final class MapResolver {
                 try (InputStream inputStream = ClassLoader.getSystemResourceAsStream(fileName)) {
                     properties.load(inputStream);
                 } catch (final IOException ex) {
-                    LOGGER.warn("Unable to load {} due to {}", fileName, ex.getMessage());
+                    logger.warn("Unable to load {} due to {}", fileName, ex.getMessage());
                 }
             }
         }

--- a/flume-ng-node/src/main/java/org/apache/flume/node/PollingZooKeeperConfigurationProvider.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/PollingZooKeeperConfigurationProvider.java
@@ -26,13 +26,13 @@ import org.apache.flume.FlumeException;
 import org.apache.flume.conf.FlumeConfiguration;
 import org.apache.flume.lifecycle.LifecycleAware;
 import org.apache.flume.lifecycle.LifecycleState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class PollingZooKeeperConfigurationProvider extends AbstractZooKeeperConfigurationProvider
         implements LifecycleAware {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PollingZooKeeperConfigurationProvider.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final EventBus eventBus;
 
@@ -61,7 +61,7 @@ public class PollingZooKeeperConfigurationProvider extends AbstractZooKeeperConf
 
     @Override
     public void start() {
-        LOGGER.debug("Starting...");
+        logger.debug("Starting...");
         try {
             client.start();
             try {
@@ -89,7 +89,7 @@ public class PollingZooKeeperConfigurationProvider extends AbstractZooKeeperConf
     }
 
     private void refreshConfiguration() throws IOException {
-        LOGGER.info("Refreshing configuration from ZooKeeper");
+        logger.info("Refreshing configuration from ZooKeeper");
         byte[] data = null;
         ChildData childData = agentNodeCache.getCurrentData();
         if (childData != null) {
@@ -101,12 +101,12 @@ public class PollingZooKeeperConfigurationProvider extends AbstractZooKeeperConf
 
     @Override
     public void stop() {
-        LOGGER.debug("Stopping...");
+        logger.debug("Stopping...");
         if (agentNodeCache != null) {
             try {
                 agentNodeCache.close();
             } catch (IOException e) {
-                LOGGER.warn("Encountered exception while stopping", e);
+                logger.warn("Encountered exception while stopping", e);
                 lifecycleState = LifecycleState.ERROR;
             }
         }
@@ -114,7 +114,7 @@ public class PollingZooKeeperConfigurationProvider extends AbstractZooKeeperConf
         try {
             client.close();
         } catch (Exception e) {
-            LOGGER.warn("Error stopping Curator client", e);
+            logger.warn("Error stopping Curator client", e);
             lifecycleState = LifecycleState.ERROR;
         }
 

--- a/flume-ng-node/src/main/java/org/apache/flume/node/StaticZooKeeperConfigurationProvider.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/StaticZooKeeperConfigurationProvider.java
@@ -19,12 +19,12 @@ package org.apache.flume.node;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.flume.FlumeException;
 import org.apache.flume.conf.FlumeConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class StaticZooKeeperConfigurationProvider extends AbstractZooKeeperConfigurationProvider {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(StaticZooKeeperConfigurationProvider.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public StaticZooKeeperConfigurationProvider(String agentName, String zkConnString, String basePath) {
         super(agentName, zkConnString, basePath);
@@ -42,7 +42,7 @@ public class StaticZooKeeperConfigurationProvider extends AbstractZooKeeperConfi
                 cf.close();
             }
         } catch (Exception e) {
-            LOGGER.error("Error getting configuration info from Zookeeper", e);
+            logger.error("Error getting configuration info from Zookeeper", e);
             throw new FlumeException(e);
         }
     }

--- a/flume-ng-node/src/main/java/org/apache/flume/node/UriConfigurationProvider.java
+++ b/flume-ng-node/src/main/java/org/apache/flume/node/UriConfigurationProvider.java
@@ -36,8 +36,8 @@ import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.conf.FlumeConfiguration;
 import org.apache.flume.lifecycle.LifecycleAware;
 import org.apache.flume.lifecycle.LifecycleState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -179,7 +179,7 @@ import org.slf4j.LoggerFactory;
  */
 public class UriConfigurationProvider extends AbstractConfigurationProvider implements LifecycleAware {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UriConfigurationProvider.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final List<ConfigurationSource> configurationSources;
     private final File backupDirectory;
@@ -223,14 +223,14 @@ public class UriConfigurationProvider extends AbstractConfigurationProvider impl
             executorService.shutdown();
             try {
                 if (!executorService.awaitTermination(500, TimeUnit.MILLISECONDS)) {
-                    LOGGER.debug("File watcher has not terminated. Forcing shutdown of executor.");
+                    logger.debug("File watcher has not terminated. Forcing shutdown of executor.");
                     executorService.shutdownNow();
                     while (!executorService.awaitTermination(500, TimeUnit.MILLISECONDS)) {
-                        LOGGER.debug("Waiting for file watcher to terminate");
+                        logger.debug("Waiting for file watcher to terminate");
                     }
                 }
             } catch (InterruptedException e) {
-                LOGGER.debug("Interrupted while waiting for file watcher to terminate");
+                logger.debug("Interrupted while waiting for file watcher to terminate");
                 Thread.currentThread().interrupt();
             }
         }
@@ -257,7 +257,7 @@ public class UriConfigurationProvider extends AbstractConfigurationProvider impl
                         case ConfigurationSource.JSON:
                         case ConfigurationSource.YAML:
                         case ConfigurationSource.XML: {
-                            LOGGER.warn("File extension type {} is unsupported", configurationSource.getExtension());
+                            logger.warn("File extension type {} is unsupported", configurationSource.getExtension());
                             break;
                         }
                         default: {
@@ -267,7 +267,7 @@ public class UriConfigurationProvider extends AbstractConfigurationProvider impl
                     }
                 }
             } catch (IOException ioe) {
-                LOGGER.warn("Unable to load properties from {}: {}", configurationSource.getUri(), ioe.getMessage());
+                logger.warn("Unable to load properties from {}: {}", configurationSource.getUri(), ioe.getMessage());
             }
             if (properties.size() > 0) {
                 configMap = MapResolver.resolveProperties(properties);
@@ -279,13 +279,13 @@ public class UriConfigurationProvider extends AbstractConfigurationProvider impl
             if (backupDirectory != null) {
                 if (backupDirectory.mkdirs()) {
                     // This is only being logged to keep Spotbugs happy. We can't ignore the result of mkdirs.
-                    LOGGER.debug("Created directories for {}", backupDirectory.toString());
+                    logger.debug("Created directories for {}", backupDirectory.toString());
                 }
                 File backupFile = getBackupFile(backupDirectory, getAgentName());
                 try (OutputStream os = new FileOutputStream(backupFile)) {
                     props.store(os, "Backup created at " + LocalDateTime.now().toString());
                 } catch (IOException ioe) {
-                    LOGGER.warn("Unable to create backup properties file: {}" + ioe.getMessage());
+                    logger.warn("Unable to create backup properties file: {}" + ioe.getMessage());
                 }
             }
         } else {
@@ -294,11 +294,11 @@ public class UriConfigurationProvider extends AbstractConfigurationProvider impl
                 if (backup.exists()) {
                     Properties props = new Properties();
                     try (InputStream is = new FileInputStream(backup)) {
-                        LOGGER.warn("Unable to access primary configuration. Trying backup");
+                        logger.warn("Unable to access primary configuration. Trying backup");
                         props.load(is);
                         configMap = MapResolver.resolveProperties(props);
                     } catch (IOException ex) {
-                        LOGGER.warn("Error reading backup file: {}", ex.getMessage());
+                        logger.warn("Error reading backup file: {}", ex.getMessage());
                     }
                 }
             }
@@ -306,7 +306,7 @@ public class UriConfigurationProvider extends AbstractConfigurationProvider impl
         if (configMap != null) {
             return new FlumeConfiguration(configMap);
         } else {
-            LOGGER.error("No configuration could be found");
+            logger.error("No configuration could be found");
             return null;
         }
     }
@@ -332,7 +332,7 @@ public class UriConfigurationProvider extends AbstractConfigurationProvider impl
 
         @Override
         public void run() {
-            LOGGER.debug("Checking for changes to sources");
+            logger.debug("Checking for changes to sources");
 
             counterGroup.incrementAndGet("uri.checks");
             try {
@@ -346,7 +346,7 @@ public class UriConfigurationProvider extends AbstractConfigurationProvider impl
                     eventBus.post(getConfiguration());
                 }
             } catch (ConfigurationException ex) {
-                LOGGER.warn("Unable to update configuration: {}", ex.getMessage());
+                logger.warn("Unable to update configuration: {}", ex.getMessage());
             }
         }
     }

--- a/flume-ng-node/src/test/java/org/apache/flume/node/TestHttpConfigurationSource.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/node/TestHttpConfigurationSource.java
@@ -30,6 +30,8 @@ import java.util.Properties;
 import org.apache.flume.conf.ConfigurationException;
 import org.apache.flume.node.net.AuthorizationProvider;
 import org.apache.flume.node.net.BasicAuthorizationProvider;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.ee11.servlet.DefaultServlet;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee11.servlet.ServletHolder;
@@ -40,14 +42,12 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests that files can be loaded via http.
  */
 public class TestHttpConfigurationSource {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestHttpConfigurationSource.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final String BASIC = "Basic ";
     private static final String expectedCreds = "flume:flume";
     private static Server server;
@@ -130,7 +130,7 @@ public class TestHttpConfigurationSource {
                 File file = new File("target/test-classes/flume-conf.properties");
                 long modifiedSince = request.getDateHeader(HttpHeader.IF_MODIFIED_SINCE.toString());
                 long lastModified = (file.lastModified() / 1000) * 1000;
-                LOGGER.debug("LastModified: {}, modifiedSince: {}", lastModified, modifiedSince);
+                logger.debug("LastModified: {}, modifiedSince: {}", lastModified, modifiedSince);
                 if (modifiedSince > 0 && lastModified <= modifiedSince) {
                     response.setStatus(304);
                     return;

--- a/flume-ng-node/src/test/java/org/apache/flume/node/TestPropertiesFileConfigurationProvider.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/node/TestPropertiesFileConfigurationProvider.java
@@ -26,15 +26,15 @@ import junit.framework.Assert;
 import org.apache.flume.conf.FlumeConfiguration;
 import org.apache.flume.conf.FlumeConfiguration.AgentConfiguration;
 import org.apache.flume.conf.FlumeConfigurationError;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestPropertiesFileConfigurationProvider {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestPropertiesFileConfigurationProvider.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static final File TESTFILE = new File(TestPropertiesFileConfigurationProvider.class
             .getClassLoader()
@@ -90,8 +90,8 @@ public class TestPropertiesFileConfigurationProvider {
         AgentConfiguration agentConfiguration = configuration.getConfigurationFor("host1");
         Assert.assertNotNull(agentConfiguration);
 
-        LOGGER.info(agentConfiguration.getPrevalidationConfig());
-        LOGGER.info(agentConfiguration.getPostvalidationConfig());
+        logger.info(agentConfiguration.getPrevalidationConfig());
+        logger.info(agentConfiguration.getPostvalidationConfig());
 
         Set<String> sources = Sets.newHashSet("source1");
         Set<String> sinks = Sets.newHashSet("sink1");

--- a/flume-ng-node/src/test/java/org/apache/flume/sink/NullInitSink.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/sink/NullInitSink.java
@@ -29,8 +29,8 @@ import org.apache.flume.Transaction;
 import org.apache.flume.node.Initializable;
 import org.apache.flume.node.MaterializedConfiguration;
 import org.apache.flume.source.EventProcessor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NullInitSink extends NullSink implements Initializable {
 
-    private static final Logger logger = LoggerFactory.getLogger(NullInitSink.class);
+    private static final Logger logger = LogManager.getLogger();
     private String sourceName = null;
     private EventProcessor eventProcessor = null;
     private long total = 0;

--- a/flume-ng-node/src/test/java/org/apache/flume/source/LocalSource.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/source/LocalSource.java
@@ -21,15 +21,15 @@ import org.apache.flume.Event;
 import org.apache.flume.EventDrivenSource;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.instrumentation.SourceCounter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Accepts an event from a local component and publishes it to a channel.
  */
 public class LocalSource extends AbstractSource implements Configurable, EventDrivenSource, EventProcessor {
 
-    private static final Logger logger = LoggerFactory.getLogger(LocalSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private SourceCounter sourceCounter;
 

--- a/flume-ng-node/src/test/java/org/apache/flume/source/TestNetcatSource.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/source/TestNetcatSource.java
@@ -42,14 +42,14 @@ import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.lifecycle.LifecycleException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(value = Parameterized.class)
 public class TestNetcatSource {
@@ -58,7 +58,7 @@ public class TestNetcatSource {
     private EventDrivenSource source;
     private boolean ackEveryEvent;
 
-    private static final Logger logger = LoggerFactory.getLogger(TestNetcatSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public TestNetcatSource(boolean ackForEveryEvent) {
         ackEveryEvent = ackForEveryEvent;

--- a/flume-ng-sdk/pom.xml
+++ b/flume-ng-sdk/pom.xml
@@ -69,13 +69,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-jul</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/flume-ng-sdk/pom.xml
+++ b/flume-ng-sdk/pom.xml
@@ -58,8 +58,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/flume-ng-sdk/pom.xml
+++ b/flume-ng-sdk/pom.xml
@@ -80,12 +80,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/AbstractRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/AbstractRpcClient.java
@@ -21,11 +21,11 @@ import java.util.Properties;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.FlumeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public abstract class AbstractRpcClient implements RpcClient {
-    private static Logger logger = LoggerFactory.getLogger(AbstractRpcClient.class);
+    private static final Logger logger = LogManager.getLogger();
 
     protected int batchSize = RpcClientConfigurationConstants.DEFAULT_BATCH_SIZE;
     protected long connectTimeout = RpcClientConfigurationConstants.DEFAULT_CONNECT_TIMEOUT_MILLIS;

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/FailoverRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/FailoverRpcClient.java
@@ -22,8 +22,8 @@ import java.util.Properties;
 import org.apache.flume.Event;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.FlumeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Avro/Netty implementation of {@link RpcClient} which supports failover. This
@@ -52,7 +52,7 @@ public class FailoverRpcClient extends AbstractRpcClient implements RpcClient {
     private boolean isActive;
     private Properties configurationProperties;
 
-    private static final Logger logger = LoggerFactory.getLogger(FailoverRpcClient.class);
+    private static final Logger logger = LogManager.getLogger();
 
     protected FailoverRpcClient() {
         lastCheckedhost = -1;

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/HostInfo.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/HostInfo.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import org.apache.flume.FlumeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A convenience class that holds the property reference name along with the
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HostInfo {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HostInfo.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final String referenceName;
     private final String hostName;
@@ -73,14 +73,14 @@ public class HostInfo {
                 if (hostAndPortStr != null) {
                     String[] hostAndPort = hostAndPortStr.split(":");
                     if (hostAndPort.length != 2) {
-                        LOGGER.error("Invalid host address" + hostAndPortStr);
+                        logger.error("Invalid host address" + hostAndPortStr);
                         throw new FlumeException("Invalid host address" + hostAndPortStr);
                     }
                     Integer port = null;
                     try {
                         port = Integer.parseInt(hostAndPort[1]);
                     } catch (NumberFormatException e) {
-                        LOGGER.error("Invalid port number" + hostAndPortStr, e);
+                        logger.error("Invalid port number" + hostAndPortStr, e);
                         throw new FlumeException("Invalid port number" + hostAndPortStr);
                     }
                     HostInfo info = new HostInfo(hostList[i], hostAndPort[0].trim(), port);

--- a/flume-ng-sdk/src/main/java/org/apache/flume/api/LoadBalancingRpcClient.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/api/LoadBalancingRpcClient.java
@@ -27,8 +27,8 @@ import org.apache.flume.FlumeException;
 import org.apache.flume.util.OrderSelector;
 import org.apache.flume.util.RandomOrderSelector;
 import org.apache.flume.util.RoundRobinOrderSelector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>An implementation of RpcClient interface that uses NettyAvroRpcClient
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LoadBalancingRpcClient extends AbstractRpcClient {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoadBalancingRpcClient.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private List<HostInfo> hosts;
     private HostSelector selector;
@@ -70,7 +70,7 @@ public class LoadBalancingRpcClient extends AbstractRpcClient {
                 break;
             } catch (Exception ex) {
                 selector.informFailure(host);
-                LOGGER.warn("Failed to send event to host " + host, ex);
+                logger.warn("Failed to send event to host " + host, ex);
             }
         }
 
@@ -94,7 +94,7 @@ public class LoadBalancingRpcClient extends AbstractRpcClient {
                 break;
             } catch (Exception ex) {
                 selector.informFailure(host);
-                LOGGER.warn("Failed to send batch to host " + host, ex);
+                logger.warn("Failed to send batch to host " + host, ex);
             }
         }
 
@@ -126,7 +126,7 @@ public class LoadBalancingRpcClient extends AbstractRpcClient {
                     try {
                         client.close();
                     } catch (Exception ex) {
-                        LOGGER.warn("Failed to close client: " + name, ex);
+                        logger.warn("Failed to close client: " + name, ex);
                     }
                 }
                 it.remove();
@@ -189,7 +189,7 @@ public class LoadBalancingRpcClient extends AbstractRpcClient {
             try {
                 client.close();
             } catch (Exception ex) {
-                LOGGER.warn("Failed to close client for " + info, ex);
+                logger.warn("Failed to close client for " + info, ex);
             }
             client = createClient(name);
             clientMap.put(name, client);

--- a/flume-ng-sdk/src/main/java/org/apache/flume/instrumentation/MonitoredCounterGroup.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/instrumentation/MonitoredCounterGroup.java
@@ -27,8 +27,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.management.ObjectName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Used for keeping track of internal metrics using atomic integers</p>
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class MonitoredCounterGroup {
 
-    private static final Logger logger = LoggerFactory.getLogger(MonitoredCounterGroup.class);
+    private static final Logger logger = LogManager.getLogger();
 
     // Key for component's start time in MonitoredCounterGroup.counterMap
     private static final String COUNTER_GROUP_START_TIME = "start.time";

--- a/flume-ng-sdk/src/main/java/org/apache/flume/serialization/LineDeserializer.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/serialization/LineDeserializer.java
@@ -25,8 +25,8 @@ import org.apache.flume.Event;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.event.EventBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A deserializer that parses text lines from a file.
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Evolving
 public class LineDeserializer implements EventDeserializer {
 
-    private static final Logger logger = LoggerFactory.getLogger(LineDeserializer.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final ResettableInputStream in;
     private final Charset outputCharset;

--- a/flume-ng-sdk/src/main/java/org/apache/flume/serialization/ResettableFileInputStream.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/serialization/ResettableFileInputStream.java
@@ -30,8 +30,8 @@ import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * <p>This class makes the following assumptions:</p>
@@ -83,7 +83,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceStability.Evolving
 public class ResettableFileInputStream extends ResettableInputStream implements RemoteMarkable, LengthMeasurable {
 
-    Logger logger = LoggerFactory.getLogger(ResettableFileInputStream.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static final int DEFAULT_BUF_SIZE = 16384;
 

--- a/flume-ng-sdk/src/main/java/org/apache/flume/util/SSLUtil.java
+++ b/flume-ng-sdk/src/main/java/org/apache/flume/util/SSLUtil.java
@@ -16,12 +16,12 @@
  */
 package org.apache.flume.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class SSLUtil {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SSLUtil.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static final String SYS_PROP_KEYSTORE_PATH = "javax.net.ssl.keyStore";
     private static final String SYS_PROP_KEYSTORE_PASSWORD = "javax.net.ssl.keyStorePassword";
@@ -71,14 +71,14 @@ public class SSLUtil {
 
     private static void initSysPropFromEnvVar(String sysPropName, String envVarName, String description) {
         if (System.getProperty(sysPropName) != null) {
-            LOGGER.debug("Global SSL " + description + " has been initialized from system property.");
+            logger.debug("Global SSL " + description + " has been initialized from system property.");
         } else {
             String envVarValue = System.getenv(envVarName);
             if (envVarValue != null) {
                 System.setProperty(sysPropName, envVarValue);
-                LOGGER.debug("Global SSL " + description + " has been initialized from environment variable.");
+                logger.debug("Global SSL " + description + " has been initialized from environment variable.");
             } else {
-                LOGGER.debug("No global SSL " + description + " specified.");
+                logger.debug("No global SSL " + description + " specified.");
             }
         }
     }

--- a/flume-ng-sources/flume-http-source/src/main/java/org/apache/flume/source/http/BLOBHandler.java
+++ b/flume-ng-sources/flume-http-source/src/main/java/org/apache/flume/source/http/BLOBHandler.java
@@ -29,8 +29,8 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.conf.LogPrivacyUtil;
 import org.apache.flume.event.EventBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  *
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BLOBHandler implements HTTPSourceHandler {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BLOBHandler.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private String commaSeparatedHeaders;
 
@@ -64,8 +64,8 @@ public class BLOBHandler implements HTTPSourceHandler {
         Map<String, String[]> parameters = request.getParameterMap();
         for (String parameter : parameters.keySet()) {
             String value = parameters.get(parameter)[0];
-            if (LOG.isDebugEnabled() && LogPrivacyUtil.allowLogRawData()) {
-                LOG.debug("Setting Header [Key, Value] as [{},{}] ", parameter, value);
+            if (logger.isDebugEnabled() && LogPrivacyUtil.allowLogRawData()) {
+                logger.debug("Setting Header [Key, Value] as [{},{}] ", parameter, value);
             }
             headers.put(parameter, value);
         }
@@ -78,7 +78,7 @@ public class BLOBHandler implements HTTPSourceHandler {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try {
             IOUtils.copy(inputStream, outputStream);
-            LOG.debug("Building an Event with stream of size -- {}", outputStream.size());
+            logger.debug("Building an Event with stream of size -- {}", outputStream.size());
             Event event = EventBuilder.withBody(outputStream.toByteArray(), headers);
             event.setHeaders(headers);
             List<Event> eventList = new ArrayList<Event>();

--- a/flume-ng-sources/flume-http-source/src/main/java/org/apache/flume/source/http/HTTPSource.java
+++ b/flume-ng-sources/flume-http-source/src/main/java/org/apache/flume/source/http/HTTPSource.java
@@ -34,6 +34,8 @@ import org.apache.flume.exception.ChannelException;
 import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.SslContextAwareAbstractSource;
 import org.apache.flume.tools.FlumeBeanConfigurator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.eclipse.jetty.http.HttpVersion;
@@ -46,8 +48,6 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A source which accepts Flume Events by HTTP POST and GET. GET should be used
@@ -87,7 +87,7 @@ public class HTTPSource extends SslContextAwareAbstractSource implements EventDr
      *
      */
 
-    private static final Logger LOG = LoggerFactory.getLogger(HTTPSource.class);
+    private static final Logger logger = LogManager.getLogger();
     private volatile Integer port;
     private volatile Server srv;
     private volatile String host;
@@ -122,14 +122,14 @@ public class HTTPSource extends SslContextAwareAbstractSource implements EventDr
                     context.getSubProperties(HTTPSourceConfigurationConstants.CONFIG_HANDLER_PREFIX);
             handler.configure(new Context(subProps));
         } catch (ClassNotFoundException ex) {
-            LOG.error("Error while configuring HTTPSource. Exception follows.", ex);
+            logger.error("Error while configuring HTTPSource. Exception follows.", ex);
             Throwables.propagate(ex);
         } catch (ClassCastException ex) {
-            LOG.error("Deserializer is not an instance of HTTPSourceHandler."
+            logger.error("Deserializer is not an instance of HTTPSourceHandler."
                     + "Deserializer must implement HTTPSourceHandler.");
             Throwables.propagate(ex);
         } catch (Exception ex) {
-            LOG.error("Error configuring HTTPSource!", ex);
+            logger.error("Error configuring HTTPSource!", ex);
             Throwables.propagate(ex);
         }
         if (sourceCounter == null) {
@@ -200,7 +200,7 @@ public class HTTPSource extends SslContextAwareAbstractSource implements EventDr
             context.setSecurityHandler(HTTPServerConstraintUtil.enforceConstraints());
             srv.start();
         } catch (Exception ex) {
-            LOG.error("Error while starting HTTPSource. Exception follows.", ex);
+            logger.error("Error while starting HTTPSource. Exception follows.", ex);
             Throwables.propagate(ex);
         }
         Preconditions.checkArgument(srv.isRunning());
@@ -215,10 +215,10 @@ public class HTTPSource extends SslContextAwareAbstractSource implements EventDr
             srv.join();
             srv = null;
         } catch (Exception ex) {
-            LOG.error("Error while stopping HTTPSource. Exception follows.", ex);
+            logger.error("Error while stopping HTTPSource. Exception follows.", ex);
         }
         sourceCounter.stop();
-        LOG.info("Http source {} stopped. Metrics: {}", getName(), sourceCounter);
+        logger.info("Http source {} stopped. Metrics: {}", getName(), sourceCounter);
     }
 
     private class FlumeHTTPServlet extends HttpServlet {
@@ -231,12 +231,12 @@ public class HTTPSource extends SslContextAwareAbstractSource implements EventDr
             try {
                 events = handler.getEvents(request);
             } catch (HTTPBadRequestException ex) {
-                LOG.warn("Received bad request from client. ", ex);
+                logger.warn("Received bad request from client. ", ex);
                 sourceCounter.incrementEventReadFail();
                 response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Bad request from client.");
                 return;
             } catch (Exception ex) {
-                LOG.warn("Deserializer threw unexpected exception. ", ex);
+                logger.warn("Deserializer threw unexpected exception. ", ex);
                 sourceCounter.incrementEventReadFail();
                 response.sendError(
                         HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Deserializer threw unexpected exception.");
@@ -247,7 +247,7 @@ public class HTTPSource extends SslContextAwareAbstractSource implements EventDr
             try {
                 getChannelProcessor().processEventBatch(events);
             } catch (ChannelException ex) {
-                LOG.warn(
+                logger.warn(
                         "Error appending event to channel. "
                                 + "Channel might be full. Consider increasing the channel "
                                 + "capacity or make sure the sinks perform faster.",
@@ -258,7 +258,7 @@ public class HTTPSource extends SslContextAwareAbstractSource implements EventDr
                         "Error appending event to channel. Channel might be full.");
                 return;
             } catch (Exception ex) {
-                LOG.warn("Unexpected error appending event to channel. ", ex);
+                logger.warn("Unexpected error appending event to channel. ", ex);
                 sourceCounter.incrementGenericProcessingFail();
                 response.sendError(
                         HttpServletResponse.SC_INTERNAL_SERVER_ERROR,

--- a/flume-ng-sources/flume-http-source/src/main/java/org/apache/flume/source/http/JSONHandler.java
+++ b/flume-ng-sources/flume-http-source/src/main/java/org/apache/flume/source/http/JSONHandler.java
@@ -30,8 +30,8 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.event.JSONEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * JSONHandler for HTTPSource that accepts an array of events.
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
  */
 public class JSONHandler implements HTTPSourceHandler {
 
-    private static final Logger LOG = LoggerFactory.getLogger(JSONHandler.class);
+    private static final Logger logger = LogManager.getLogger();
     private final Type listType = new TypeToken<List<JSONEvent>>() {}.getType();
     private final Gson gson;
 
@@ -90,12 +90,12 @@ public class JSONHandler implements HTTPSourceHandler {
         // UTF-8 is default for JSON. If no charset is specified, UTF-8 is to
         // be assumed.
         if (charset == null) {
-            LOG.debug("Charset is null, default charset of UTF-8 will be used.");
+            logger.debug("Charset is null, default charset of UTF-8 will be used.");
             charset = "UTF-8";
         } else if (!(charset.equalsIgnoreCase("utf-8")
                 || charset.equalsIgnoreCase("utf-16")
                 || charset.equalsIgnoreCase("utf-32"))) {
-            LOG.error(
+            logger.error(
                     "Unsupported character set in request {}. "
                             + "JSON handler supports UTF-8, "
                             + "UTF-16 and UTF-32 only.",

--- a/flume-ng-sources/flume-http-source/src/test/java/org/apache/flume/source/http/TestHTTPSource.java
+++ b/flume-ng-sources/flume-http-source/src/test/java/org/apache/flume/source/http/TestHTTPSource.java
@@ -48,7 +48,9 @@ import javax.management.Query;
 import javax.management.QueryExp;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
 import org.apache.flume.Channel;
 import org.apache.flume.ChannelSelector;
@@ -515,7 +517,7 @@ public class TestHTTPSource {
         doTestHttps(null, httpsPort, httpsChannel);
     }
 
-    @Test(expected = javax.net.ssl.SSLHandshakeException.class)
+    @Test(expected = SSLHandshakeException.class)
     public void testHttpsSSLv3() throws Exception {
         doTestHttps("SSLv3", httpsPort, httpsChannel);
     }
@@ -546,7 +548,7 @@ public class TestHTTPSource {
         Transaction transaction = null;
         try {
             SSLContext sc = null;
-            javax.net.ssl.SSLSocketFactory factory = null;
+            SSLSocketFactory factory = null;
             if (System.getProperty("java.vendor").contains("IBM")) {
                 sc = SSLContext.getInstance("SSL_TLS");
             } else {
@@ -664,12 +666,12 @@ public class TestHTTPSource {
         }
     }
 
-    private class DisabledProtocolsSocketFactory extends javax.net.ssl.SSLSocketFactory {
+    private class DisabledProtocolsSocketFactory extends SSLSocketFactory {
 
-        private final javax.net.ssl.SSLSocketFactory socketFactory;
+        private final SSLSocketFactory socketFactory;
         private final String[] protocols;
 
-        DisabledProtocolsSocketFactory(javax.net.ssl.SSLSocketFactory factory, String protocol) {
+        DisabledProtocolsSocketFactory(SSLSocketFactory factory, String protocol) {
             this.socketFactory = factory;
             protocols = new String[1];
             protocols[0] = protocol;

--- a/flume-ng-sources/flume-netcat-source/src/main/java/org/apache/flume/source/netcat/NetcatUdpSource.java
+++ b/flume-ng-sources/flume-netcat-source/src/main/java/org/apache/flume/source/netcat/NetcatUdpSource.java
@@ -41,8 +41,8 @@ import org.apache.flume.conf.Configurables;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.source.AbstractSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class NetcatUdpSource extends AbstractSource implements EventDrivenSource, Configurable {
 
@@ -52,7 +52,7 @@ public class NetcatUdpSource extends AbstractSource implements EventDrivenSource
     private String remoteHostHeader = "REMOTE_ADDRESS";
     private EventLoopGroup group;
 
-    private static final Logger logger = LoggerFactory.getLogger(NetcatUdpSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private CounterGroup counterGroup = new CounterGroup();
 

--- a/flume-ng-sources/flume-netcat-source/src/test/java/org/apache/flume/source/netcat/TestNetcatUdpSource.java
+++ b/flume-ng-sources/flume-netcat-source/src/test/java/org/apache/flume/source/netcat/TestNetcatUdpSource.java
@@ -32,12 +32,13 @@ import org.apache.flume.channel.ChannelProcessor;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 
 public class TestNetcatUdpSource {
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(TestNetcatUdpSource.class);
+    private static final Logger logger = LogManager.getLogger();
     private NetcatUdpSource source;
     private Channel channel;
     private static final int TEST_NETCAT_PORT = 0;

--- a/flume-ng-sources/flume-syslog-source/pom.xml
+++ b/flume-ng-sources/flume-syslog-source/pom.xml
@@ -98,7 +98,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/MultiportSyslogTCPSource.java
+++ b/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/MultiportSyslogTCPSource.java
@@ -39,14 +39,14 @@ import org.apache.flume.conf.LogPrivacyUtil;
 import org.apache.flume.event.EventBuilder;
 import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.SslContextAwareAbstractSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.mina.core.buffer.IoBuffer;
 import org.apache.mina.core.service.IoHandlerAdapter;
 import org.apache.mina.core.session.IdleStatus;
 import org.apache.mina.core.session.IoSession;
 import org.apache.mina.filter.ssl.SslFilter;
 import org.apache.mina.transport.socket.nio.NioSocketAcceptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
 public class MultiportSyslogTCPSource extends SslContextAwareAbstractSource
         implements EventDrivenSource, Configurable, BatchSizeSupported {
 
-    public static final Logger logger = LoggerFactory.getLogger(MultiportSyslogTCPSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final ConcurrentMap<Integer, ThreadSafeDecoder> portCharsets;
 

--- a/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/SyslogParser.java
+++ b/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/SyslogParser.java
@@ -41,14 +41,14 @@ import org.apache.flume.Event;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.event.EventBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class SyslogParser {
 
-    private static final Logger logger = LoggerFactory.getLogger(SyslogParser.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static final int TS_CACHE_MAX = 1000; // timestamp cache size limit
     private static final Pattern TWO_SPACES = Pattern.compile("  ");

--- a/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/SyslogTcpSource.java
+++ b/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/SyslogTcpSource.java
@@ -46,15 +46,15 @@ import org.apache.flume.conf.Configurables;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.SslContextAwareAbstractSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @deprecated use {@link MultiportSyslogTCPSource} instead.
  */
 @Deprecated
 public class SyslogTcpSource extends SslContextAwareAbstractSource implements EventDrivenSource, Configurable {
-    private static final Logger logger = LoggerFactory.getLogger(SyslogTcpSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private int port;
     private String host = null;

--- a/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/SyslogUDPSource.java
+++ b/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/SyslogUDPSource.java
@@ -38,15 +38,15 @@ import org.apache.flume.conf.Configurables;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.AbstractSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class SyslogUDPSource extends AbstractSource implements EventDrivenSource, Configurable {
 
     // Default Min size
     public static final int DEFAULT_MIN_SIZE = 2048;
     public static final int DEFAULT_INITIAL_SIZE = DEFAULT_MIN_SIZE;
-    private static final Logger logger = LoggerFactory.getLogger(SyslogUDPSource.class);
+    private static final Logger logger = LogManager.getLogger();
     private final int maxsize = 1 << 16; // 64k is max allowable in RFC 5426
     private int port;
     private String host = null;

--- a/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/SyslogUtils.java
+++ b/flume-ng-sources/flume-syslog-source/src/main/java/org/apache/flume/source/syslog/SyslogUtils.java
@@ -41,8 +41,8 @@ import org.apache.flume.Event;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.event.EventBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
@@ -88,7 +88,7 @@ public class SyslogUtils {
     private Mode m = Mode.START;
     private StringBuilder prio = new StringBuilder();
     private ByteArrayOutputStream baos;
-    private static final Logger logger = LoggerFactory.getLogger(SyslogUtils.class);
+    private static final Logger logger = LogManager.getLogger();
 
     public static final String SYSLOG_FACILITY = "Facility";
     public static final String SYSLOG_SEVERITY = "Severity";

--- a/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestMultiportSyslogTCPSource.java
+++ b/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestMultiportSyslogTCPSource.java
@@ -78,7 +78,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 public class TestMultiportSyslogTCPSource {
-    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Logger logger = LogManager.getLogger();
     private static final String TEST_CLIENT_IP_HEADER = "testClientIPHeader";
     private static final String TEST_CLIENT_HOSTNAME_HEADER = "testClientHostnameHeader";
     private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
@@ -114,7 +114,7 @@ public class TestMultiportSyslogTCPSource {
             BiConsumer<Integer, byte[]> eventSenderFuncton,
             Context additionalContext)
             throws IOException {
-        LOGGER.info("source: {}, channel: {}, numPorts: {}", source.toString(), channel.getName(), numPorts);
+        logger.info("source: {}, channel: {}, numPorts: {}", source.toString(), channel.getName(), numPorts);
         Context channelContext = new Context();
         channelContext.put("capacity", String.valueOf(2000));
         channelContext.put("transactionCapacity", String.valueOf(2000));
@@ -144,7 +144,7 @@ public class TestMultiportSyslogTCPSource {
         for (int i = 0; i < numPorts; i++) {
             ports.append(String.valueOf(portList.get(i))).append(" ");
         }
-        LOGGER.info("ports: {}", ports.toString());
+        logger.info("ports: {}", ports.toString());
         Context context = new Context();
         context.put(
                 SyslogSourceConfigurationConstants.CONFIG_PORTS,
@@ -157,7 +157,7 @@ public class TestMultiportSyslogTCPSource {
         for (int i = 0; i < numPorts; i++) {
             byte[] data = getEvent(i);
             eventSenderFuncton.accept(portList.get(i), data);
-            LOGGER.info("Sent {} to port {}", new String(data), portList.get(i));
+            logger.info("Sent {} to port {}", new String(data), portList.get(i));
         }
 
         Transaction txn = channel.getTransaction();
@@ -165,7 +165,7 @@ public class TestMultiportSyslogTCPSource {
         for (int i = 0; i < numPorts; i++) {
             Event e = channel.take();
             if (e == null) {
-                LOGGER.error("Got a null event for port number: {}", i);
+                logger.error("Got a null event for port number: {}", i);
                 throw new NullPointerException("Event is null");
             }
             channelEvents.add(e);
@@ -265,7 +265,7 @@ public class TestMultiportSyslogTCPSource {
             try {
                 socket.close();
             } catch (IOException ioe) {
-                LOGGER.warn("Error closing socket: {}", ioe.getMessage());
+                logger.warn("Error closing socket: {}", ioe.getMessage());
             }
         });
     }

--- a/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestSyslogTcpSource.java
+++ b/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestSyslogTcpSource.java
@@ -49,16 +49,17 @@ import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.exception.ChannelException;
 import org.apache.flume.util.TestKeyStores;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
-import org.slf4j.LoggerFactory;
 
 public class TestSyslogTcpSource {
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(TestSyslogTcpSource.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final String TEST_CLIENT_IP_HEADER = "testClientIPHeader";
     private static final String TEST_CLIENT_HOSTNAME_HEADER = "testClientHostnameHeader";
 

--- a/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestSyslogUdpSource.java
+++ b/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestSyslogUdpSource.java
@@ -42,13 +42,14 @@ import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.channel.ReplicatingChannelSelector;
 import org.apache.flume.conf.Configurables;
 import org.apache.flume.exception.ChannelException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.slf4j.LoggerFactory;
 
 public class TestSyslogUdpSource {
-    private static final org.slf4j.Logger logger = LoggerFactory.getLogger(TestSyslogUdpSource.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final String TEST_CLIENT_IP_HEADER = "testClientIPHeader";
     private static final String TEST_CLIENT_HOSTNAME_HEADER = "testClientHostnameHeader";
 

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/ReliableTaildirEventReader.java
@@ -37,13 +37,13 @@ import org.apache.flume.FlumeException;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
 import org.apache.flume.event.ReliableEventReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class ReliableTaildirEventReader implements ReliableEventReader {
-    private static final Logger logger = LoggerFactory.getLogger(ReliableTaildirEventReader.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final List<TaildirMatcher> taildirCache;
     private final Table<String, String, String> headerTable;

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TailFile.java
@@ -26,11 +26,11 @@ import java.util.List;
 import java.util.Map;
 import org.apache.flume.Event;
 import org.apache.flume.event.EventBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TailFile {
-    private static final Logger logger = LoggerFactory.getLogger(TailFile.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private static final byte BYTE_NL = (byte) 10;
     private static final byte BYTE_CR = (byte) 13;

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirMatcher.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirMatcher.java
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.flume.annotations.InterfaceAudience;
 import org.apache.flume.annotations.InterfaceStability;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Identifies and caches the files matched by single file pattern for {@code TAILDIR} source.
@@ -62,7 +62,7 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
 public class TaildirMatcher {
-    private static final Logger logger = LoggerFactory.getLogger(TaildirMatcher.class);
+    private static final Logger logger = LogManager.getLogger();
     private static final FileSystem FS = FileSystems.getDefault();
 
     // flag from configuration to switch off caching completely

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
@@ -51,12 +51,12 @@ import org.apache.flume.exception.ChannelException;
 import org.apache.flume.instrumentation.SourceCounter;
 import org.apache.flume.source.AbstractSource;
 import org.apache.flume.source.PollableSourceConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TaildirSource extends AbstractSource implements PollableSource, Configurable, BatchSizeSupported {
 
-    private static final Logger logger = LoggerFactory.getLogger(TaildirSource.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private Map<String, String> filePaths;
     private Table<String, String, String> headerTable;

--- a/flume-parent/pom.xml
+++ b/flume-parent/pom.xml
@@ -339,12 +339,12 @@
         <scope>test</scope>
         <exclusions>
           <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
           </exclusion>
           <exclusion>
             <!-- exclude this from hadoop minikdc as the minikdc depends on
@@ -614,12 +614,12 @@
             <artifactId>jasper-runtime</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -637,12 +637,8 @@
             <artifactId>jasper-runtime</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -658,14 +654,6 @@
           <exclusion>
             <groupId>tomcat</groupId>
             <artifactId>jasper-runtime</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -684,12 +672,12 @@
             <artifactId>jasper-runtime</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -709,12 +697,12 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -725,12 +713,12 @@
         <scope>test</scope>
         <exclusions>
           <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -746,12 +734,8 @@
         <version>${zookeeper.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1229,6 +1213,49 @@
             <goals>
               <goal>clean</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Ban logging implementations (not logging APIs) that dependencies
+           incorrectly add as compile dependencies -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>ban-logging-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <!-- JCL replacement -->
+                    <exclude>org.springframework:spring-jcl</exclude>
+                    <!-- Log4j 1.x -->
+                    <exclude>log4j:log4j</exclude>
+                    <!-- Groups with logging dependencies -->
+                    <exclude>ch.qos.logback:*</exclude>
+                    <exclude>ch.qos.reload4j:*</exclude>
+                    <exclude>org.apache.logging.log4j:*</exclude>
+                    <exclude>org.jboss.logging:*</exclude>
+                    <exclude>org.slf4j:*</exclude>
+                    <exclude>org.ops4j.pax.logging:*</exclude>
+                  </excludes>
+                  <includes>
+                    <!-- As compile dependencies (including transitive): only real logging APIs -->
+                    <include>commons-logging:commons-logging</include>
+                    <include>org.apache.logging.log4j:log4j-api</include>
+                    <include>org.jboss.logging:jboss-logging</include>
+                    <include>org.slf4j:slf4j-api</include>
+                    <!-- As a test dependency and in the binary distribution -->
+                    <include>org.apache.logging.log4j:*</include>
+                  </includes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/flume-parent/pom.xml
+++ b/flume-parent/pom.xml
@@ -277,7 +277,6 @@
     <prometheus.version>1.7.0</prometheus.version>
     <rat.version>0.12</rat.version>
     <snappy-java.version>1.1.10.8</snappy-java.version>
-    <slf4j.version>1.7.32</slf4j.version>
     <spotbugs-annotations.version>4.9.3</spotbugs-annotations.version>
     <system-rules.version>1.19.0</system-rules.version>
     <wiremock.version>1.53</wiremock.version>
@@ -395,12 +394,6 @@
         <version>${log4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
       </dependency>
 
       <dependency>

--- a/flume-parent/pom.xml
+++ b/flume-parent/pom.xml
@@ -233,6 +233,7 @@
     <commons-compress.version>1.28.0</commons-compress.version>
     <commons-io.version>2.22.0</commons-io.version>
     <commons-lang.version>3.20.0</commons-lang.version>
+    <commons-logging.version>1.4.0</commons-logging.version>
     <commons-text.version>1.15.0</commons-text.version>
     <curator.version>5.9.0</curator.version>
     <derby.version>10.17.1.0</derby.version>
@@ -276,6 +277,7 @@
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
     <prometheus.version>1.7.0</prometheus.version>
     <rat.version>0.12</rat.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <snappy-java.version>1.1.10.8</snappy-java.version>
     <spotbugs-annotations.version>4.9.3</spotbugs-annotations.version>
     <system-rules.version>1.19.0</system-rules.version>
@@ -370,6 +372,13 @@
         <version>${commons-cli.version}</version>
       </dependency>
 
+      <!-- Pin commons-logging to a version with native Log4j API support -->
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>${commons-logging.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
@@ -392,6 +401,15 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
         <version>${log4j.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Pin SLF4J to 2.x so transitive deps cannot downgrade it to 1.x -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-bom</artifactId>
+        <version>${slf4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -1250,8 +1268,9 @@
                     <include>org.apache.logging.log4j:log4j-api</include>
                     <include>org.jboss.logging:jboss-logging</include>
                     <include>org.slf4j:slf4j-api</include>
-                    <!-- As a test dependency and in the binary distribution -->
-                    <include>org.apache.logging.log4j:*</include>
+                    <!-- As a test dependency -->
+                    <include>org.apache.logging.log4j:log4j-core:*:jar:test</include>
+                    <include>org.apache.logging.log4j:log4j-slf4j2-impl:*:jar:test</include>
                   </includes>
                 </bannedDependencies>
               </rules>

--- a/flume-tools/pom.xml
+++ b/flume-tools/pom.xml
@@ -62,8 +62,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.easytesting</groupId>

--- a/flume-tools/src/main/java/org/apache/flume/tools/FileChannelIntegrityTool.java
+++ b/flume-tools/src/main/java/org/apache/flume/tools/FileChannelIntegrityTool.java
@@ -42,11 +42,11 @@ import org.apache.flume.channel.file.LogFileV3;
 import org.apache.flume.channel.file.LogRecord;
 import org.apache.flume.channel.file.Serialization;
 import org.apache.flume.channel.file.TransactionEventRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class FileChannelIntegrityTool implements FlumeTool {
-    public static final Logger LOG = LoggerFactory.getLogger(FileChannelIntegrityTool.class);
+    private static final Logger logger = LogManager.getLogger();
 
     private final List<File> dataDirs = new ArrayList<File>();
 
@@ -63,7 +63,7 @@ public class FileChannelIntegrityTool implements FlumeTool {
     public void run(String[] args) throws IOException, ParseException {
         boolean shouldContinue = parseCommandLineOpts(args);
         if (!shouldContinue) {
-            LOG.error("Could not parse command line options. Exiting ...");
+            logger.error("Could not parse command line options. Exiting ...");
             System.exit(1);
         }
         for (File dataDir : dataDirs) {
@@ -81,7 +81,7 @@ public class FileChannelIntegrityTool implements FlumeTool {
             });
             if (dataFiles != null && dataFiles.length > 0) {
                 for (File dataFile : dataFiles) {
-                    LOG.info("Checking for corruption in " + dataFile.toString());
+                    logger.info("Checking for corruption in " + dataFile.toString());
                     LogFile.SequentialReader reader = new LogFileV3.SequentialReader(dataFile, null, true);
                     LogFile.OperationRecordUpdater updater = new LogFile.OperationRecordUpdater(dataFile);
                     boolean fileDone = false;
@@ -131,7 +131,7 @@ public class FileChannelIntegrityTool implements FlumeTool {
                         } catch (CorruptEventException e) {
                             corruptEvents++;
                             totalChannelEvents++;
-                            LOG.warn("Corruption found in " + dataFile.toString() + " at " + eventPosition);
+                            logger.warn("Corruption found in " + dataFile.toString() + " at " + eventPosition);
                             if (!fileBackedup) {
                                 Serialization.copyFile(
                                         dataFile, new File(dataFile.getParent(), dataFile.getName() + ".bak"));


### PR DESCRIPTION
Standardize all modules on the Log4j 2.x API so Flume's own logging no longer uses SLF4J. Applied the OpenRewrite Slf4jToLog4j recipe, then normalized the result: drop loggers that were never used, make every logger field private static final named "logger", and use the no-arg LogManager.getLogger() since each one named its own class.

Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>