### PR TITLE
Run `install` before generating the site

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -45,6 +45,7 @@ jobs:
           profile: ~
           whoami: ${{ github.ref_name }}-site-stg-out
           subdir: content/flume/2.x
+      install-required: true
       target-branch: ${{ github.ref_name }}-site-stg-out
 
   deploy-site-pro:
@@ -59,6 +60,7 @@ jobs:
           profile: ~
           whoami: ${{ github.ref_name }}-out
           subdir: content/flume/2.x
+      install-required: true
       target-branch: ${{ github.ref_name }}-out
 
   export-version:
@@ -85,4 +87,5 @@ jobs:
           profile: ~
           whoami: ${{ github.ref_name }}-site-stg-out
           subdir: content/flume/${{ needs.export-version.outputs.version }}
+      install-required: true
       target-branch: ${{ github.ref_name }}-site-stg-out


### PR DESCRIPTION
The `deploy-site` workflow fails to resolve the reactor's own `2.0.0-SNAPSHOT` artifacts: the `site` lifecycle does not package any jars, so Maven falls back to remote repositories, where no snapshot repository is configured. Past runs only succeeded when the shared `setup-java` Maven cache happened to contain artifacts installed by a previous snapshot deploy job; any POM change rotates the cache key and breaks the build.

Setting `install-required: true` makes the reusable workflow run `./mvnw -Dmaven.test.skip install` before `site`, so the site is generated against the jars of the commit being built. This matches what `logging-log4j2` already does.

In the long term, the duplicate build could be avoided by adding a `reference-artifact-name`-style parameter to `deploy-site-reusable.yaml` (as in `verify-reproducibility-reusable.yaml`), so the site build can reuse the Maven repository produced by the build that deployed the snapshot.