### PR TITLE
Migrate `flume-project` hierarchy to `logging-parent`

### DIFF
--- a/flume-bom/.logging-parent-bom-activator
+++ b/flume-bom/.logging-parent-bom-activator
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# Marker file to activate BOM flattening

--- a/flume-bom/pom.xml
+++ b/flume-bom/pom.xml
@@ -22,16 +22,22 @@
   <parent>
     <groupId>org.apache.flume</groupId>
     <artifactId>flume-project</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
-  <groupId>org.apache.flume</groupId>
+
   <artifactId>flume-dependencies</artifactId>
   <packaging>pom</packaging>
 
-  <name>Apache Flume Artifacts</name>
+  <name>Apache Flume BOM</name>
+  <description>Bill of materials (BOM) of Apache Flume.
+  It provides a coherent set of versions for all Apache Flume artifacts in the official distribution.</description>
 
   <properties>
-    <!-- <flume-hadoop.version>2.0.0-SNAPSHOT</flume-hadoop.version>-->
+    <!-- Re-enable publishing: `flume-project` disables it, but this BOM must be installed and deployed. -->
+    <maven.install.skip>false</maven.install.skip>
+    <maven.deploy.skip>false</maven.deploy.skip>
+
+    <flume-hadoop.version>2.0.0-SNAPSHOT</flume-hadoop.version>
     <flume-http.version>2.0.0-SNAPSHOT</flume-http.version>
     <flume-irc.version>2.0.0-SNAPSHOT</flume-irc.version>
     <flume-jdbc.version>2.0.0-SNAPSHOT</flume-jdbc.version>
@@ -234,43 +240,5 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-    <plugins>
-
-      <!-- Enable BOM flattening -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.7.3</version>
-        <executions>
-          <execution>
-            <id>flatten-bom</id>
-            <goals>
-              <goal>flatten</goal>
-            </goals>
-            <phase>process-resources</phase>
-            <inherited>false</inherited>
-            <configuration>
-              <updatePomFile>true</updatePomFile>
-              <flattenMode>bom</flattenMode>
-              <pomElements>
-                <dependencyManagement>resolve</dependencyManagement>
-                <properties>flatten</properties>
-              </pomElements>
-            </configuration>
-          </execution>
-          <!-- ensure proper cleanup -->
-          <execution>
-            <id>flatten.clean</id>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-    </plugins>
-  </build>
 
 </project>

--- a/flume-third-party/.logging-parent-bom-activator
+++ b/flume-third-party/.logging-parent-bom-activator
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# Marker file to activate BOM flattening

--- a/flume-third-party/pom.xml
+++ b/flume-third-party/pom.xml
@@ -22,37 +22,21 @@
   <parent>
     <groupId>org.apache.flume</groupId>
     <artifactId>flume-project</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>${revision}</version>
   </parent>
-  <groupId>org.apache.flume</groupId>
+
   <artifactId>flume-third-party-dependencies</artifactId>
   <packaging>pom</packaging>
 
   <name>Apache Flume Third Party Dependencies</name>
-
-  <inceptionYear>2009</inceptionYear>
-
-  <organization>
-    <name>Apache Software Foundation</name>
-    <url>http://www.apache.org</url>
-  </organization>
-
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <scm>
-    <connection>scm:git:http://git-wip-us.apache.org/repos/asf/flume.git</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/flume.git</developerConnection>
-    <url>https://git-wip-us.apache.org/repos/asf?p=flume.git;a=tree;h=refs/heads/trunk;hb=trunk</url>
-  </scm>
+  <description>Bill of materials (BOM) for the third-party dependencies of Apache Flume.
+  It matches the versions of the runtime dependencies used by the corresponding `flume-dependencies` artifacts.</description>
 
   <properties>
-    <flume-project.version>2.0.0-SNAPSHOT</flume-project.version>
+    <!-- Re-enable publishing: `flume-project` disables it, but this BOM must be installed and deployed. -->
+    <maven.install.skip>false</maven.install.skip>
+    <maven.deploy.skip>false</maven.deploy.skip>
+
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-codec.version>1.22.0</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
@@ -280,7 +264,7 @@
       <dependency>
         <groupId>org.apache.flume</groupId>
         <artifactId>flume-dependencies</artifactId>
-        <version>${flume-project.version}</version>
+        <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -288,7 +272,7 @@
       <dependency>
         <groupId>org.apache.flume</groupId>
         <artifactId>build-support</artifactId>
-        <version>${flume-project.version}</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
@@ -481,40 +465,4 @@
     </dependencies>
   </dependencyManagement>
 
-  <build>
-    <plugins>
-
-      <!-- Enable BOM flattening -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>flatten-maven-plugin</artifactId>
-        <version>1.7.3</version>
-        <executions>
-          <execution>
-            <id>flatten-bom</id>
-            <goals>
-              <goal>flatten</goal>
-            </goals>
-            <phase>process-resources</phase>
-            <inherited>false</inherited>
-            <configuration>
-              <updatePomFile>true</updatePomFile>
-              <flattenMode>bom</flattenMode>
-              <pomElements>
-                <dependencyManagement>resolve</dependencyManagement>
-                <properties>flatten</properties>
-              </pomElements>
-            </configuration>
-          </execution>
-          <!-- ensure proper cleanup -->
-          <execution>
-            <id>flatten.clean</id>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -15,21 +15,46 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" child.project.url.inherit.append.path="false" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache</groupId>
-    <artifactId>apache</artifactId>
-    <version>23</version>
+    <groupId>org.apache.logging</groupId>
+    <artifactId>logging-parent</artifactId>
+    <version>12.1.1</version>
+    <relativePath />
   </parent>
+
   <groupId>org.apache.flume</groupId>
   <artifactId>flume-project</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <name>Apache Flume Project</name>
+  <description>Aggregator for the main Apache Flume repository.
+  This artifact is not published to Maven Central.</description>
+  <url>https://logging.apache.org/flume/2.x/index.html</url>
+
+  <inceptionYear>2009</inceptionYear>
+
+  <!-- Override the Log4j-specific mailing lists inherited from `logging-parent`. -->
+  <mailingLists>
+    <mailingList>
+      <name>flume-users</name>
+      <subscribe>flume-users-subscribe@logging.apache.org</subscribe>
+      <unsubscribe>flume-users-unsubscribe@logging.apache.org</unsubscribe>
+      <post>flume-users@logging.apache.org</post>
+      <archive>https://lists.apache.org/list.html?flume-users@logging.apache.org</archive>
+    </mailingList>
+    <mailingList>
+      <name>dev</name>
+      <subscribe>dev-subscribe@logging.apache.org</subscribe>
+      <unsubscribe>dev-unsubscribe@logging.apache.org</unsubscribe>
+      <post>dev@logging.apache.org</post>
+      <archive>https://lists.apache.org/list.html?dev@logging.apache.org</archive>
+    </mailingList>
+  </mailingLists>
 
   <modules>
     <module>flume-bom</module>
@@ -53,199 +78,33 @@
     <module>flume-ng-configfilters</module>
   </modules>
 
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/logging-flume.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/logging-flume.git</developerConnection>
+    <tag>rel/${revision}</tag>
+    <url>https://gitbox.apache.org/repos/asf/logging-flume.git</url>
+  </scm>
+
+  <issueManagement>
+    <system>GitHub Issues</system>
+    <url>https://github.com/apache/logging-flume/issues</url>
+  </issueManagement>
+
+  <ciManagement>
+    <system>GitHub Actions</system>
+    <url>https://github.com/apache/logging-flume/actions</url>
+  </ciManagement>
+
   <properties>
-    <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
-    <palantir-java-format.version>2.90.0</palantir-java-format.version>
+    <revision>2.0.0-SNAPSHOT</revision>
+
+    <!-- Dummy value; overwritten by CI at release time. Do not edit manually. -->
+    <project.build.outputTimestamp>2026-01-01T00:00:00Z</project.build.outputTimestamp>
+
+    <!-- `flume-project` is only a reactor aggregator: it is neither installed nor deployed.
+         The published children (`flume-dependencies`, `flume-third-party-dependencies`) override these back to `false`. -->
+    <maven.install.skip>true</maven.install.skip>
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <version>${spotless-maven-plugin.version}</version>
-        </plugin>
-
-      </plugins>
-    </pluginManagement>
-
-    <plugins>
-
-      <!-- Configuration here must match the one in `.editorconfig`! -->
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <configuration>
-          <java>
-            <licenseHeader>
-              <!-- https://www.apache.org/legal/src-headers.html#headers -->
-              <content>/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to you under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */</content>
-            </licenseHeader>
-            <palantirJavaFormat>
-              <version>${palantir-java-format.version}</version>
-            </palantirJavaFormat>
-          </java>
-          <pom>
-            <licenseHeader>
-              <!-- https://www.apache.org/legal/src-headers.html#headers -->
-              <content>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
-&lt;!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one or more
-  ~ contributor license agreements.  See the NOTICE file distributed with
-  ~ this work for additional information regarding copyright ownership.
-  ~ The ASF licenses this file to you under the Apache License, Version 2.0
-  ~ (the "License"); you may not use this file except in compliance with
-  ~ the License.  You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  --&gt;</content>
-              <delimiter>&lt;project</delimiter>
-            </licenseHeader>
-            <sortPom>
-              <expandEmptyElements>false</expandEmptyElements>
-              <!-- Maven Release plugin uses this style -->
-              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-            </sortPom>
-          </pom>
-          <formats>
-            <format>
-              <includes>
-                <include>src/**/*.xml</include>
-              </includes>
-              <excludes>
-                <!-- The license header in changelog entry files causing Git to match irrelevant files.
-                     This is eventually causing merge conflicts.
-                     Hence, we avoid enforcing license headers there. -->
-                <exclude>src/changelog/**/*.xml</exclude>
-              </excludes>
-              <licenseHeader>
-                <!-- https://www.apache.org/legal/src-headers.html#headers -->
-                <content>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
-&lt;!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one or more
-  ~ contributor license agreements.  See the NOTICE file distributed with
-  ~ this work for additional information regarding copyright ownership.
-  ~ The ASF licenses this file to you under the Apache License, Version 2.0
-  ~ (the "License"); you may not use this file except in compliance with
-  ~ the License.  You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  --&gt;</content>
-                <delimiter>&lt;(!DOCTYPE|\w)</delimiter>
-              </licenseHeader>
-              <endWithNewline />
-              <trimTrailingWhitespace />
-            </format>
-            <format>
-              <includes>
-                <include>src/**/*.properties</include>
-              </includes>
-              <licenseHeader>
-                <!-- https://www.apache.org/legal/src-headers.html#headers -->
-                <content>#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to you under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#</content>
-                <delimiter>(##|[^#])</delimiter>
-              </licenseHeader>
-              <endWithNewline />
-            </format>
-          </formats>
-          <yaml>
-            <includes>
-              <include>.asf.yaml</include>
-              <include>.github/**/*.yaml</include>
-              <include>.github/**/*.yml</include>
-              <include>src/**/*.yaml</include>
-              <include>src/**/*.yml</include>
-            </includes>
-            <licenseHeader>
-              <!-- https://www.apache.org/legal/src-headers.html#headers -->
-              <content>#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to you under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#</content>
-              <delimiter>(##|[^#])</delimiter>
-            </licenseHeader>
-            <endWithNewline />
-            <trimTrailingWhitespace />
-          </yaml>
-          <lineEndings>UNIX</lineEndings>
-        </configuration>
-        <dependencies>
-          <!-- `com.palantir.javaformat:palantir-java-format` is a fake dependency to receive updates from `dependabot`, `maven-versions-plugin`, etc.
-               This dependency is not needed to be defined here, it is implied by `<palantirJavaFormat>` element above. -->
-          <dependency>
-            <groupId>com.palantir.javaformat</groupId>
-            <artifactId>palantir-java-format</artifactId>
-            <version>${palantir-java-format.version}</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <id>default-spotless</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-      </plugin>
-
-    </plugins>
-  </build>
 
 </project>


### PR DESCRIPTION
Flume requires two POM hierarchies:

- `flume-dependencies` and `flume-third-party-dependencies` are published flattened, so their common metadata can live in the aggregator `flume-project`, which is **not** published.
- `flume-parent` is reused by satellite repositories, so it **needs** to be published. To avoid an excessive inheritance chain, it extends `logging-parent` directly instead of `flume-project`.
