### PR TITLE
Adjust PMD violation ceilings to PMD 7 counts

### DIFF
--- a/flume-ng-auth/pom.xml
+++ b/flume-ng-auth/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <!-- TODO fix spotbugs/pmd violations -->
     <spotbugs.maxAllowedViolations>6</spotbugs.maxAllowedViolations>
-    <pmd.maxAllowedViolations>7</pmd.maxAllowedViolations>
+    <pmd.maxAllowedViolations>5</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.auth</module.name>
   </properties>
 

--- a/flume-ng-channels/flume-file-channel/pom.xml
+++ b/flume-ng-channels/flume-file-channel/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <!-- TODO fix spotbugs violations -->
     <spotbugs.maxAllowedViolations>162</spotbugs.maxAllowedViolations>
-    <pmd.maxAllowedViolations>19</pmd.maxAllowedViolations>
+    <pmd.maxAllowedViolations>21</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.channel.file</module.name>
   </properties>
 

--- a/flume-ng-channels/flume-spillable-memory-channel/pom.xml
+++ b/flume-ng-channels/flume-spillable-memory-channel/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <!-- TODO fix spotbugs/pmd violations -->
     <spotbugs.maxAllowedViolations>11</spotbugs.maxAllowedViolations>
-    <pmd.maxAllowedViolations>8</pmd.maxAllowedViolations>
+    <pmd.maxAllowedViolations>4</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.channel.spillable.memory</module.name>
   </properties>
 

--- a/flume-ng-configuration/pom.xml
+++ b/flume-ng-configuration/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <!-- TODO fix spotbugs violations -->
     <spotbugs.maxAllowedViolations>36</spotbugs.maxAllowedViolations>
-    <pmd.maxAllowedViolations>17</pmd.maxAllowedViolations>
+    <pmd.maxAllowedViolations>13</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.conf</module.name>
   </properties>
 

--- a/flume-ng-core/pom.xml
+++ b/flume-ng-core/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <!-- TODO fix spotbugs violations -->
     <spotbugs.maxAllowedViolations>152</spotbugs.maxAllowedViolations>
-    <pmd.maxAllowedViolations>64</pmd.maxAllowedViolations>
+    <pmd.maxAllowedViolations>69</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.core</module.name>
   </properties>
 

--- a/flume-ng-instrumentation/flume-ganglia-monitor/pom.xml
+++ b/flume-ng-instrumentation/flume-ganglia-monitor/pom.xml
@@ -32,8 +32,9 @@
   <properties>
     <!-- This artifact was never released before -->
     <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
-    <!-- TODO fix spotbugs violations -->
+    <!-- TODO fix spotbugs/pmd violations -->
     <spotbugs.maxAllowedViolations>13</spotbugs.maxAllowedViolations>
+    <pmd.maxAllowedViolations>3</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.instrumentation.ganglia</module.name>
   </properties>
 

--- a/flume-ng-node/pom.xml
+++ b/flume-ng-node/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <!-- TODO fix spotbugs violations -->
     <spotbugs.maxAllowedViolations>12</spotbugs.maxAllowedViolations>
-    <pmd.maxAllowedViolations>7</pmd.maxAllowedViolations>
+    <pmd.maxAllowedViolations>5</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.node</module.name>
     <junit-jupiter.version>6.1.2</junit-jupiter.version>
   </properties>

--- a/flume-ng-sdk/pom.xml
+++ b/flume-ng-sdk/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <!-- TODO fix spotbugs/pmd violations -->
     <spotbugs.maxAllowedViolations>69</spotbugs.maxAllowedViolations>
-    <pmd.maxAllowedViolations>170</pmd.maxAllowedViolations>
+    <pmd.maxAllowedViolations>30</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.sdk</module.name>
   </properties>
 

--- a/flume-ng-sources/flume-syslog-source/pom.xml
+++ b/flume-ng-sources/flume-syslog-source/pom.xml
@@ -32,8 +32,9 @@
   <properties>
     <!-- This artifact was never released before -->
     <bnd.baseline.fail.on.missing>false</bnd.baseline.fail.on.missing>
-    <!-- TODO fix spotbugs violations -->
+    <!-- TODO fix spotbugs/pmd violations -->
     <spotbugs.maxAllowedViolations>8</spotbugs.maxAllowedViolations>
+    <pmd.maxAllowedViolations>1</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.source.syslog</module.name>
   </properties>
 

--- a/flume-ng-sources/flume-taildir-source/pom.xml
+++ b/flume-ng-sources/flume-taildir-source/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <!-- TODO fix spotbugs/pmd violations -->
     <spotbugs.maxAllowedViolations>24</spotbugs.maxAllowedViolations>
-    <pmd.maxAllowedViolations>3</pmd.maxAllowedViolations>
+    <pmd.maxAllowedViolations>4</pmd.maxAllowedViolations>
     <module.name>org.apache.flume.source.taildir</module.name>
   </properties>
 


### PR DESCRIPTION
Dependabot PRs were auto-merged without the build being a required check, and #479 (the maven-minor-updates group) bumped `maven-pmd-plugin` 3.15.0 to 3.28.0, moving from PMD 6 to PMD 7.17.0.

The new PMD finds a different violation mix, and `flume-ng-core` now exceeds its `pmd.maxAllowedViolations` ceiling (69 found vs 64 allowed), breaking the build on all platforms. The merge commits triggered no push builds (bot-token merges do not trigger workflows), so trunk is red without CI showing it.

This ratchets every module's `pmd.maxAllowedViolations` to the actual PMD 7.17.0 count:

| Module | Old | New |
|---|---|---|
| flume-ng-core | 64 | 69 |
| flume-ng-sdk | 170 | 30 |
| flume-ng-auth | 7 | 5 |
| flume-ng-configuration | 17 | 13 |
| flume-ng-node | 7 | 5 |
| flume-file-channel | 19 | 21 |
| flume-spillable-memory-channel | 8 | 4 |
| flume-taildir-source | 3 | 4 |
| flume-ganglia-monitor | (none) | 3 |
| flume-syslog-source | (none) | 1 |

ganglia-monitor and syslog-source were previously PMD-clean; they only fail once the reactor gets past flume-ng-core, so their new ceilings are needed too. Fixing the violations themselves (mostly `UnnecessaryModifier` in flume-ng-core) remains a TODO.

Verified locally with a full `mvn -T1C verify` (tests included): BUILD SUCCESS, all modules at or under their ceilings.

The other auto-merged bumps are fine: JUnit Jupiter 6.1.2 and apacheds-jdbm1 built green standalone, and the mockserver-netty PR only hit the known-flaky `TestExecSource.testBatchTimeout` on Windows.
