### PR TITLE
Require the build checks before merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -73,9 +73,13 @@ github:
       required_conversation_resolution: true
       # Require checks to pass before merging
       required_status_checks:
-        ## The GitHub Actions app
-        #- app_slug: github-actions
-        #  name: "build (ubuntu-latest)"
+        # The GitHub Actions app
+        - app_slug: github-actions
+          name: "build / build (macos-latest)"
+        - app_slug: github-actions
+          name: "build / build (ubuntu-latest)"
+        - app_slug: github-actions
+          name: "build / build (windows-latest)"
         # The GitHub Advanced Security app
         - app_slug: github-advanced-security
           name: "CodeQL"


### PR DESCRIPTION
Stacked on the PMD ceilings fix (base: `fix/pmd-7-violation-ceilings`); retarget to `trunk` once that PR merges.

Auto-merged Dependabot PRs landed on trunk with a failing build, because the `build` workflow was not a required status check (only CodeQL was). This adds the three platform jobs of the reusable build workflow to the branch protection ruleset in `.asf.yaml`, so auto-merge waits for a green build:

- `build / build (macos-latest)`
- `build / build (ubuntu-latest)`
- `build / build (windows-latest)`

The check names match the job names reported by the `build` workflow on PRs (reusable workflow jobs report as `<caller job> / <job> (<matrix>)`).

One caveat: `TestExecSource.testBatchTimeout` is known to be flaky on windows-latest, so requiring that job may occasionally need a re-run before auto-merge proceeds.
