### PR TITLE
De-flake `TestExecSource` on Windows

### DIFF
--- a/flume-ng-core/pom.xml
+++ b/flume-ng-core/pom.xml
@@ -99,6 +99,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.easytesting</groupId>
       <artifactId>fest-reflect</artifactId>
       <scope>test</scope>

--- a/flume-ng-core/src/main/java/org/apache/flume/source/ExecSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/ExecSource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.flume.source;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.BufferedReader;
@@ -258,6 +259,11 @@ public class ExecSource extends AbstractSource implements EventDrivenSource, Con
     @Override
     public long getBatchSize() {
         return bufferCount;
+    }
+
+    @VisibleForTesting
+    SourceCounter getSourceCounter() {
+        return sourceCounter;
     }
 
     private static class ExecRunnable implements Runnable {

--- a/flume-ng-core/src/test/java/org/apache/flume/source/TestExecSource.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/source/TestExecSource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.flume.source;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -31,6 +32,7 @@ import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import javax.management.Attribute;
 import javax.management.AttributeList;
@@ -58,9 +60,9 @@ import org.junit.Test;
 public class TestExecSource {
 
     private AbstractSource source;
-    private Channel channel = new MemoryChannel();
-    private Context context = new Context();
-    private ChannelSelector rcs = new ReplicatingChannelSelector();
+    private final Channel channel = new MemoryChannel();
+    private final Context context = new Context();
+    private final ChannelSelector rcs = new ReplicatingChannelSelector();
 
     @Before
     public void setUp() {
@@ -101,7 +103,8 @@ public class TestExecSource {
         // Generates input file with a random data set (10 lines, 200 characters each)
         FileOutputStream outputStream1 = new FileOutputStream(inputFile);
         for (int i = 0; i < 10; i++) {
-            outputStream1.write(RandomStringUtils.randomAlphanumeric(200).getBytes());
+            outputStream1.write(
+                    RandomStringUtils.insecure().nextAlphanumeric(200).getBytes());
             outputStream1.write('\n');
         }
         outputStream1.close();
@@ -116,7 +119,7 @@ public class TestExecSource {
         Configurables.configure(source, context);
 
         source.start();
-        Thread.sleep(2000);
+        awaitEventCount(10);
         Transaction transaction = channel.getTransaction();
 
         transaction.begin();
@@ -286,35 +289,40 @@ public class TestExecSource {
     public void testBatchTimeout()
             throws InterruptedException, LifecycleException, EventDeliveryException, IOException {
 
-        String filePath = "/tmp/flume-execsource." + Thread.currentThread().getId();
+        File file = File.createTempFile("flume-execsource", null);
+        FileUtils.forceDeleteOnExit(file);
         String eventBody = "TestMessage";
-        FileOutputStream outputStream = new FileOutputStream(filePath);
+
+        // Write the file up front, so the command output does not depend on
+        // when the process starts reading; both commands below print the last
+        // lines of an existing file and then follow it.
+        FileOutputStream outputStream = new FileOutputStream(file);
+        for (int lineNumber = 0; lineNumber < 3; lineNumber++) {
+            outputStream.write((eventBody).getBytes());
+            outputStream.write(String.valueOf(lineNumber).getBytes());
+            outputStream.write('\n');
+        }
+        outputStream.close();
 
         context.put(ExecSourceConfigurationConstants.CONFIG_BATCH_SIZE, "50000");
         context.put(ExecSourceConfigurationConstants.CONFIG_BATCH_TIME_OUT, "750");
         context.put(
                 "shell",
                 SystemUtils.IS_OS_WINDOWS ? "powershell -ExecutionPolicy Unrestricted -command" : "/bin/bash -c");
+        // The process must outlive the batch timeout, so that only the timed
+        // flush can deliver the events.
         context.put(
                 "command",
                 SystemUtils.IS_OS_WINDOWS
-                        ? "Get-Content " + filePath + " | Select-Object -Last 10"
-                        : ("tail -f " + filePath));
+                        ? "Get-Content -Tail 10 -Wait '" + file.getAbsolutePath() + "'"
+                        : ("tail -f " + file.getAbsolutePath()));
 
         Configurables.configure(source, context);
         source.start();
+        awaitEventCount(3);
 
         Transaction transaction = channel.getTransaction();
         transaction.begin();
-
-        for (int lineNumber = 0; lineNumber < 3; lineNumber++) {
-            outputStream.write((eventBody).getBytes());
-            outputStream.write(String.valueOf(lineNumber).getBytes());
-            outputStream.write('\n');
-            outputStream.flush();
-        }
-        outputStream.close();
-        Thread.sleep(1500);
 
         for (int i = 0; i < 3; i++) {
             Event event = channel.take();
@@ -326,8 +334,18 @@ public class TestExecSource {
         transaction.commit();
         transaction.close();
         source.stop();
-        File file = new File(filePath);
         FileUtils.forceDelete(file);
+    }
+
+    /**
+     * Waits until the source accepted the given number of events.
+     *
+     * <p>A fixed sleep is not enough on slow environments, where starting
+     * the child process alone can take several seconds.
+     */
+    private void awaitEventCount(int expected) {
+        await().atMost(30, TimeUnit.SECONDS)
+                .until(() -> ((ExecSource) source).getSourceCounter().getEventAcceptedCount() >= expected);
     }
 
     private void runTestShellCmdHelper(String shell, String command, String[] expectedOutput)
@@ -336,9 +354,7 @@ public class TestExecSource {
         context.put("command", command);
         Configurables.configure(source, context);
         source.start();
-        // Some commands might take longer to complete, specially on Windows
-        // or on slow environments (e.g. Travis CI).
-        Thread.sleep(2500);
+        awaitEventCount(expectedOutput.length);
         Transaction transaction = channel.getTransaction();
         transaction.begin();
         try {


### PR DESCRIPTION
`TestExecSource.testBatchTimeout` fails intermittently on the Windows runner (e.g. [this run](https://github.com/apache/logging-flume/actions/runs/32839614557/job/97775993174)). Three causes, all Windows-specific or Windows-amplified:

1. **Fixed sleeps lose to PowerShell start-up.** The tests slept a fixed 1.5–2.5 s before draining the channel; PowerShell cold-start on a loaded runner regularly takes longer. The tests now await the source counter (Awaitility, up to 30 s) via a new package-private `ExecSource#getSourceCounter()`, following the `SyslogTcpSource` precedent. This also cuts ~20 s of unconditional sleeping from the suite (~41 s → ~15 s).
2. **Write/read race.** The input file was written after `source.start()`, but the Windows command `Get-Content <file> | Select-Object -Last 10` is a one-shot read: it sees whatever happens to be in the file when PowerShell gets to it. The file is now fully written before the source starts.
3. **Wrong semantics on Windows.** Because the one-shot command exits, events were delivered by the EOF flush rather than the 750 ms batch timeout the test is meant to exercise. `Get-Content -Tail 10 -Wait` is the real `tail -f` equivalent: the process stays alive and only the timed flush delivers the events.

Also replaces the hard-coded `/tmp` path, which only worked on Windows by accident, with a real temporary file.