### PR TITLE
Publish the website at the root of the site directory

### DIFF
--- a/antora-playbook.yaml
+++ b/antora-playbook.yaml
@@ -18,7 +18,7 @@
 site:
   title: Apache Flume
   url: "https://logging.apache.org/flume/2.x"
-  start_page: "flume::index.adoc"
+  start_page: "ROOT::index.adoc"
 
 content:
   sources:

--- a/src/site/antora/antora.tmpl.yml
+++ b/src/site/antora/antora.tmpl.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: flume
+name: ROOT
 title: Apache Flume
 version: ~
 start_page: index.adoc

--- a/src/site/antora/antora.yml
+++ b/src/site/antora/antora.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: flume
+name: ROOT
 title: Apache Flume
 version: ~
 start_page: index.adoc


### PR DESCRIPTION
Antora only drops the component segment from page URLs for a component named `ROOT`. With the component named `flume`, pages were published at `https://logging.apache.org/flume/2.x/flume/…` with a redirect stub at `/flume/2.x/index.html`.

Renaming the component to `ROOT` (matching `logging-parent`, `log4j`, `log4net`, `log4j-tools` and `log4j-transform`) publishes the pages directly under `/flume/2.x/`.

Verified locally with Antora 3.1.15: pages, images, stylesheet paths and the sitemap all resolve at the site root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
