### PR TITLE
Adapt the build to `logging-parent` conventions

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,11 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+-Dfile.encoding=UTF-8

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,0 +1,2 @@
+.rat-excludes
+**/src/test/resources/test_command.ps1

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestCheckpointRebuilder.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestCheckpointRebuilder.java
@@ -16,7 +16,10 @@
  */
 package org.apache.flume.channel.file;
 
-import static org.apache.flume.channel.file.TestUtils.*;
+import static org.apache.flume.channel.file.TestUtils.compareInputAndOut;
+import static org.apache.flume.channel.file.TestUtils.consumeChannel;
+import static org.apache.flume.channel.file.TestUtils.fillChannel;
+import static org.apache.flume.channel.file.TestUtils.getAllLogs;
 
 import com.google.common.collect.Maps;
 import java.io.File;

--- a/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelRestart.java
+++ b/flume-ng-channels/flume-file-channel/src/test/java/org/apache/flume/channel/file/TestFileChannelRestart.java
@@ -25,7 +25,7 @@ import static org.apache.flume.channel.file.TestUtils.putEvents;
 import static org.apache.flume.channel.file.TestUtils.putWithoutCommit;
 import static org.apache.flume.channel.file.TestUtils.takeEvents;
 import static org.apache.flume.channel.file.TestUtils.takeWithoutCommit;
-import static org.fest.reflect.core.Reflection.*;
+import static org.fest.reflect.core.Reflection.field;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;

--- a/flume-ng-channels/flume-spillable-memory-channel/src/main/java/org/apache/flume/channel/SpillableMemoryChannel.java
+++ b/flume-ng-channels/flume-spillable-memory-channel/src/main/java/org/apache/flume/channel/SpillableMemoryChannel.java
@@ -535,6 +535,9 @@ public class SpillableMemoryChannel extends FileChannel {
             channelCounter.addToEventPutSuccessCount(putList.size());
         }
 
+        // `queueLock` must not be held on blocking operations,
+        // and an approximate channel size is enough for the counter.
+        @SuppressWarnings("GuardedBy")
         @Override
         protected void doRollback() {
             logger.debug("Rollback() of " + (takeCalled ? " Take Tx" : (putCalled ? " Put Tx" : "Empty Tx")));
@@ -729,6 +732,8 @@ public class SpillableMemoryChannel extends FileChannel {
         super.configure(context);
     }
 
+    // the unguarded read of `memQueue` only detects whether the queue needs resizing
+    @SuppressWarnings("GuardedBy")
     private void resizePrimaryQueue(int newMemoryCapacity) throws InterruptedException {
         if (memQueue != null && memoryCapacity == newMemoryCapacity) {
             return;
@@ -765,6 +770,8 @@ public class SpillableMemoryChannel extends FileChannel {
         }
     }
 
+    // an approximate channel size is enough for the counter
+    @SuppressWarnings("GuardedBy")
     @Override
     public synchronized void start() {
         super.start();
@@ -779,6 +786,8 @@ public class SpillableMemoryChannel extends FileChannel {
         channelCounter.setChannelSize(totalCount);
     }
 
+    // an approximate channel size is enough for the counter
+    @SuppressWarnings("GuardedBy")
     @Override
     public synchronized void stop() {
         if (getLifecycleState() == LifecycleState.STOP) {

--- a/flume-ng-configfilters/flume-ng-external-process-config-filter/src/test/resources/test.sh
+++ b/flume-ng-configfilters/flume-ng-external-process-config-filter/src/test/resources/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 
 if [ $1 = "my_password_key" ]; then
     echo "filtered";

--- a/flume-ng-configfilters/flume-ng-external-process-config-filter/src/test/resources/test_error.sh
+++ b/flume-ng-configfilters/flume-ng-external-process-config-filter/src/test/resources/test_error.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
 echo "Error message from stderr" 1>&2
 echo "Error message from stdout"
 

--- a/flume-ng-configuration/src/test/java/org/apache/flume/conf/TestAgentConfiguration.java
+++ b/flume-ng-configuration/src/test/java/org/apache/flume/conf/TestAgentConfiguration.java
@@ -17,7 +17,11 @@
 package org.apache.flume.conf;
 
 import static org.apache.flume.conf.FlumeConfigurationError.ErrorOrWarning.ERROR;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/flume-ng-configuration/src/test/java/org/apache/flume/conf/TestFlumeConfiguration.java
+++ b/flume-ng-configuration/src/test/java/org/apache/flume/conf/TestFlumeConfiguration.java
@@ -17,7 +17,12 @@
 package org.apache.flume.conf;
 
 import static org.apache.flume.conf.FlumeConfigurationError.ErrorOrWarning.ERROR;
-import static org.apache.flume.conf.FlumeConfigurationErrorType.*;
+import static org.apache.flume.conf.FlumeConfigurationErrorType.AGENT_CONFIGURATION_INVALID;
+import static org.apache.flume.conf.FlumeConfigurationErrorType.AGENT_NAME_MISSING;
+import static org.apache.flume.conf.FlumeConfigurationErrorType.CONFIG_ERROR;
+import static org.apache.flume.conf.FlumeConfigurationErrorType.INVALID_PROPERTY;
+import static org.apache.flume.conf.FlumeConfigurationErrorType.PROPERTY_NAME_NULL;
+import static org.apache.flume.conf.FlumeConfigurationErrorType.PROPERTY_VALUE_NULL;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;

--- a/flume-ng-core/pom.xml
+++ b/flume-ng-core/pom.xml
@@ -190,7 +190,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>${mvn-antrun-plugin.version}</version>
             <executions>
               <execution>
                 <id>generate-version</id>
@@ -213,7 +212,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>${mvn-build-helper-plugin}</version>
             <executions>
               <execution>
                 <id>add-source</id>
@@ -246,7 +244,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>${mvn-antrun-plugin.version}</version>
             <executions>
               <execution>
                 <id>generate-version</id>
@@ -269,7 +266,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>${mvn-build-helper-plugin}</version>
             <executions>
               <execution>
                 <id>add-source</id>

--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
@@ -110,6 +110,9 @@ public class MemoryChannel extends BasicChannelSemantics implements TransactionC
             return event;
         }
 
+        // `queueLock` must not be held on blocking operations,
+        // and an approximate channel size is sufficient for the counter.
+        @SuppressWarnings("GuardedBy")
         @Override
         protected void doCommit() throws InterruptedException {
             int remainingChange = takeList.size() - putList.size();
@@ -158,6 +161,9 @@ public class MemoryChannel extends BasicChannelSemantics implements TransactionC
             channelCounter.setChannelSize(queue.size());
         }
 
+        // `queueLock` must not be held on blocking operations
+        // and an approximate channel size is sufficient for the counter.
+        @SuppressWarnings("GuardedBy")
         @Override
         protected void doRollback() {
             int takes = takeList.size();
@@ -218,6 +224,8 @@ public class MemoryChannel extends BasicChannelSemantics implements TransactionC
      * <li>byteCapacityBufferPercentage = type int that defines the percent of buffer between byteCapacity and the estimated event size.
      * <li>keep-alive = type int that defines the number of second to wait for a queue permit
      */
+    // the unguarded null check on `queue` only detects whether the channel was already configured
+    @SuppressWarnings("GuardedBy")
     @Override
     public void configure(Context context) {
         Integer capacity = null;
@@ -347,6 +355,8 @@ public class MemoryChannel extends BasicChannelSemantics implements TransactionC
         }
     }
 
+    // an approximate channel size is sufficient for the counter
+    @SuppressWarnings("GuardedBy")
     @Override
     public synchronized void start() {
         channelCounter.start();
@@ -355,6 +365,8 @@ public class MemoryChannel extends BasicChannelSemantics implements TransactionC
         super.start();
     }
 
+    // an approximate channel size is sufficient for the counter
+    @SuppressWarnings("GuardedBy")
     @Override
     public synchronized void stop() {
         channelCounter.setChannelSize(queue.size());

--- a/flume-ng-core/src/main/java/org/apache/flume/event/EventHelper.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/event/EventHelper.java
@@ -61,7 +61,7 @@ public class EventHelper {
             }
             String result = buffer.toString();
             if (result.endsWith(EOL) && buffer.length() > EOL.length()) {
-                buffer.delete(buffer.length() - EOL.length(), buffer.length()).toString();
+                buffer.delete(buffer.length() - EOL.length(), buffer.length());
             }
         }
         return "{ headers:" + event.getHeaders() + " body:" + buffer + " }";

--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/HostInterceptor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/HostInterceptor.java
@@ -16,7 +16,12 @@
  */
 package org.apache.flume.interceptor;
 
-import static org.apache.flume.interceptor.HostInterceptor.Constants.*;
+import static org.apache.flume.interceptor.HostInterceptor.Constants.HOST;
+import static org.apache.flume.interceptor.HostInterceptor.Constants.HOST_HEADER;
+import static org.apache.flume.interceptor.HostInterceptor.Constants.PRESERVE;
+import static org.apache.flume.interceptor.HostInterceptor.Constants.PRESERVE_DFLT;
+import static org.apache.flume.interceptor.HostInterceptor.Constants.USE_IP;
+import static org.apache.flume.interceptor.HostInterceptor.Constants.USE_IP_DFLT;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;

--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/TimestampInterceptor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/TimestampInterceptor.java
@@ -16,7 +16,10 @@
  */
 package org.apache.flume.interceptor;
 
-import static org.apache.flume.interceptor.TimestampInterceptor.Constants.*;
+import static org.apache.flume.interceptor.TimestampInterceptor.Constants.CONFIG_HEADER_NAME;
+import static org.apache.flume.interceptor.TimestampInterceptor.Constants.CONFIG_PRESERVE;
+import static org.apache.flume.interceptor.TimestampInterceptor.Constants.DEFAULT_HEADER_NAME;
+import static org.apache.flume.interceptor.TimestampInterceptor.Constants.DEFAULT_PRESERVE;
 
 import java.util.List;
 import java.util.Map;

--- a/flume-ng-core/src/test/java/org/apache/flume/TestContext.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/TestContext.java
@@ -16,7 +16,8 @@
  */
 package org.apache.flume;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;

--- a/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
@@ -300,7 +300,7 @@ public class TestMemoryChannel {
     }
 
     @Test
-    @Ignore
+    @Ignore("TODO: document why this test is disabled and re-enable it.")
     public void testByteCapacityBufferEmptyingAfterTakeCommit() {
         Context context = new Context();
         Map<String, String> parms = new HashMap<String, String>();

--- a/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannel.java
@@ -34,6 +34,7 @@ import org.apache.flume.event.SimpleEvent;
 import org.apache.flume.exception.ChannelException;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestMemoryChannel {
@@ -298,6 +299,8 @@ public class TestMemoryChannel {
         Assert.assertEquals(8, channel.getBytesRemainingValue());
     }
 
+    @Test
+    @Ignore
     public void testByteCapacityBufferEmptyingAfterTakeCommit() {
         Context context = new Context();
         Map<String, String> parms = new HashMap<String, String>();

--- a/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannelConcurrency.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/channel/TestMemoryChannelConcurrency.java
@@ -224,6 +224,7 @@ public class TestMemoryChannelConcurrency {
         final CountDownLatch startGate = new CountDownLatch(1);
         final CountDownLatch endGate = new CountDownLatch(threadCount);
 
+        final Object takeMapLock = new Object();
         // start a sink and source for each
         for (int i = 0; i < threadCount / 2; i++) {
             Thread t = new Thread() {
@@ -268,7 +269,6 @@ public class TestMemoryChannelConcurrency {
             };
             // start source
             t.start();
-            final Integer takeMapLock = 0;
             t = new Thread() {
                 @Override
                 public void run() {

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestAbstractPollableSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestAbstractPollableSource.java
@@ -16,7 +16,7 @@
  */
 package org.apache.flume.source;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.spy;
 
 import java.util.HashMap;
 import org.apache.flume.Context;

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestBasicSourceSemantics.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestBasicSourceSemantics.java
@@ -16,7 +16,8 @@
  */
 package org.apache.flume.source;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 import org.apache.flume.Context;
 import org.apache.flume.FlumeException;

--- a/flume-ng-core/src/test/java/org/apache/flume/tools/TestVersionInfo.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/tools/TestVersionInfo.java
@@ -16,7 +16,8 @@
  */
 package org.apache.flume.tools;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/flume-ng-instrumentation/flume-ganglia-monitor/pom.xml
+++ b/flume-ng-instrumentation/flume-ganglia-monitor/pom.xml
@@ -30,6 +30,8 @@
   <name>Flume Ganglia Monitor</name>
 
   <properties>
+    <!-- This artifact was never released before -->
+    <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
     <!-- TODO fix spotbugs violations -->
     <spotbugs.maxAllowedViolations>13</spotbugs.maxAllowedViolations>
     <module.name>org.apache.flume.instrumentation.ganglia</module.name>

--- a/flume-ng-instrumentation/flume-ganglia-monitor/src/main/resources/META-INF/services/org.apache.flume.instrumentation.MonitorService
+++ b/flume-ng-instrumentation/flume-ganglia-monitor/src/main/resources/META-INF/services/org.apache.flume.instrumentation.MonitorService
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 org.apache.flume.instrumentation.ganglia.GangliaServer

--- a/flume-ng-instrumentation/flume-http-monitor/pom.xml
+++ b/flume-ng-instrumentation/flume-http-monitor/pom.xml
@@ -30,6 +30,8 @@
   <name>Flume HTTP Monitor</name>
 
   <properties>
+    <!-- This artifact was never released before -->
+    <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
     <!-- TODO fix spotbugs violations -->
     <spotbugs.maxAllowedViolations>3</spotbugs.maxAllowedViolations>
     <module.name>org.apache.flume.instrumentation.http</module.name>

--- a/flume-ng-instrumentation/flume-http-monitor/src/main/resources/META-INF/services/org.apache.flume.instrumentation.MonitorService
+++ b/flume-ng-instrumentation/flume-http-monitor/src/main/resources/META-INF/services/org.apache.flume.instrumentation.MonitorService
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 org.apache.flume.instrumentation.http.HTTPMetricsServer

--- a/flume-ng-instrumentation/flume-prometheus-monitor/pom.xml
+++ b/flume-ng-instrumentation/flume-prometheus-monitor/pom.xml
@@ -30,6 +30,8 @@
   <name>Flume Prometheus Monitor</name>
 
   <properties>
+    <!-- This artifact was never released before -->
+    <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
     <!-- TODO fix spotbugs/pmd violations -->
     <spotbugs.maxAllowedViolations>6</spotbugs.maxAllowedViolations>
     <pmd.maxAllowedViolations>1</pmd.maxAllowedViolations>

--- a/flume-ng-instrumentation/flume-prometheus-monitor/src/main/resources/META-INF/services/org.apache.flume.instrumentation.MonitorService
+++ b/flume-ng-instrumentation/flume-prometheus-monitor/src/main/resources/META-INF/services/org.apache.flume.instrumentation.MonitorService
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 org.apache.flume.instrumentation.prometheus.PrometheusHTTPMetricsServer

--- a/flume-ng-node/src/test/java/org/apache/flume/node/TestApplication.java
+++ b/flume-ng-node/src/test/java/org/apache/flume/node/TestApplication.java
@@ -16,7 +16,11 @@
  */
 package org.apache.flume.node;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;

--- a/flume-ng-sources/flume-http-source/pom.xml
+++ b/flume-ng-sources/flume-http-source/pom.xml
@@ -30,6 +30,8 @@
   <name>Flume HTTP Source</name>
 
   <properties>
+    <!-- This artifact was never released before -->
+    <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
     <!-- TODO fix spotbugs/pmd violations -->
     <spotbugs.maxAllowedViolations>10</spotbugs.maxAllowedViolations>
     <pmd.maxAllowedViolations>2</pmd.maxAllowedViolations>

--- a/flume-ng-sources/flume-http-source/src/test/java/org/apache/flume/source/http/TestHTTPSource.java
+++ b/flume-ng-sources/flume-http-source/src/test/java/org/apache/flume/source/http/TestHTTPSource.java
@@ -385,8 +385,8 @@ public class TestHTTPSource {
                         .size()
                 == 0);
 
-        int newPort = findFreePort();
-        Context configuredSourceContext = getDefaultNonSecureContext(newPort);
+        final int firstPort = findFreePort();
+        Context configuredSourceContext = getDefaultNonSecureContext(firstPort);
         configuredSourceContext.put("HttpConfiguration.sendServerVersion", "false");
         configuredSourceContext.put("HttpConfiguration.sendXPoweredBy", "true");
         configuredSourceContext.put("ServerConnector.acceptQueueSize", "22");
@@ -398,7 +398,7 @@ public class TestHTTPSource {
         newChannel.start();
         newSource.start();
 
-        HttpPost newPostRequest = new HttpPost("http://0.0.0.0:" + newPort);
+        HttpPost newPostRequest = new HttpPost("http://0.0.0.0:" + firstPort);
 
         resp = httpClient.execute(newPostRequest);
         Assert.assertTrue(resp.getHeaders("X-Powered-By").length > 0);
@@ -414,8 +414,8 @@ public class TestHTTPSource {
         newChannel.stop();
 
         // Configure SslContextFactory with junk protocols (expect failure)
-        newPort = findFreePort();
-        configuredSourceContext = getDefaultSecureContext(newPort);
+        final int secondPort = findFreePort();
+        configuredSourceContext = getDefaultSecureContext(secondPort);
         configuredSourceContext.put("SslContextFactory.IncludeProtocols", "abc def");
 
         newSource = new HTTPSource();
@@ -426,14 +426,8 @@ public class TestHTTPSource {
         newChannel.start();
         newSource.start();
 
-        newPostRequest = new HttpPost("http://0.0.0.0:" + newPort);
-        try {
-            doTestHttps(null, newPort, httpsChannel);
-            // We are testing that this fails because we've deliberately configured the wrong protocols
-            Assert.assertTrue(false);
-        } catch (AssertionError ex) {
-            // no-op
-        }
+        newPostRequest = new HttpPost("http://0.0.0.0:" + secondPort);
+        Assert.assertThrows(AssertionError.class, () -> doTestHttps(null, secondPort, httpsChannel));
         newSource.stop();
         newChannel.stop();
     }

--- a/flume-ng-sources/flume-netcat-source/pom.xml
+++ b/flume-ng-sources/flume-netcat-source/pom.xml
@@ -30,6 +30,8 @@
   <name>Flume Netcat Source</name>
 
   <properties>
+    <!-- This artifact was never released before -->
+    <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
     <!-- TODO fix spotbugs violations -->
     <spotbugs.maxAllowedViolations>3</spotbugs.maxAllowedViolations>
     <module.name>org.apache.flume.source.netcat</module.name>

--- a/flume-ng-sources/flume-syslog-source/pom.xml
+++ b/flume-ng-sources/flume-syslog-source/pom.xml
@@ -30,6 +30,8 @@
   <name>Flume Syslog Source</name>
 
   <properties>
+    <!-- This artifact was never released before -->
+    <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
     <!-- TODO fix spotbugs violations -->
     <spotbugs.maxAllowedViolations>8</spotbugs.maxAllowedViolations>
     <module.name>org.apache.flume.source.syslog</module.name>

--- a/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestMultiportSyslogTCPSource.java
+++ b/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestMultiportSyslogTCPSource.java
@@ -19,7 +19,8 @@ package org.apache.flume.source.syslog;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.doThrow;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;

--- a/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestSyslogUtils.java
+++ b/flume-ng-sources/flume-syslog-source/src/test/java/org/apache/flume/source/syslog/TestSyslogUtils.java
@@ -16,7 +16,7 @@
  */
 package org.apache.flume.source.syslog;
 
-import static io.netty.buffer.Unpooled.*;
+import static io.netty.buffer.Unpooled.buffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 

--- a/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
+++ b/flume-ng-sources/flume-taildir-source/src/main/java/org/apache/flume/source/taildir/TaildirSource.java
@@ -16,7 +16,29 @@
  */
 package org.apache.flume.source.taildir;
 
-import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.*;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.BATCH_SIZE;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.BYTE_OFFSET_HEADER;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.CACHE_PATTERN_MATCHING;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_BATCH_SIZE;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_BYTE_OFFSET_HEADER;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_CACHE_PATTERN_MATCHING;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_FILENAME_HEADER_KEY;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_FILE_HEADER;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_IDLE_TIMEOUT;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_MAX_BATCH_COUNT;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_POSITION_FILE;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_SKIP_TO_END;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.DEFAULT_WRITE_POS_INTERVAL;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.FILENAME_HEADER;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.FILENAME_HEADER_KEY;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.FILE_GROUPS;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.FILE_GROUPS_PREFIX;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.HEADERS_PREFIX;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.IDLE_TIMEOUT;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.MAX_BATCH_COUNT;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.POSITION_FILE;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.SKIP_TO_END;
+import static org.apache.flume.source.taildir.TaildirSourceConfigurationConstants.WRITE_POS_INTERVAL;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;

--- a/flume-parent/pom.xml
+++ b/flume-parent/pom.xml
@@ -413,6 +413,28 @@
 
   <profiles>
 
+    <!-- Read additional RAT exclusions from a `.rat-excludes` file at the root of the repository, if present.
+         Guarded by a profile, since the plugin fails if `excludesFile` points to a missing file. -->
+    <profile>
+      <id>rat-excludes-file</id>
+      <activation>
+        <file>
+          <exists>${maven.multiModuleProjectDirectory}/.rat-excludes</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.rat</groupId>
+            <artifactId>apache-rat-plugin</artifactId>
+            <configuration>
+              <excludesFile>${maven.multiModuleProjectDirectory}/.rat-excludes</excludesFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>skipChecks</id>
       <properties>

--- a/flume-parent/pom.xml
+++ b/flume-parent/pom.xml
@@ -15,200 +15,67 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" child.project.url.inherit.append.path="false" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache</groupId>
-    <artifactId>apache</artifactId>
-    <version>23</version>
+    <groupId>org.apache.logging</groupId>
+    <artifactId>logging-parent</artifactId>
+    <version>12.1.1</version>
     <relativePath />
   </parent>
+
   <groupId>org.apache.flume</groupId>
   <artifactId>flume-parent</artifactId>
   <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <name>Apache Flume</name>
+  <name>Apache Flume Parent</name>
+  <description>Parent POM of all Apache Flume modules.
+  It imports the Flume BOMs and provides the common test dependencies and build configuration, also for the satellite repositories.</description>
+  <url>https://logging.apache.org/flume/2.x/index.html</url>
 
   <inceptionYear>2009</inceptionYear>
 
-  <organization>
-    <name>Apache Software Foundation</name>
-    <url>http://www.apache.org</url>
-  </organization>
-
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <id>abayer</id>
-      <name>Andrew Bayer</name>
-      <email>abayer@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>ahmed</id>
-      <name>Ahmed Radwan</name>
-      <email>ahmed@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>arvind</id>
-      <name>Arvind Prabhakar</name>
-      <email>arvind@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>brock</id>
-      <name>Brock Noland</name>
-      <email>brock@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>brucem</id>
-      <name>Bruce Mitchener</name>
-      <email>brucem@apache.org</email>
-      <organization>-</organization>
-    </developer>
-    <developer>
-      <id>ddeeter</id>
-      <name>Derek Deeter</name>
-      <email>ddeeter@apache.org</email>
-      <organization>Intuit</organization>
-    </developer>
-    <developer>
-      <id>esammer</id>
-      <name>Eric Sammer</name>
-      <email>esammer@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>henry</id>
-      <name>Henry Robinson</name>
-      <email>henry@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>hshreedharan</id>
-      <name>Hari Shreedharan</name>
-      <email>hshreedharan@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>jarcec</id>
-      <name>Jaroslav Cecho</name>
-      <email>jarcec@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>jmhsieh</id>
-      <name>Jonathan Hsieh</name>
-      <email>jmhsieh@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>juhanic</id>
-      <name>Juhani Connolly</name>
-      <email>juhanic@apache.org</email>
-      <organization>CyberAgent</organization>
-    </developer>
-    <developer>
-      <id>kimballa</id>
-      <name>Aaron Kimball</name>
-      <email>kimballa@apache.org</email>
-      <organization>Odiago</organization>
-    </developer>
-    <developer>
-      <id>mlai</id>
-      <name>Mingjie Lai</name>
-      <email>mlai@apache.org</email>
-      <organization>Trend Micro</organization>
-    </developer>
-    <developer>
-      <id>mpercy</id>
-      <name>Mike Percy</name>
-      <email>mpercy@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>nerdynick</id>
-      <name>Nick Verbeck</name>
-      <email>nerdynick@apache.org</email>
-      <organization>-</organization>
-    </developer>
-    <developer>
-      <id>phunt</id>
-      <name>Patrick Hunt</name>
-      <email>phunt@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>prasadm</id>
-      <name>Prasad Mujumdar</name>
-      <email>prasadm@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>rgoers</id>
-      <name>Ralph Goers</name>
-      <email>rgoers@apache.org</email>
-      <organization>Intuit</organization>
-    </developer>
-    <developer>
-      <id>will</id>
-      <name>Will McQueen</name>
-      <email>will@apache.org</email>
-      <organization>Cloudera</organization>
-    </developer>
-    <developer>
-      <id>roshannaik</id>
-      <name>Roshan</name>
-      <email>roshannaik@apache.org</email>
-      <organization>Hortonworks</organization>
-    </developer>
-  </developers>
-
+  <!-- Override the Log4j-specific mailing lists inherited from `logging-parent`. -->
   <mailingLists>
     <mailingList>
-      <name>Flume User List</name>
-      <subscribe>user-subscribe@flume.apache.org</subscribe>
-      <unsubscribe>user-unsubscribe@flume.apache.org</unsubscribe>
-      <post>user@flume.apache.org</post>
-      <archive>http://mail-archives.apache.org/mod_mbox/flume-user/</archive>
+      <name>flume-users</name>
+      <subscribe>flume-users-subscribe@logging.apache.org</subscribe>
+      <unsubscribe>flume-users-unsubscribe@logging.apache.org</unsubscribe>
+      <post>flume-users@logging.apache.org</post>
+      <archive>https://lists.apache.org/list.html?flume-users@logging.apache.org</archive>
     </mailingList>
     <mailingList>
-      <name>Flume Developer List</name>
-      <subscribe>dev@logging.apache.org</subscribe>
+      <name>dev</name>
+      <subscribe>dev-subscribe@logging.apache.org</subscribe>
       <unsubscribe>dev-unsubscribe@logging.apache.org</unsubscribe>
-      <post>dev@flume.apache.org</post>
-      <archive>http://mail-archives.apache.org/mod_mbox/flume-dev/</archive>
+      <post>dev@logging.apache.org</post>
+      <archive>https://lists.apache.org/list.html?dev@logging.apache.org</archive>
     </mailingList>
   </mailingLists>
 
-  <scm>
-    <connection>scm:git:http://git-wip-us.apache.org/repos/asf/flume.git</connection>
-    <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/flume.git</developerConnection>
-    <url>https://git-wip-us.apache.org/repos/asf?p=flume.git;a=tree;h=refs/heads/trunk;hb=trunk</url>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/logging-flume.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/logging-flume.git</developerConnection>
+    <tag>rel/${project.version}</tag>
+    <url>https://gitbox.apache.org/repos/asf/logging-flume.git</url>
   </scm>
 
   <issueManagement>
-    <system>JIRA</system>
-    <url>https://issues.apache.org/jira/browse/FLUME</url>
+    <system>GitHub Issues</system>
+    <url>https://github.com/apache/logging-flume/issues</url>
   </issueManagement>
 
   <ciManagement>
-    <system>jenkins</system>
-    <url>https://builds.apache.org/job/flume-trunk</url>
+    <system>GitHub Actions</system>
+    <url>https://github.com/apache/logging-flume/actions</url>
   </ciManagement>
 
   <properties>
+
+    <!-- Version of the artifacts released from the main `logging-flume` repository -->
     <flume-project.version>2.0.0-SNAPSHOT</flume-project.version>
     <!-- The website is generated by Antora from `flume-project`: skip the per-module `maven-site-plugin` sites. -->
     <maven.site.skip>true</maven.site.skip>
@@ -217,49 +84,28 @@
     <!-- Set default encoding to UTF-8 to remove maven complaints -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <!-- Java compiler configuration -->
-    <releaseJavaVersion>17</releaseJavaVersion>
-
-    <!-- Signing User for release -->
-    <GPGSigningUserName>rgoers@apache.org</GPGSigningUserName>
+    <!-- Flume generates Java 17 bytecode. Disable all compiler switches except `release` -->
+    <maven.compiler.source />
+    <maven.compiler.target />
+    <maven.compiler.release>17</maven.compiler.release>
 
     <!-- defaults for flaky test and focused test exclusions -->
     <test.exclude.pattern>$</test.exclude.pattern>
     <!-- junk pattern -->
     <test.include.pattern>**/Test*.java</test.include.pattern>
-    <stagingDirectory>${project.basedir}/target/docs</stagingDirectory>
+    <redirectTestOutput>true</redirectTestOutput>
 
-    <bundle-plugin.version>2.3.7</bundle-plugin.version>
     <curator.version>5.9.0</curator.version>
     <fest-reflect.version>1.4.1</fest-reflect.version>
     <hadoop.version>3.5.0</hadoop.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>5.18.0</mockito.version>
-    <mvn-antrun-plugin.version>1.8</mvn-antrun-plugin.version>
-    <!-- Do not upgrade the assumbly plugin version until MASSEMBLY-941 is fixed -->
-    <mvn-assembly-plugin.version>3.2.0</mvn-assembly-plugin.version>
-    <mvn-build-helper-plugin>3.0.0</mvn-build-helper-plugin>
     <mvn-checksum-plugin.version>1.7</mvn-checksum-plugin.version>
-    <mvn-clean-plugin.version>3.1.0</mvn-clean-plugin.version>
-    <mvn-compiler-plugin.version>3.8.1</mvn-compiler-plugin.version>
-    <mvn-deploy-plugin.version>2.8.2</mvn-deploy-plugin.version>
-    <mvn-gpg-plugin.version>1.6</mvn-gpg-plugin.version>
-    <mvn-jar-plugin.version>3.2.2</mvn-jar-plugin.version>
-    <mvn-javadoc-plugin.version>3.2.0</mvn-javadoc-plugin.version>
     <mvn-pmd-plugin.version>3.15.0</mvn-pmd-plugin.version>
-    <mvn-site-plugin.version>3.9.0</mvn-site-plugin.version>
-    <spotbugs.version>4.9.3</spotbugs.version>
-    <mvn-spotbugs-plugin.version>${spotbugs.version}.0</mvn-spotbugs-plugin.version>
-    <mvn-surefire-plugin.version>3.5.5</mvn-surefire-plugin.version>
     <external.protobuf.version>4.35.0</external.protobuf.version>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
-    <rat.version>0.12</rat.version>
-    <wiremock.version>1.53</wiremock.version>
     <os.maven.version>1.7.1</os.maven.version>
-    <redirectTestOutput>true</redirectTestOutput>
-    <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
     <system-rules.version>1.19.0</system-rules.version>
-    <palantir-java-format.version>2.90.0</palantir-java-format.version>
   </properties>
 
   <dependencyManagement>
@@ -411,6 +257,21 @@
         <version>3.10.8</version>
         <scope>test</scope>
       </dependency>
+
+      <!-- Transitive dependencies pinned to satisfy `requireUpperBoundDeps`,
+           so that resolution does not depend on declaration order.
+           
+           If the check fails here, try:
+           1. Removing the pin first,
+           2. Otherwise, bump to the highest version required by our direct dependencies.
+           
+           Dependabot must *not* upgrade these dependencies.
+        -->
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.48.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -418,75 +279,19 @@
 
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <version>${mvn-antrun-plugin.version}</version>
-        </plugin>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-gpg-plugin</artifactId>
-          <version>${mvn-gpg-plugin.version}</version>
-          <configuration>
-            <excludes>
-              <exclude>**/*.sha512</exclude>
-            </excludes>
-            <keyname>${GPGSigningUserName}</keyname>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>${mvn-compiler-plugin.version}</version>
-          <configuration>
-            <release>${releaseJavaVersion}</release>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>${mvn-jar-plugin.version}</version>
-          <executions>
-            <execution>
-              <id>default-jar</id>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-              <configuration>
-                <archive>
-                  <manifestEntries>
-                    <Specification-Title>${project.name}</Specification-Title>
-                    <Specification-Version>${flume-project.version}</Specification-Version>
-                    <Specification-Vendor>${project.organization.name}</Specification-Vendor>
-                    <Implementation-Title>${project.name}</Implementation-Title>
-                    <Implementation-Version>${flume-project.version}</Implementation-Version>
-                    <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
-                    <Implementation-Vendor-Id>org.apache</Implementation-Vendor-Id>
-                    <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
-                    <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
-                    <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
-                  </manifestEntries>
-                </archive>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
           <artifactId>protobuf-maven-plugin</artifactId>
           <version>${protobuf.plugin.version}</version>
         </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${mvn-surefire-plugin.version}</version>
           <configuration>
             <reuseForks>false</reuseForks>
             <forkCount>1</forkCount>
-            <!--<rerunFailingTestsCount>10</rerunFailingTestsCount>-->
             <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
             <redirectTestOutputToFile>${redirectTestOutput}</redirectTestOutputToFile>
             <argLine>-Djava.net.preferIPv4Stack=true</argLine>
@@ -501,120 +306,11 @@
         </plugin>
 
         <plugin>
-          <groupId>org.apache.rat</groupId>
-          <artifactId>apache-rat-plugin</artifactId>
-          <version>${rat.version}</version>
-          <configuration>
-            <excludes>
-              <exclude>**/.idea/</exclude>
-              <exclude>**/*.iml</exclude>
-              <exclude>src/main/resources/META-INF/services/**/*</exclude>
-              <exclude>**/nb-configuration.xml</exclude>
-              <exclude>.git/</exclude>
-              <exclude>patchprocess/</exclude>
-              <exclude>.gitignore</exclude>
-              <exclude>**/*.yml</exclude>
-              <exclude>**/*.yaml</exclude>
-              <exclude>**/*.json</exclude>
-              <!-- ASF jenkins box puts the Maven repo in our root directory. -->
-              <exclude>.repository/</exclude>
-              <exclude>**/*.diff</exclude>
-              <exclude>**/*.patch</exclude>
-              <exclude>**/*.avsc</exclude>
-              <exclude>**/*.avro</exclude>
-              <exclude>**/docs/**</exclude>
-              <exclude>**/test/resources/**</exclude>
-              <exclude>**/.settings/*</exclude>
-              <exclude>**/.classpath</exclude>
-              <exclude>**/.project</exclude>
-              <exclude>**/target/**</exclude>
-              <exclude>**/derby.log</exclude>
-              <exclude>**/metastore_db/</exclude>
-              <exclude>.mvn/**</exclude>
-              <exclude>**/exclude-pmd.properties</exclude>
-            </excludes>
-            <consoleOutput>true</consoleOutput>
-          </configuration>
-          <executions>
-            <execution>
-              <id>verify.rat</id>
-              <goals>
-                <goal>check</goal>
-              </goals>
-              <phase>verify</phase>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${mvn-javadoc-plugin.version}</version>
-          <configuration>
-            <outputDirectory>${project.build.directory}/site/apidocs</outputDirectory>
-            <!-- switch on dependency-driven aggregation -->
-            <includeDependencySources>true</includeDependencySources>
-
-            <dependencySourceIncludes>
-              <!-- include ONLY flume multi-module dependencies -->
-              <dependencySourceInclude>org.apache.flume:*</dependencySourceInclude>
-            </dependencySourceIncludes>
-            <additionalparam>-Xdoclint:none</additionalparam>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <version>${mvn-assembly-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>${mvn-clean-plugin.version}</version>
-          <configuration>
-            <filesets>
-              <fileset>
-                <directory>docs</directory>
-                <includes>
-                  <include>**</include>
-                </includes>
-              </fileset>
-            </filesets>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>com.github.spotbugs</groupId>
-          <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>${mvn-spotbugs-plugin.version}</version>
-          <configuration>
-            <effort>Max</effort>
-            <threshold>Low</threshold>
-          </configuration>
-          <executions>
-            <execution>
-              <id>verify.spotbugs</id>
-              <goals>
-                <goal>check</goal>
-              </goals>
-              <phase>verify</phase>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>com.diffplug.spotless</groupId>
-          <artifactId>spotless-maven-plugin</artifactId>
-          <version>${spotless-maven-plugin.version}</version>
-        </plugin>
-
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${mvn-pmd-plugin.version}</version>
           <configuration>
-            <targetJdk>${releaseJavaVersion}</targetJdk>
+            <targetJdk>${maven.compiler.release}</targetJdk>
             <excludeRoots>
               <excludeRoot>${project.build.directory}/generated-sources</excludeRoot>
             </excludeRoots>
@@ -637,193 +333,21 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
 
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-      </plugin>
-
-      <!-- Configuration here must match the one in `.editorconfig`! -->
+      <!-- Append the Flume-specific exclusions to the Spotless configuration of `logging-parent`. -->
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <configuration>
           <java>
             <excludes>
-              <!-- Third-party vendored sources: ASF policy forbids adding the ASF header to them.
-                   They keep their original header and are formatted by a dedicated execution
-                   (see the `guava` execution in `flume-ng-core`). -->
+              <!-- Third-party vendored sources: ASF policy forbids adding the ASF header to them. -->
               <exclude>**/source/shaded/guava/**</exclude>
             </excludes>
-            <licenseHeader>
-              <!-- https://www.apache.org/legal/src-headers.html#headers -->
-              <content>/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to you under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */</content>
-            </licenseHeader>
-            <palantirJavaFormat>
-              <version>${palantir-java-format.version}</version>
-            </palantirJavaFormat>
           </java>
-          <pom>
-            <licenseHeader>
-              <!-- https://www.apache.org/legal/src-headers.html#headers -->
-              <content>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
-&lt;!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one or more
-  ~ contributor license agreements.  See the NOTICE file distributed with
-  ~ this work for additional information regarding copyright ownership.
-  ~ The ASF licenses this file to you under the Apache License, Version 2.0
-  ~ (the "License"); you may not use this file except in compliance with
-  ~ the License.  You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  --&gt;</content>
-              <delimiter>&lt;project</delimiter>
-            </licenseHeader>
-            <sortPom>
-              <expandEmptyElements>false</expandEmptyElements>
-              <!-- Maven Release plugin uses this style -->
-              <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
-            </sortPom>
-          </pom>
-          <formats>
-            <format>
-              <includes>
-                <include>src/**/*.xml</include>
-              </includes>
-              <excludes>
-                <!-- The license header in changelog entry files causing Git to match irrelevant files.
-                     This is eventually causing merge conflicts.
-                     Hence, we avoid enforcing license headers there. -->
-                <exclude>src/changelog/**/*.xml</exclude>
-              </excludes>
-              <licenseHeader>
-                <!-- https://www.apache.org/legal/src-headers.html#headers -->
-                <content>&lt;?xml version="1.0" encoding="UTF-8"?&gt;
-&lt;!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one or more
-  ~ contributor license agreements.  See the NOTICE file distributed with
-  ~ this work for additional information regarding copyright ownership.
-  ~ The ASF licenses this file to you under the Apache License, Version 2.0
-  ~ (the "License"); you may not use this file except in compliance with
-  ~ the License.  You may obtain a copy of the License at
-  ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  --&gt;</content>
-                <delimiter>&lt;(!DOCTYPE|\w)</delimiter>
-              </licenseHeader>
-              <endWithNewline />
-              <trimTrailingWhitespace />
-            </format>
-            <format>
-              <includes>
-                <include>src/**/*.properties</include>
-              </includes>
-              <licenseHeader>
-                <!-- https://www.apache.org/legal/src-headers.html#headers -->
-                <content>#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to you under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#</content>
-                <delimiter>(##|[^#])</delimiter>
-              </licenseHeader>
-              <endWithNewline />
-            </format>
-          </formats>
-          <yaml>
-            <includes>
-              <include>.asf.yaml</include>
-              <include>.github/**/*.yaml</include>
-              <include>.github/**/*.yml</include>
-              <include>src/**/*.yaml</include>
-              <include>src/**/*.yml</include>
-            </includes>
-            <licenseHeader>
-              <!-- https://www.apache.org/legal/src-headers.html#headers -->
-              <content>#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to you under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#</content>
-              <delimiter>(##|[^#])</delimiter>
-            </licenseHeader>
-            <endWithNewline />
-            <trimTrailingWhitespace />
-          </yaml>
-          <lineEndings>UNIX</lineEndings>
         </configuration>
-        <dependencies>
-          <!-- `com.palantir.javaformat:palantir-java-format` is a fake dependency to receive updates from `dependabot`, `maven-versions-plugin`, etc.
-               This dependency is not needed to be defined here, it is implied by `<palantirJavaFormat>` element above. -->
-          <dependency>
-            <groupId>com.palantir.javaformat</groupId>
-            <artifactId>palantir-java-format</artifactId>
-            <version>${palantir-java-format.version}</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <id>default-spotless</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -876,6 +400,7 @@
         </executions>
       </plugin>
     </plugins>
+
     <extensions>
       <extension>
         <groupId>kr.motd.maven</groupId>
@@ -886,104 +411,7 @@
 
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-        <reportSets>
-          <reportSet>
-            <reports>
-              <report>ci-management</report>
-              <report>distribution-management</report>
-              <report>team</report>
-              <report>mailing-lists</report>
-              <report>issue-management</report>
-              <report>licenses</report>
-              <report>scm</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-      </plugin>
-
-    </plugins>
-  </reporting>
-
   <profiles>
-
-    <profile>
-      <id>not-windows</id>
-      <activation>
-        <os>
-          <family>!Windows</family>
-        </os>
-      </activation>
-    </profile>
-
-    <profile>
-      <id>windows</id>
-      <activation>
-        <os>
-          <family>Windows</family>
-        </os>
-      </activation>
-    </profile>
-
-    <profile>
-      <id>sign</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-                <phase>verify</phase>
-                <configuration>
-                  <keyname>${GPGSigningUserName}</keyname>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>site</id>
-
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
-            <executions>
-              <execution>
-                <id>javadoc-jar</id>
-                <goals>
-                  <goal>aggregate-jar</goal>
-                </goals>
-                <phase>package</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-
-    </profile>
 
     <profile>
       <id>skipChecks</id>
@@ -991,9 +419,8 @@
         <spotbugs.skip>true</spotbugs.skip>
         <pmd.skip>true</pmd.skip>
         <rat.skip>true</rat.skip>
+        <spotless.check.skip>true</spotless.check.skip>
       </properties>
-
     </profile>
   </profiles>
-
 </project>

--- a/flume-third-party/pom.xml
+++ b/flume-third-party/pom.xml
@@ -71,7 +71,7 @@
     <snappy-java.version>1.1.10.8</snappy-java.version>
     <system-rules.version>1.19.0</system-rules.version>
     <zlib.version>1.1.3</zlib.version>
-    <zookeeper.version>3.8.6</zookeeper.version>
+    <zookeeper.version>3.9.3</zookeeper.version>
     <os.maven.version>1.7.1</os.maven.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,4 +113,29 @@
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
+  <profiles>
+
+    <!-- Read additional RAT exclusions from the `.rat-excludes` file at the root of the repository, if present.
+         The code modules inherit the same profile from `flume-parent`, but this aggregator does not. -->
+    <profile>
+      <id>rat-excludes-file</id>
+      <activation>
+        <file>
+          <exists>${maven.multiModuleProjectDirectory}/.rat-excludes</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.rat</groupId>
+            <artifactId>apache-rat-plugin</artifactId>
+            <configuration>
+              <excludesFile>${maven.multiModuleProjectDirectory}/.rat-excludes</excludesFile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Follow-up to #464: makes the whole reactor build green under the `logging-parent` conventions.

- **Adapt build to `logging-parent` conventions**: `flume-parent` now inherits most build configuration from `logging-parent` and the `apache` parent POM. ZooKeeper is bumped to 3.9.3 to satisfy `requireUpperBoundDeps`.
- **Expand star imports**: required by the formatting rules inherited from `logging-parent`.
- **Fix or suppress Error Prone warnings**:
  - the `GuardedBy` suppressions in `MemoryChannel` and `SpillableMemoryChannel` are intentional, so we add `@SuppressWarnings` annotations,
  - a boxed `Integer` lock in tests have been replaced with an `Object` lock,
  - a never-run test,
  - an ignored return value,
  - and a self-catching assertion.
- **Disable BND baseline for never-released artifacts**: six artifacts have no published version on Maven Central to compare against (verified against `repo1.maven.org`).
- **Configure RAT exclusions via `.rat-excludes`**: the file is read by the Maven build (through a file-activated profile, so repositories without the file are unaffected) and by the ASF Trusted Releases platform RAT check.
