### PR TITLE
Temporarily remove required check

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -71,9 +71,9 @@ github:
       required_conversation_resolution: true
       # Require checks to pass before merging
       required_status_checks:
-        # The GitHub Actions app
-        - app_slug: github-actions
-          name: "build (ubuntu-latest)"
+        ## The GitHub Actions app
+        #- app_slug: github-actions
+        #  name: "build (ubuntu-latest)"
         # The GitHub Advanced Security app
         - app_slug: github-advanced-security
           name: "CodeQL"


### PR DESCRIPTION
Removes the `build (ubuntu-latest)` required check temporarily.

#470 replaces the single build with a matrix, therefore we need to:

1. Remove `build (ubuntu-latest)` from the required checks,
2. Merge #470,
3. Add `build / build (ubuntu-latest)` to the required checks.