### PR TITLE
Make TestRateLimiter locale-independent

### DIFF
--- a/flume-ng-core/src/test/java/org/apache/flume/source/shaded/guava/TestRateLimiter.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/shaded/guava/TestRateLimiter.java
@@ -23,6 +23,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import junit.framework.TestCase;
 import org.apache.flume.source.shaded.guava.RateLimiter.SleepingStopwatch;
@@ -428,7 +429,7 @@ public class TestRateLimiter extends TestCase {
 
         void sleepMicros(String caption, long micros) {
             instant += MICROSECONDS.toNanos(micros);
-            events.add(caption + String.format("%3.2f", (micros / 1000000.0)));
+            events.add(caption + String.format(Locale.ROOT, "%3.2f", (micros / 1000000.0)));
         }
 
         @Override


### PR DESCRIPTION
The vendored Guava `TestRateLimiter` in `flume-ng-core` formatted its expected events with the JVM default locale, so all 12 assertion-based tests failed on machines with a comma decimal separator (e.g. `pl_PL`), reporting `R0,00` instead of `R0.00`.

This passes `Locale.ROOT` to the single `String.format` call in `FakeStopwatch.sleepMicros`, matching the fix upstream Guava applied to the same test. Verified with `mvn test -Dtest=TestRateLimiter` under both `pl_PL.UTF-8` and `en_US.UTF-8` (23/23 pass in each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)