### PR TITLE
Enable discussion notifications

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,6 +22,7 @@ notifications:
   # GitHub already provides notifications for PRs and issues.
   # Please don't duplicate that noise here!
   commits: commits@logging.apache.org
+  discussions: dev@logging.apache.org
   jira_options: link label
 github:
   description: "Apache Flume is a distributed, reliable, and available service for efficiently collecting, aggregating, and moving large amounts of log-like data"


### PR DESCRIPTION
To enable GitHub Discussions, we also need to provide an address for the notifications.